### PR TITLE
Fix buccen typo

### DIFF
--- a/docs/hoon/twig/buc-mold/cen-book.md
+++ b/docs/hoon/twig/buc-mold/cen-book.md
@@ -4,7 +4,7 @@ sort: 4
 
 ---
 
-# `:book  $%  "buctis"` 
+# `:book  $%  "buccen"` 
 
 `{$book p/(list {{aura @} moss})}`: mold which recognizes a union tagged by head atom.
 


### PR DESCRIPTION
Copy and paste error: 'buccen' was 'buctis'.