### PR TITLE
fixes duplicate file index (`:funk`), corrects typos

### DIFF
--- a/docs/hoon/twig/bar-core.md
+++ b/docs/hoon/twig/bar-core.md
@@ -9,10 +9,10 @@ sort: 5
 Core twigs are flow twigs.  The compiler essentially pins a Nock
 formula, or battery of formulas, to the subject.
 
-All `|` twigs are macros around `$core`.  (See the `$core`
-section in [`span`](../span) above.)  `$core` uses the subject as
-the payload of a battery, whose arms are compiled with the core
-itself as the subject.
+All `|` twigs are macros around `$core`. (See the `$core`
+section in [`span`](../../basic#-core-p-span-q-map-term-span) above.)
+`$core` uses the subject as the payload of a battery, whose arms are
+compiled with the core itself as the subject.
 
 ## Stems
 

--- a/docs/hoon/twig/bar-core/cen-core.md
+++ b/docs/hoon/twig/bar-core/cen-core.md
@@ -21,7 +21,6 @@ Regular: *battery*.
 A core is like an "object" in a conventional language, but its
 attributes (*arms*) are functions on the core, not the core and
 an argument.  A "method" on a core is an arm producing a gate.
-gate.
 
 ## Examples
 

--- a/docs/hoon/twig/sig-hint/cen-fast.md
+++ b/docs/hoon/twig/sig-hint/cen-fast.md
@@ -27,7 +27,7 @@ between opening and closing `==`.
 formal identity to the interpreter, which may or may not be able
 to recognize and/or accelerate it.
 
-Registered cores are are organized in a containment hierarchy.
+Registered cores are organized in a containment hierarchy.
 The parent core is at any leg within the child core.  When we
 register a core, we state the leg to its parent, in the form of
 wing `q`.  We assume the parent is already registered -- as it

--- a/docs/hoon/twig/sig-hint/fas-funk.md
+++ b/docs/hoon/twig/sig-hint/fas-funk.md
@@ -1,6 +1,6 @@
 ---
 navhome: /docs
-sort: 1
+sort: 11
 ---
 
 # `:funk  ~/  "sigfas"`


### PR DESCRIPTION
and corrects a link for `$core`...

Thus ends my whirlwind tour of the twig references