### PR TITLE
minor Hoon twig corrections

### DIFF
--- a/docs/hoon/twig/cen-call/sig-open.md
+++ b/docs/hoon/twig/cen-call/sig-open.md
@@ -31,5 +31,5 @@ learn to step outside your linear, Western way of thinking."
 
 ## Examples
 
-See [`:door`](../bar-core/cab-door).
+See [`:door`](../../bar-core/cab-door).
 

--- a/docs/hoon/twig/col-cell/hep-cons.md
+++ b/docs/hoon/twig/col-cell/hep-cons.md
@@ -23,7 +23,7 @@ Irregular: `a^b^c` is `[a b c]`.
 
 Irregular: `a+b` is `[%a b]`.
 
-Irregular: `\`a` is `[~ a]`.
+Irregular: `` `a`` is `[~ a]`.
 
 Irregular: `~[a b]` is `[a b ~]`.
 
@@ -40,4 +40,10 @@ compiler does), `[a b]` is the same as `[%cons a b]`.
 ```
 ~zod:dojo> :-(1 2)
 [1 2]
+~zod:dojo> 1^2
+[1 2]
+~zod:dojo> 1+2
+[%1 2]
+~zod:dojo> `1
+[~ 1]
 ```

--- a/docs/hoon/twig/ket-cast/hep-cast.md
+++ b/docs/hoon/twig/ket-cast/hep-cast.md
@@ -15,7 +15,9 @@ sort: 2
 
 ## Syntax
 
-Regular: *2-fixed*
+Regular: *2-fixed*.
+
+Irregular: `` `foo`bar`` is `:cast(foo bar)`.
 
 ## Discussion
 
@@ -27,7 +29,7 @@ infinite loop in the compiler).
 
 ## Examples
 
-``
+```
 ~zod:dojo> (add 90 7)
 97
 ~zod:dojo> `@t`(add 90 7)

--- a/docs/hoon/twig/ket-cast/lus-like.md
+++ b/docs/hoon/twig/ket-cast/lus-like.md
@@ -16,11 +16,13 @@ within the span of `q`.  Otherwise, `nest-fail`.
 
 Regular: *2-fixed*.
 
-Irregular: `\`_foo\`bar` is `:like(foo bar)`.
-
 ## Examples
 
 ```
-~zod:dojo> :like('text' 97)
+~zod:dojo> :like('text' %a)
 'a'
+~zod:dojo> :like('text' 97)
+nest-fail
 ```
+
+

--- a/docs/hoon/twig/ket-cast/lus-like.md
+++ b/docs/hoon/twig/ket-cast/lus-like.md
@@ -21,8 +21,6 @@ Regular: *2-fixed*.
 ```
 ~zod:dojo> :like('text' %a)
 'a'
-~zod:dojo> :like('text' 97)
-nest-fail
 ```
 
 

--- a/docs/hoon/twig/ket-cast/sig-burn.md
+++ b/docs/hoon/twig/ket-cast/sig-burn.md
@@ -9,7 +9,7 @@ sort: 6
 
 ## Produces
 
-`p`, folded as a constqnt if possible.
+`p`, folded as a constant if possible.
 
 ## Syntax
 


### PR DESCRIPTION
- moves irregular `:cast` form example from `:like` -> `:cast`, corrects formatting
- adds irregular form examples for `:cons` (quoting rules seem confusing without examples), corrects formatting
- fixes broken link from `:call` -> `:door`