### PR TITLE
Nock interpreter in Scheme

### DIFF
--- a/docs/nock/implementations/groovy.md
+++ b/docs/nock/implementations/groovy.md
@@ -10,6 +10,7 @@ next: true
 From [Kohányi Róbert](https://github.com/kohanyirobert/gnock/blob/master/gnock.groovy):
 
 ```
+@Memoized
 def i(def a) {
   a.class in [
     byte, Byte,
@@ -21,28 +22,40 @@ def i(def a) {
   ] && a >= 0
 }
 
+@Memoized
 def n(def a) {
+  def r
+  n(a, { r = it })
+  r
+}
+
+@TailRecursive
+def n(def a, def r) {
   if (a in List) {
     if (a.size() == 1) {
-      n(a[0])
-    } else if (a.size() == 2) {
-      [n(a[0]), n(a[1])]
-    } else if (a.size() > 2) {
-      [n(a[0]), n(a.tail())]
+      r(a[0])
+    } else if (a.size() >= 2) {
+      n(a[0], { t ->
+        n(a.size() == 2 ? a[1] : a.tail(), { h ->
+          r([t, h])
+        })
+      })
     } else {
       throw new IllegalStateException()
     }
   } else if (i(a)) {
-    (BigInteger) a
+    r((BigInteger) a)
   } else {
     throw new IllegalStateException()
   }
 }
 
+@Memoized
 def wut(def a) {
   i(a) ? 1 : 0
 }
 
+@Memoized
 def lus(def a) {
   if (wut(a) == 0) {
     throw new IllegalStateException()
@@ -50,6 +63,7 @@ def lus(def a) {
   1 + a
 }
 
+@Memoized
 def tis(def a) {
   if (wut(a) == 1) {
     throw new IllegalStateException()
@@ -57,7 +71,15 @@ def tis(def a) {
   a[0] == a[1] ? 0 : 1
 }
 
+@Memoized
 def fas(def a) {
+  def r
+  fas(a, { r = it })
+  r
+}
+
+@TailRecursive
+def fas(def a, def r) {
   if (wut(a) == 1) {
     throw new IllegalStateException()
   }
@@ -69,27 +91,34 @@ def fas(def a) {
   if (h == 0) {
     throw new IllegalStateException()
   } else if (h == 1) {
-    t
+    r(t)
   } else {
     if (i(t)) {
       throw new IllegalStateException()
     }
     if (h == 2) {
-      t[0]
+      r(t[0])
     } else if (h == 3) {
-      t[1]
+      r(t[1])
     } else {
-      def x = h.intdiv(2)
-      if (h.mod(2) == 0) {
-        fas([2, fas([x, t])])
-      } else {
-        fas([3, fas([x, t])])
-      }
+      fas([h.intdiv(2), t], { p ->
+        fas([2 + h.mod(2), p], { q ->
+          r(q)
+        })
+      })
     }
   }
 }
 
+@Memoized
 def tar(def a) {
+  def r
+  tar(a, { r = it})
+  r
+}
+
+@TailRecursive
+def tar(def a, def r) {
   if (wut(a) == 1) {
     throw new IllegalStateException()
   }
@@ -101,18 +130,28 @@ def tar(def a) {
   def o = f[0]
   def v = f[1]
   if (wut(o) == 0) {
-    [tar([s, o]), tar([s, v])]
+    tar([s, o], { p ->
+      tar([s, v], { q ->
+        r([p, q])
+      })
+    })
   } else {
     if (o == 0) {
-      fas([v, s])
+      r(fas([v, s]))
     } else if (o == 1) {
-      v
+      r(v)
     } else if (o == 3) {
-      wut(tar([s, v]))
+      tar([s, v], {
+        r(wut(it))
+      })
     } else if (o == 4) {
-      lus(tar([s, v]))
+      tar([s, v], {
+        r(lus(it))
+      })
     } else if (o == 5) {
-      tis(tar([s, v]))
+      tar([s, v], {
+        r(tis(it))
+      })
     } else {
       if (wut(v) == 1) {
         throw new IllegalStateException()
@@ -120,29 +159,43 @@ def tar(def a) {
       def x = v[0]
       def y = v[1]
       if (o == 2) {
-        tar([tar([s, x]), tar([s, y])])
+        tar([s, x], { p ->
+          tar([s, y], { q ->
+            tar([p, q], {
+              r(it)
+            })
+          })
+        })
       } else if (o == 7) {
-        tar(n([s, 2, x, 1, y]))
+        tar(n([s, 2, x, 1, y]), {
+          r(it)
+        })
       } else if (o == 8) {
-        tar(n([s, 7, [[7, [0, 1], x], 0, 1], y]))
+        tar(n([s, 7, [[7, [0, 1], x], 0, 1], y]), {
+          r(it)
+        })
       } else if (o == 9) {
-        tar(n([s, 7, y, 2, [0, 1], 0, x]))
+        tar(n([s, 7, y, 2, [0, 1], 0, x]), {
+          r(it)
+        })
       } else if (o == 10) {
         if (wut(x) == 1) {
-          tar([s, y])
+          tar([s, y], {
+            r(it)
+          })
         } else {
-          def r = x[0]
-          def t = x[1]
-          tar(n([s, 8, t, 7, [0, 3], y]))
+          tar(n([s, 8, x[1], 7, [0, 3], y]), {
+            r(it)
+          })
         }
       } else {
         if (wut(y) == 1) {
           throw new IllegalStateException()
         }
-        def p = y[0]
-        def q = y[1]
         if (o == 6) {
-          tar(n([s, 2, [0, 1], 2, [1, p, q], [1, 0], 2, [1, 2, 3], [1, 0], 4, 4, x]))
+          tar(n([s, 2, [0, 1], 2, [1, y[0], y[1]], [1, 0], 2, [1, 2, 3], [1, 0], 4, 4, x]), {
+            r(it)
+          })
         } else {
           throw new IllegalStateException()
         }

--- a/docs/nock/implementations/hoon.md
+++ b/docs/nock/implementations/hoon.md
@@ -1,7 +1,7 @@
 ---
 navhome: /docs
 title: Hoon
-sort: 8
+sort: 9
 ---
 
 # Hoon 

--- a/docs/nock/implementations/scheme.md
+++ b/docs/nock/implementations/scheme.md
@@ -1,0 +1,128 @@
+---
+navhome: /docs
+title: Scheme
+sort: 8
+next: true
+---
+
+# Groovy 
+
+From [Kohányi Róbert](https://github.com/kohanyirobert/snock/blob/master/snock.ss):
+
+```
+(import (rnrs (6)))
+
+(define (i a) a)
+
+(define (n a r)
+  (cond
+    ((list? a)
+     (let ((l (length a)))
+       (cond
+         ((equal? l 0) (raise 1))
+         ((equal? l 1) (r (car a)))
+         (else
+           (let ((t (cond
+                      ((equal? l 2) (cadr a))
+                      (else (cdr a)))))
+             (n (car a)
+                (lambda (p) (n t
+                               (lambda (q) (r (cons p q)))))))))))
+    ((fixnum? a) (r a))
+    (else (raise 2))))
+
+(define (wut a)
+  (cond
+    ((fixnum? a) 1)
+    (else 0)))
+
+(define (lus a)
+  (cond
+    ((equal? (wut a) 0) (raise 3))
+    (else (+ 1 a))))
+
+(define (tis a)
+  (cond
+    ((equal? (wut a) 1) (raise 4))
+    ((equal? (car a) (cdr a)) 0)
+    (else 1)))
+
+(define (fas a r)
+  (cond
+    ((equal? (wut a) 1) (raise 5))
+    (else
+      (let ((h (car a))
+          (t (cdr a)))
+      (cond
+        ((not (fixnum? h)) (raise 6))
+        ((equal? h 0) (raise 7))
+        ((equal? h 1) (r t))
+        ((fixnum? t) (raise 8))
+        ((equal? h 2) (r (car t)))
+        ((equal? h 3) (r (cdr t)))
+        (else
+            (fas (cons (div h 2) t)
+                 (lambda (p) (fas (cons (+ 2 (mod h 2)) p)
+                                  (lambda (q) (r q)))))))))))
+
+(define (tar a r)
+  (cond
+    ((equal? (wut a) 1) (raise 9))
+    (else
+      (let ((s (car a))
+            (f (cdr a)))
+        (cond
+          ((equal? (wut f) 1) (raise 10))
+          (else
+            (let ((o (car f))
+                  (v (cdr f)))
+              (cond
+                ((equal? (wut o) 0) (tar (cons s o)
+                                         (lambda (p) (tar (cons s v)
+                                                          (lambda (q) (r (cons p q)))))))
+                ((equal? o 0) (r (fas (cons v s) i)))
+                ((equal? o 1) (r v))
+                ((equal? o 3) (tar (cons s v)
+                                   (lambda (p) (r (wut p)))))
+                ((equal? o 4) (tar (cons s v)
+                                   (lambda (p) (r (lus p)))))
+                ((equal? o 5) (tar (cons s v)
+                                   (lambda (p) (r (tis p)))))
+                ((equal? (wut v) 1) (raise 11))
+                (else
+                  (let ((x (car v))
+                        (y (cdr v)))
+                    (cond
+                      ((equal? o 2) (tar (cons s x)
+                                         (lambda (p) (tar (cons s y)
+                                                          (lambda (q) (tar (cons p q)
+                                                                           (lambda (u) (r u))))))))
+                      ((equal? o 7) (tar (n (list (list s) 2 (list x) 1 (list y)) i)
+                                         (lambda (p) (r p))))
+                      ((equal? o 8) (tar (n (list (list s) 7 (list (list 7 (list 0 1) (list x)) 0 1) (list y)) i)
+                                         (lambda (p) (r p))))
+                      ((equal? o 9) (tar (n (list (list s) 7 (list y) 2 (list 0 1) 0 (list x)) i)
+                                         (lambda (p) (r p))))
+                      ((equal? o 10) (cond
+                                       ((equal? (wut x) 1) (tar (cons s y)
+                                                                (lambda (p) (r p))))
+                                       (else (tar (n (list (list s) 8 (list (cdr x)) 7 (list 0 3) (list y)) i)
+                                                  (lambda (p) (r p))))))
+                      ((equal? (wut y) 1) (raise 12))
+                      ((equal? o 6) (tar (n (list
+                                              (list s)
+                                              2
+                                              (list 0 1)
+                                              2
+                                              (list 1 (list (car y)) (list (cdr y)))
+                                              (list 1 0)
+                                              2
+                                              (list 1 2 3)
+                                              (list 1 0)
+                                              4
+                                              4
+                                              (list x))
+                                            i)
+                                         (lambda (p) (r p))))
+                      (else (raise 13)))))))))))))
+```

--- a/docs/nock/implementations/scheme.md
+++ b/docs/nock/implementations/scheme.md
@@ -5,7 +5,7 @@ sort: 8
 next: true
 ---
 
-# Groovy 
+# Scheme 
 
 From [Kohányi Róbert](https://github.com/kohanyirobert/snock/blob/master/snock.ss):
 


### PR DESCRIPTION
After writing a Nock interpreter in Groovy #9 I've decided to rewrite it in Scheme. Groovy does not handle tail recursion really well and is bit slow. I've rewritten the Groovy code to use continuation-passing style tail recursion, but it didn't help too much - `StackOverflowError`s all over the place. (I've updated `groovy.md` to reflect the changes.)

The Scheme version benefits from the continuation-passing style recursion. A deep recursion basically runs forever (it does pollutes the stack/heap - don't know which one - but much slower). Anyway, I didn't know too much about CPS before, so it was worth digging into it a bit. The code is a direct rewrite of the Groovy one, no novelty here. Also, I haven't used Scheme since reading the The Little Schemer ages ago, so it might look ugly :)

Sorry for only contributing only useless things, but it was fun.

*goes back figuring out how to implement decrement in nock*