### PR TITLE
fixes some typos and links

### DIFF
--- a/docs/hoon/advanced.md
+++ b/docs/hoon/advanced.md
@@ -186,7 +186,7 @@ limb, we just search the span depth-first.
 If a name is in the `p.p` map, it's an alias.  The map contains a
 `(unit twig)`; if the unit is full, the name resolves to that
 twig (compiled against the `q` span).  If the unit is empty,
-the name is blocked / skipped (see [limb](twig/limb) for what
+the name is blocked / skipped (see [limb](../twig/limb) for what
 this means).
 
 If a name is in the `q.p` map, it's a bridge.  When we search for

--- a/docs/hoon/exercises/data-structures.md
+++ b/docs/hoon/exercises/data-structures.md
@@ -26,7 +26,7 @@ exercises, you'll need to refer to the [library reference for
     `'javacript'`, `'python'`.
 
 1.  At the dojo, take the union of `s` and `l`.  Delete
-    `'javascript'` from the result, and add `'coffescript'`.
+    `'javascript'` from the result, and add `'coffeescript'`.
 
 1.  Create an alphabetized list of the members of the set created
     in the previous exercise.

--- a/docs/hoon/library/2b.md
+++ b/docs/hoon/library/2b.md
@@ -667,7 +667,7 @@ sorted according to `b`.
 Accepts
 -------
 
-`b` is a gate that ccepts two nouns and produces a boolean.
+`b` is a gate that accepts two nouns and produces a boolean.
 
 Produces
 --------

--- a/docs/hoon/library/2q.md
+++ b/docs/hoon/library/2q.md
@@ -147,9 +147,9 @@ Source
 Examples
 --------
 
-    > `(list ,char)`"foobar"
+    > `(list char)`"foobar"
     "foobar"
-    > `(list ,@)`"foobar"
+    > `(list @)`"foobar"
     ~[102 111 111 98 97 114]
 
 

--- a/docs/hoon/reference.md
+++ b/docs/hoon/reference.md
@@ -10,6 +10,10 @@ title: Twig reference
 
 <div class="book">
 
+### [Atoms and strings](../twig/atom)
+
+### [Limbs and wings](../twig/limb)
+
 ## `$ buc` (mold)
 
 <list src="../twig/buc-mold" dataPreview="true" className="runes" childIsFragment="true"></list>

--- a/docs/hoon/twig/wut-test/gar-sure.md
+++ b/docs/hoon/twig/wut-test/gar-sure.md
@@ -3,7 +3,7 @@ navhome: /docs
 sort: 11
 ---
 
-# `:sure  ?<  "wutgar"`
+# `:sure  ?>  "wutgar"`
 
 `{$sure p/seed q/seed}`: positive assertion.
 

--- a/docs/hoon/twig/wut-test/lus-deft.md
+++ b/docs/hoon/twig/wut-test/lus-deft.md
@@ -3,7 +3,7 @@ navhome: /docs
 sort: 13
 ---
 
-# `:deft  ?-  "wutlus"`
+# `:deft  ?+  "wutlus"`
 
 `{$case p/wing q/seed r/(list (pair moss seed))}`: switch against 
 a union, with a default.

--- a/docs/hoon/twig/zap-wild/gar-wrap.md
+++ b/docs/hoon/twig/zap-wild/gar-wrap.md
@@ -24,5 +24,5 @@ span-noun cell is generally called a `vase`.
 
 ```
 ~zod:dojo> !>(1)
-[#t/@ud q=1]
+[p=#t/@ud q=1]
 ```


### PR DESCRIPTION
A bit of a grab-bag here

- broken link in `:limb`
- incorrect runes in `?`
- commas in type assertions
- incorrect pretty-printing

Also, I added explicit links to `limbs` and `strings` for the hoon reference. The navigation gets a little confusing there, and I've often found myself backtracking through the nav to find those.