### PR TITLE
typo fixes & example code more readily readable

### DIFF
--- a/docs/hoon/basic.md
+++ b/docs/hoon/basic.md
@@ -79,11 +79,8 @@ tail `q`.
 ### `{$hold p/span q/twig}`
 
 A `$hold` span, with span `p` and twig `q`, is a lazy reference
-to the span of `(mint p q)`.  In English it means: "the type of
-the product when we compile `q` against subject `p`.
-
-This is "manual laziness."  Hoon is a strict language, so we have
-to express 
+to the span of `(mint p q)`.  In English, it means: "the type of
+the product when we compile `q` against subject `p`."
 
 ### `{$face p/term q/span}`
 

--- a/docs/hoon/syntax.md
+++ b/docs/hoon/syntax.md
@@ -21,7 +21,7 @@ piles*, *indentation creep*, and *feature/label confusion*.
 
 ## Terminator piles
 
-*Terminator piles* are like Lisp's stacks of right parenthesess.
+*Terminator piles* are like Lisp's stacks of right parentheses.
 Significant whitespace solves this problem and creates others.
 
 Hoon has no terminator piles.  Except for a 1-space / more-space
@@ -228,7 +228,7 @@ s
 
 The hope of backstep indentation is that the heaviest twigs are
 at the bottom, keeping code flow vertical rather than diagonal.
-Alternate, reversing
+
 
 ### Conventions: *running*
 
@@ -345,7 +345,7 @@ starting in order of construction from `a`, or within a tuple
 mold `p`.  Hoon uses single-letter names for the same reason
 Algol style languages pass arguments by order, rather than
 keyword.  Naming items by order makes sense when there are no
-more than three or four; five is stretching it; six is too many.
+more than three or four; five is stretching it; six is outright.
 
 For example, when defining `add`, we want to name the operands
 `a` and `b`.  It's silly to call them `foo` and `bar`, let alone

--- a/docs/hoon/twig.md
+++ b/docs/hoon/twig.md
@@ -30,9 +30,9 @@ of this structure is a *subexpression* or just *leg*.
 Usually a subexpression is itself a `twig`; sometimes it's an
 `@tas` (symbol) or a `wing` (reference path).
 
-## Moldy moss and woody seed
+## Moldy moss; woody seed
 
-When defining each pages in the `twig` book, we never use `twig`
+When defining each page in the `twig` book, we never use `twig`
 itself as a leg.  Instead, we use the mold `moss` to describe
 twigs whose product is used as a mold, and `seed` for twigs whose
 product could be anything.  Both `moss` and `seed` are just
@@ -47,7 +47,7 @@ For instance, `[%foo %bar]` is woody: a twig producing the noun
 producing a function whose product is always `[7.303.014
 7.496.034]`.
 
-This mold of course is a noun (a gate).  The value of that noun
+This mold, of course, is a noun (a gate).  The value of that noun
 is not `[7.303.014 7.496.034]`, or anything remotely like it.
 The noun is a pile of code.  It is probably a big pile of code,
 because most cores include a lot of formulas, contexts, etc,


### PR DESCRIPTION
* In examples.md, added the relevant snippets of code immediately above the lines describing their function, to prevent readers from needing to scroll up and down continuously.
* Fixed a few typos and incomplete sentences. 