### PR TITLE
arvo exercises (formatting and broken examples)

### DIFF
--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -16,7 +16,7 @@ for improving our [code](https://github.com/urbit/urbit/) and
 Our official guide to contributing can be found
 [here](https://github.com/urbit/urbit/blob/master/CONTRIBUTING.md),
 which is most useful for large and low-level changes. For simpler
-revisions, refer to [Hoon Syntax](/hoon/syntax) for an in-depth guide to
+revisions, refer to [Hoon Syntax](../../hoon/syntax) for an in-depth guide to
 good Hoon. Alternatively, [browse the
 source](https://github.com/urbit/arvo/blob/master/arvo/hoon.hoon).
 

--- a/docs/arvo/basic.md
+++ b/docs/arvo/basic.md
@@ -29,8 +29,18 @@ at the [basic operation](/docs/using/admin) of your urbit.
 If you haven't copied in the examples repo, running the following
 commands from your urbit directory should do the trick:
 
-`$ cp -r {wherever-you've-pulled-to}/examples/gall/*/ arvo/`
-`$ cp -r {wherever-you've-pulled-to}/examples/dojo/*/ arvo/`
+Make sure you've mounted your `%home` desk:
+
+```
+~fintud-macrep:dojo> |mount %
+```
+
+Then, copy the example into it
+
+```
+$ cp -r {urbit-examples}/gall/*/ {your-pier}/home/
+$ cp -r {urbit-examples}/dojo/*/ {your-pier}/home/
+```
 
 Run an example to ensure it worked:
 
@@ -213,8 +223,8 @@ of the code. However, `b` is not an argument; `=|` sets `b` to the
 default value of whatever type it is declared as. Since the default
 value of an atom is `0`, b is set to `0`.
 
-> To produce the default value of any given type, use `$*` ('buctar')
-> followed by the type. Alternatively, use the irregular form `*`.
+> To produce the default value of any given type, use `*` ('tar')
+> followed by the type. This operaction is called *bunt*.
 >
 >         > *@ :: produce the default value of atom @
 >         0

--- a/docs/arvo/basic.md
+++ b/docs/arvo/basic.md
@@ -256,10 +256,10 @@ function call, then you have to specify every argument.
 
 **Exercises**:
 
-Tweak your code to complete the following excercises.
+Tweak your code to complete the following exercises.
 
 There are a few runes and some syntax that we have yet to cover that you
-will need to complete the excercises below. For these, please refer to
+will need to complete the exercises below. For these, please refer to
 our cheatsheat at the bottom.
 
 1.  Read and understand `++five` line by line.

--- a/docs/arvo/basic.md
+++ b/docs/arvo/basic.md
@@ -163,7 +163,7 @@ You can write:
 ### Lines 12-34
 
 Now let's quickly walk through this code line-by-line. Lines 12-34 are
-wrapped in a `|%` ('[barcen](/hoon/twig/bar-core/cen-core/)'), which produces a core. Cores are a
+wrapped in a `|%` ('[barcen](../../hoon/twig/bar-core/cen-core/)'), which produces a core. Cores are a
 fundamental datatype in Hoon, similar to a struct, class, or object. A
 core is just a map of names to any kind of code, whether it be functions
 or data. Each element in this map begins with a `++` followed by the
@@ -182,7 +182,7 @@ Let's step into each of the three arms within our core.
       (add (five a) (three a))
     --
 
-`|=` ('[bartis](/hoon/twig/bar-core/tis-gate/)') produces a function, much like a lambda in lisp. It
+`|=` ('[bartis](../../hoon/twig/bar-core/tis-gate/)') produces a function, much like a lambda in lisp. It
 takes two children:
 
 1.  A set of argument(s). In this case our argument set only contains
@@ -207,7 +207,7 @@ takes two children:
 As above, `++three` takes an integer argument, `a`, and then executes
 the remainder of the code with `a` set to the actual arguments.
 
-Similarly, `=|` ('[tisbar](/hoon/twig/tis-flow/bar-new/)') pushes its first child, `b` into our context
+Similarly, `=|` ('[tisbar](../../hoon/twig/tis-flow/bar-new/)') pushes its first child, `b` into our context
 (in other words, it declares a variable `b`) and executes the remainder
 of the code. However, `b` is not an argument; `=|` sets `b` to the
 default value of whatever type it is declared as. Since the default
@@ -225,10 +225,10 @@ value of an atom is `0`, b is set to `0`.
 So now we have two variables: `a` is set to our input, and `b` is
 initialized to `0`.
 
-One way to think about `|-` ('[barhep](/hoon/twig/bar-core/hep-loop/)') is that it lays down a recursion
+One way to think about `|-` ('[barhep](../../hoon/twig/bar-core/hep-loop/)') is that it lays down a recursion
 point. More on this later.
 
-`^-` ('[kethep](/hoon/core/ket-cast/hep-cast/)') is just a cast that sets the result of the remainder of
+`^-` ('[kethep](../../hoon/core/ket-cast/hep-cast/)') is just a cast that sets the result of the remainder of
 the code to an unsigned integer, `@u`.
 
 In pseudocode, the last three lines read like this: if `a` is less than
@@ -272,7 +272,7 @@ our cheatsheat at the bottom.
     =(a b)  test equality
     (function args ...)  call function with args
 
-Lookup each of these expressions (and all others!) in the [Twig Expressions](/hoon/twig/) definition.
+Lookup each of these expressions (and all others!) in the [Twig Expressions](../../hoon/twig/) definition.
 
 ### New material
 

--- a/docs/arvo/generators.md
+++ b/docs/arvo/generators.md
@@ -65,13 +65,11 @@ optionally specify the message as well.
 We'll need a new mark for our arguments.  Let's call it
 `examples-ping-message`.
 
-<blockquote class="blockquote">
-For app-specific marks, it's good style to prefix the name of
-the mark with the name of the app.  Since many apps have
-several such marks, subdirectories in `/mar` are rendered as
-`-`, so that `ping-message` is written in
-(/mar/examples/ping/message.hoon).
-</blockquote>
+> For app-specific marks, it's good style to prefix the name of
+> the mark with the name of the app.  Since many apps have
+> several such marks, subdirectories in `/mar` are rendered as
+> `-`, so that `ping-message` is written in
+> (/mar/examples/ping/message.hoon).
 
 ```
 ::  Up-ness monitor. Accepts atom url, 'on', or 'off'
@@ -214,23 +212,21 @@ text and null.
 Secondly, `?~(a b c)` is a rune which means "if the `a` is null,
 do `b`, else `c`".  It is roughly equivalent to `?:(=(~ a) b c)`.
 
-<blockquote class="blockquote">
-`?~(a b c)` is actually equivalent to `?:=(?=(~ a) b c)`,
-which, although identical at run time, is subtly different at
-compile time.  Specifically, using `?=` rather than `=` means
-that we're checking whether `a` is in the *type* of `~`, and so
-the compiler knows that in the `b` case `a` is null, and in the
-`c` case `a` is not null.  Since `=` is purely a runtime value
-check with no type implications, the compiler doesn't gain any
-information.
-
-At any rate, this is the reason why we can refer to
-`text.message` in the `c` clause.  The compiler knows that
-`message` is not null, so it must have `text` within it.  If
-you used `?:(=(~ message) 'howdy' text.message)` the compiler
-would complain that it doesn't know whether `message` has
-`text` within it.
-</blockquote>
+> `?~(a b c)` is actually equivalent to `?:=(?=(~ a) b c)`,
+> which, although identical at run time, is subtly different at
+> compile time.  Specifically, using `?=` rather than `=` means
+> that we're checking whether `a` is in the *type* of `~`, and so
+> the compiler knows that in the `b` case `a` is null, and in the
+> `c` case `a` is not null.  Since `=` is purely a runtime value
+> check with no type implications, the compiler doesn't gain any
+> information.
+>
+> At any rate, this is the reason why we can refer to
+> `text.message` in the `c` clause.  The compiler knows that
+> `message` is not null, so it must have `text` within it.  If
+> you used `?:(=(~ message) 'howdy' text.message)` the compiler
+> would complain that it doesn't know whether `message` has
+> `text` within it.
 
 This is run as follows:
 

--- a/docs/arvo/http.md
+++ b/docs/arvo/http.md
@@ -77,12 +77,10 @@ line, though.
 Firstly, there's two kinds of cards we're sending to arvo.  A
 `%them` card makes an HTTP requrest out of a unit `hiss`.
 
-<blockquote class="blockquote">
-Recall that `++unit` means "maybe".  Formally, "`(unit a)` is
-either null or a pair of null and a value in `a`". Also recall
-that to pull a value out of a unit `(u.unit)`, you must first
-verify that the unit is not null (for example with `?~`).
-</blockquote>
+> Recall that `++unit` means "maybe".  Formally, "`(unit a)` is
+> either null or a pair of null and a value in `a`". Also recall
+> that to pull a value out of a unit `(u.unit)`, you must first
+> verify that the unit is not null (for example with `?~`).
 
 A `hiss` (all of the following terms are defined in `zuse`) is a
 pair of a `purl` and a `moth`.  A `purl` is a parsed url
@@ -96,11 +94,9 @@ of HTTP headers.  The `(unit octs)` is a possible octet stream
 representing the body.  If it's null, then no body is sent (as in
 this case).
 
-<blockquote class="blockquote">
-An octect stream is a pair of the length in bytes of the data
-plus the data itself.  You can use `++taco` takes text and
-turns it into an octet strem.
-</blockquote>
+> An octect stream is a pair of the length in bytes of the data
+> plus the data itself.  You can use `++taco` takes text and
+> turns it into an octet strem.
 
 When you send this request, you can expect a `%thou` with the
 response, which we handle later on in `++thou-request`.
@@ -108,11 +104,9 @@ response, which we handle later on in `++thou-request`.
 For `%wait`, you just pass a [`@da`]() (absolute date), and arvo will
 produce a `%wake` when the time comes.
 
-<blockquote class="blockquote">
-A timer is guaranteed to not be triggered before the given
-time, but it's currently impossible to guarantee the timer will be
-triggered at exactly the requested time.
-</blockquote>
+> A timer is guaranteed to not be triggered before the given
+> time, but it's currently impossible to guarantee the timer will be
+> triggered at exactly the requested time.
 
 Let's take a look at our state:
 
@@ -133,11 +127,9 @@ of `value`, but make the default value be `value`".  Thus, our
 type is still a boolean, just like `?`, but the default value is
 `|` (false).
 
-<blockquote class="blockquote">
-This is the same `_` used in `_+>.$`, which means "the same
-type as the value "+>.$".  In other words, the same type as our
-current context and state.
-</blockquote>
+> This is the same `_` used in `_+>.$`, which means "the same
+> type as the value "+>.$".  In other words, the same type as our
+> current context and state.
 
 Let's take a look at `++poke-cord`.  When we're poked with a
 cord, we first check whether it's `'off'`.  If so, we set `on` to
@@ -151,14 +143,12 @@ This request follows the pattern in `++hiss` well.  `(need (epur
 target))`  is the parsed url, `%get` is the HTTP method, `~`
 means no extra headers, and another `~` means no body.
 
-<blockquote class="blockquote">
-Note the `~` at the end of the move.  This is a convenient
-shortcut for creating a list of a single element.  It's part of
-a small family of such shortcuts.  `~[a b c]` is `[a b c ~]`,
-`[a b c]~` is `[[a b c] ~]` and `\`[a b c]` is `[~ a b c]`.
-These may be mixed and matched to create various convoluted
-structures and emojis.
-</blockquote>
+> Note the `~` at the end of the move.  This is a convenient
+> shortcut for creating a list of a single element.  It's part of
+> a small family of such shortcuts.  `~[a b c]` is `[a b c ~]`,
+> `[a b c]~` is `[[a b c] ~]` and `\`[a b c]` is `[~ a b c]`.
+> These may be mixed and matched to create various convoluted
+> structures and emojis.
 
 If the argument is neither 'off' nor 'on', then we assume it's an
 actual url, so we save it in `target`.

--- a/docs/arvo/internals/eyre/commentary.md
+++ b/docs/arvo/internals/eyre/commentary.md
@@ -96,7 +96,7 @@ initiates the long-polling loop, run against an injected `urb.js` of
 
 A `%js` `pest` is `resolve`d as a `text/javascript` success `%this`.
 
-When `poll.js` is recieved by the client, it opens an `XMLHttpRequest` for
+When `poll.js` is received by the client, it opens an `XMLHttpRequest` for
 `/~/on/{window.urb.poll}.json`, bringing us back to `%poll:process`.
 
 In the case of a non-`%js` `/~/on/`, `%poll:process-parsed` turns into a
@@ -167,7 +167,7 @@ the first nontrivial `++check-oryx` occurs, `++grab-body` the request oryx and
 ensuring it is recorded for the session. The request parsed with `++need-body`
 to a `[%auth %try {password}]` perk. `%get:process-auth` checks it against
 `++load-secret`, upon success updates the session with `++logon:ya`, and
-serves a fresh `auth.json` which reflects the changed `user`. Upon recieving
+serves a fresh `auth.json` which reflects the changed `user`. Upon receiving
 this, the page is refreshed to retry the original request.
 
 ## Post-authentication: app communication. [#auth-ok]
@@ -212,7 +212,7 @@ Upon receipt, the client realizes the long-poll isn't actually running, so that
 is started using `urb.poll`. At `/~/of/{ixor}`, perk
 `[%view ixor ~ {sequence-number}]`, it is `process`ed by `++poll:ix` (the cyst
 is retrieved by `++ire-ix` form global state, using the perk `ixor`): the
-sequence number is in the past, so the previously recieved `%rush` is 
+sequence number is in the past, so the previously received `%rush` is
 `++give-even`. After deleting the previous message in the queue and invoking 
 `++pass-took` to signal `%gall` of this occurrence, the data is annotated with
 the source app+path `++subs-to-json`, and returned to the polling duct.

--- a/docs/arvo/network.md
+++ b/docs/arvo/network.md
@@ -57,7 +57,7 @@ do that is to poke it from the command line, which we we did with
 `:echo 5` (`:[app-name] [argument(s)]`).
 
 In this case, `++poke-noun` takes an argument `arg` and prints it out
-with `~&` ([sigpam](/hoon/twig/sig-hint/pam-dump/)). This is an unusual
+with `~&` ([sigpam](../../hoon/twig/sig-hint/pam-dump/)). This is an unusual
 rune that formally "does nothing", but the interpreter detects it and
 printfs the first child, before executing the second as if the first
 didn't exist. This is a slightly hacky way of printing to the console,

--- a/docs/arvo/network.md
+++ b/docs/arvo/network.md
@@ -235,7 +235,7 @@ Sometimes, the module can immediately handle the event and produce any
 necessary results. For example, when we poked the `++poke-atom` arm
 above, we poked %gall, our application server, which was able to respond
 to our poke directly. When the module cannot service the request itself,
-it sends instructions to another kernel module or application (the the
+it sends instructions to another kernel module or application (through the
 %gall module) to do a specified action, and produces the result from
 that.
 
@@ -305,7 +305,7 @@ urbit as for sending messages between apps on different urbits.
 
 -   Write two apps, `even` and `odd`. When you pass an atom to `even`,
     check whether it's even. If so, divide it by two and recurse;
-    otherwise, poke `odd` with it. When `odd` recieves an atom, check
+    otherwise, poke `odd` with it. When `odd` receives an atom, check
     whether it's equal to one. If so, terminate, printing "%success".
     Otherwise, check whether it's odd. If so, multiply it by three, add
     one, and recurse; otherwise, poke `even` with it. When either app

--- a/docs/arvo/network.md
+++ b/docs/arvo/network.md
@@ -34,7 +34,8 @@ a value, it prints that value out. To try this out, you have to start
 the app, then you can poke it from the command line with the following
 commands:
 
-    ~fintud-macrep:dojo> |start %echo
+    ~fintud-macrep:dojo> |start %examples-echo
+    'prep'
     >=
     ~fintud-macrep:dojo> :examples-echo 5
     [%argument 5]
@@ -169,7 +170,7 @@ Run it with these commands:
 
     ~fintud-macrep:dojo> |start %examples-pong
     >=
-    ~fintud-macrep:dojo> :pong &examples-urbit ~sampel-sipnym
+    ~fintud-macrep:dojo> :examples-pong &urbit ~sampel-sipnym
     >=
 
 Replace `~sampel-sipnym` with another urbit. The easiest thing to do is
@@ -220,7 +221,7 @@ Let's walk through each of these elements step by step.
 If you look up `++bone` in `hoon.hoon`, you'll see that it's a number
 (`@ud`), and that it's an opaque reference to a duct. `++duct` in
 hoon.hoon is a list of `wire`s, where `++wire` is an alias for `++path`.
-`++path` is a list of `++span`s, which are ASCII text. Thus, a duct is a
+`++path` is a list of `++knot`s, which are ASCII text. Thus, a duct is a
 list of paths, and a bone is an opaque reference to it (in the same way
 that a Unix file descriptor is an opaque reference to a file structure).
 Thus, to truly understand bones, we must understand ducts.
@@ -283,7 +284,7 @@ The move ends with `*` (that is, any noun) since each type of move takes
 different data. In our case, a `%poke` move takes a target (urbit and
 app) and marked data, then pokes the arm of the corresponding mark on
 that app on that urbit with that data. `[to-urbit-address %pong]` is the
-target urbit and app, `%atom` is the mark`, and`'howdy'\` is the data.
+target urbit and app, `%atom` is the `mark`, and`'howdy'` is the data.
 
 When arvo receives a `%poke` move, it calls the appropriate `++poke`.
 The same mechanism is used for sending messages between apps on the same
@@ -312,30 +313,30 @@ urbit as for sending messages between apps on different urbits.
     the end, you should be able to watch Collatz's conjecture play out
     between the two apps. Sample output:
 
-<!-- -->
-
-    ~fintud-macrep:dojo> :even &atom 18
-    [%even 18]
-    [%odd 9]
-    [%even 28]
-    [%even 14]
-    [%odd 7]
-    [%even 22]
-    [%odd 11]
-    [%even 34]
-    [%odd 17]
-    [%even 52]
-    [%even 26]
-    [%odd 13]
-    [%even 40]
-    [%even 20]
-    [%even 10]
-    [%odd 5]
-    [%even 16]
-    [%even 8]
-    [%even 4]
-    [%even 2]
-    %success
+```
+~fintud-macrep:dojo> :even &atom 18
+[%even 18]
+[%odd 9]
+[%even 28]
+[%even 14]
+[%odd 7]
+[%even 22]
+[%odd 11]
+[%even 34]
+[%odd 17]
+[%even 52]
+[%even 26]
+[%odd 13]
+[%even 40]
+[%even 20]
+[%even 10]
+[%odd 5]
+[%even 16]
+[%even 8]
+[%even 4]
+[%even 2]
+%success
+```
 
 -   Put `even` and `odd` on two separate urbits and pass the messages
     over the network. Post a link to a working solution in :talk to

--- a/docs/arvo/state.md
+++ b/docs/arvo/state.md
@@ -99,6 +99,13 @@ ever go through the hassle of having to set up and write to a database.
 -   Write an app that prints out the previous value you poked it with.
     Sample output:
 
-\`\`\` \~fintud-macrep:dojo\> :examples-last 7 [%last 0] \>=
-\~fintud-macrep:dojo\> :examples-last [1 2 3][%last 7] \>=
-\~fintud-macrep:dojo\> :examples-last 'howdy' [%last [1 2 3]]
+```
+~fintud-macrep:dojo> :examples-last 7
+[%last 0]
+>= 
+~fintud-macrep:dojo> :examples-last [1 2 3]
+[%last 7]
+>=
+~fintud-macrep:dojo> :examples-last 'howdy'
+[%last [1 2 3]]
+```

--- a/docs/arvo/subject.md
+++ b/docs/arvo/subject.md
@@ -15,7 +15,7 @@ Now we're going to cover the boiler plate that we skimmed over earlier.
     =<  (sum [1.000 2.000])
 
 The first rune, `:-` (colhep, aka
-[:cons](/hoon/twig/col-cell/hep-cons/)), constructs the 2-element cell
+[:cons](../../hoon/twig/col-cell/hep-cons/)), constructs the 2-element cell
 that will be our program. The first element, `%say`, tells the
 interpreter what to produce--in this case a value.
 
@@ -28,7 +28,7 @@ Similarly, the rest of the program (which we construct with another
 producing a value of type `noun`, and the code that we run to actually
 produce our value of the type `noun`.
 
-`=<` ([tisgal](/hoon/twig/tis-flow/gal-rap/)) is a rune that takes two
+`=<` ([tisgal](../../hoon/twig/tis-flow/gal-rap/)) is a rune that takes two
 children. The second child is the context against which we run the first
 child. So in this case, we are running the expression
 `(sum [1.000 2.000])` against everything contained within the `|%`. In
@@ -72,7 +72,7 @@ allows a sort of reification of the context through continutations, and
 some may see a parallel to Forth's stack, but Hoon takes takes the
 concept one step further.
 
-Our starting subject is the [standard library](/hoon/library), which is
+Our starting subject is the [standard library](../../hoon/library), which is
 defined in `/arvo/hoon.hoon` and `/arvo/zuse.hoon`. This is where
 functions like `add` are defined. When we define a core with `|%`, we
 don't throw away the subject (i.e. the standard library); rather, we

--- a/docs/arvo/subject.md
+++ b/docs/arvo/subject.md
@@ -36,7 +36,7 @@ Hoon, we call the code executed the "formula" and its context the
 "subject".
 
     ::::::::::::::::::::::::::::::
-    =<  (sum [1.000 2.000])             :: formula
+    =<  (sum [1.000 2.000])     :: formula
     ::::::::::::::::::::::::::::::
     |%                          ::
     ++  three                   ::
@@ -58,8 +58,8 @@ Hoon, we call the code executed the "formula" and its context the
       (add b $(b (add b 5)))    ::
                                 ::
     ++  sum                     ::
-      |=  a/@u                  ::
-      (add (five a) (three a))  ::
+      |=  {a/@u b/@u}           ::
+      (add (five a) (three b))  ::
     --                          ::
     ::::::::::::::::::::::::::::::
 

--- a/docs/arvo/subscriptions.md
+++ b/docs/arvo/subscriptions.md
@@ -75,42 +75,42 @@ Cheat sheet:
 
 -   `&` (pam) can either be the boolean true (as can `%.y`, `0`), or
     the irregular wide form of the `?&`
-    ([wutpam](/hoon/twig/wut-test/pam-and)) rune, which computes 
+    ([wutpam](../../hoon/twig/wut-test/pam-and)) rune, which computes
     logical `AND` on its two children.
 
 -   Similar to `&`,`|` is either the boolean false (along with `%.n` and
     `1`), or the irregular short for of `?|`
-    ([wutbar](/hoon/twig/wut-test/bar-or)), which computes logical `OR`
+    ([wutbar](../../hoon/twig/wut-test/bar-or)), which computes logical `OR`
     on its two children.
 
 -   `!` is the irregular wide form of `?!`
-    ([wutzap](/hoon/twig/wut-test/zap-not/)), which computes logical
+    ([wutzap](../../hoon/twig/wut-test/zap-not/)), which computes logical
     `NOT` on its child.
 
--   `?~` ([wutsig](/hoon/twig/wut-test/sig-ifno/)) is basically an
+-   `?~` ([wutsig](../../hoon/twig/wut-test/sig-ifno/)) is basically an
     if-then-else that checks whether condition `p` is `~` (null). `?~`
     is slightly different from `?:(~ %tru %fal)` in that `?~` reduces to
     `?:($=(%type value) %tru %false)`. `$=`
-    ([buctis](/hoon/twig/buc-mold/tis-coat/)) tests whether value `q` is
+    ([buctis](../../hoon/twig/buc-mold/tis-coat/)) tests whether value `q` is
     of type `p`.
     <!--One thing to watch out for in hoon: if you do `?~`, it
       affects the type of the conditional value: XXexample-->
 
--   `:_` ([colcab](/hoon/twig/col-cell/cab-scon/)) is inverted `:-`: it
+-   `:_` ([colcab](../../hoon/twig/col-cell/cab-scon/)) is inverted `:-`: it
     accepts `p` and `q`, and produces `[q p]`.
 
 -   `++bowl` is the type of the system state within our app. For
     example, it includes things like `our`, the name of the host urbit,
     and `now`, the current time.
 
--   `$%` ([buccen](/hoon/twig/buc-mold/cen-book/)) is a type
+-   `$%` ([buccen](../../hoon/twig/buc-mold/cen-book/)) is a type
     constructor: it defines a new type, composed of `n` types that it is
     passed. For example `$%  @  *  ^  ==` is the type of either `@`,
     `*`, or a cell `^`. <!--XX this is a union, right?-->
 
 -   You may have noticed the separate `|%`
-    ([barcen](/hoon/twig/bar-core/cen-core/)) above the application core
-    `|_` ([barcab](/hoon/twig/bar-core/cab-door/). We usually put our
+    ([barcen](../../hoon/twig/bar-core/cen-core/)) above the application core
+    `|_` ([barcab](../../hoon/twig/bar-core/cab-door/). We usually put our
     types in another core on top of the application core. We can access
     these type from our `|_` because in `hoon.hoon` files, all cores are
     called against each other. (The shorthand for 'called' is `=>`.)

--- a/docs/arvo/subscriptions.md
+++ b/docs/arvo/subscriptions.md
@@ -59,7 +59,7 @@ And secondly, `:examples-sink`:
     ++  diff-noun
       |=  {wir/wire arg/*}
       ^-  {(list move) _+>.$}
-      ~&  [%recieved-data arg]
+      ~&  [%received-data arg]
       [~ +>.$]
     ++  reap
       |=  {wir/wire error/(unit tang)}
@@ -180,7 +180,7 @@ so you don't have to. You can access your subscribers by looking at
 subscribed, and which path they subscribed on. If you want to
 communicate with your subscribers, send them messages along their bone.
 
-`++poke-noun` "spams" the given arguement to all our subscribers.
+`++poke-noun` "spams" the given argument to all our subscribers.
 There's a few things we haven't seen before. Firstly, `:_(a b)` is the
 same as `[b a]`. It's just a convenient way of formatting things when
 the first thing in a cell is much more complicated than the second.

--- a/docs/arvo/web-apps.md
+++ b/docs/arvo/web-apps.md
@@ -145,7 +145,7 @@ the app from the command line.
   `:click` and print out the subscription updates on the command
   line.
 
-#Frontend
+# Frontend
 
 That's all that's needed for the back end.  The front end is just
 some "sail" html (Hoon markup for XML) and javascript.  Here's `/web/click.hoon`:

--- a/docs/hoon/exercises/fizzbuzz.md
+++ b/docs/hoon/exercises/fizzbuzz.md
@@ -28,8 +28,8 @@ comments: true
     ```
 
     Modify this to produce "Fuzz" when the number is divisible by
-    7, "Fuzz" when divisible by 21, "FuzzFizz" when divisble by 35,
-    and "FuzzFizzBuzz" when divisble by 105.
+    7, "Fuzz" when divisible by 21, "FuzzFizz" when divisible by 35,
+    and "FuzzFizzBuzz" when divisible by 105.
 
 1.  Modify FizzBuzz from the previous exercise to take both a
     start and an end number.

--- a/docs/hoon/library/4h.md
+++ b/docs/hoon/library/4h.md
@@ -61,7 +61,7 @@ Examples
 Parse backslash
 
 Parses ASCII character 92, the backslash. Note the extra `\` in the calling of
-`bas` with [`++just`](/doc/hoon/library/2ec#++just) is to escape the escape
+`bas` with [`++just`](/docs/hoon/library/2ec#++just) is to escape the escape
 character, `\`.
 
 Source

--- a/docs/hoon/library/zuse/core/epur.md
+++ b/docs/hoon/library/zuse/core/epur.md
@@ -12,7 +12,7 @@ Parses an entire URL.
 Accepts
 -------
 
-`a` is a [`++cord`](/doc/hoon/library/1#++cord).
+`a` is a [`++cord`](/docs/hoon/library/1#++cord).
 
 Produces
 --------

--- a/docs/hoon/library/zuse/core/yu.md
+++ b/docs/hoon/library/zuse/core/yu.md
@@ -153,7 +153,7 @@ Examples
 Back-shifted leap second dates
 
 Produces a [`++list`]() of absolute dates ([`@da`]()s) that represent the Urbit
-Galactc Time equivalents of the UTC leap second dates in [`++les`](/doc/hoon/library/3bc#++les).
+Galactc Time equivalents of the UTC leap second dates in [`++les`](/docs/hoon/library/3bc#++les).
 
 Produces
 --------

--- a/docs/hoon/library/zuse/diff.md
+++ b/docs/hoon/library/zuse/diff.md
@@ -227,7 +227,7 @@ Examples
 Find common
 
 Finds a subsequence of repeated elements within two
-[`++list`](/doc/hoon/library/1#++list)s, producing a [\`++tape]().
+[`++list`](/docs/hoon/library/1#++list)s, producing a [\`++tape]().
 
 Accepts
 -------

--- a/docs/hoon/library/zuse/gate/jesc.md
+++ b/docs/hoon/library/zuse/gate/jesc.md
@@ -7,7 +7,7 @@ navhome: /docs
 
 Escape JSON character
 
-Produces a [`++tape`]() of an escaped [`++json`](/doc/hoon/library/3bi#++json) character `a`.
+Produces a [`++tape`]() of an escaped [`++json`](/docs/hoon/library/3bi#++json) character `a`.
 
 Accepts
 -------

--- a/docs/hoon/library/zuse/gate/tope.md
+++ b/docs/hoon/library/zuse/gate/tope.md
@@ -24,7 +24,7 @@ A `++path`.
           ^-  path
           [(scot %p p.bem) q.bem (scot r.bem) (flop s.bem)]
 
-Parses a [`++beam`]() to a [`++path`](/doc/hoon/library/1#++path).
+Parses a [`++beam`]() to a [`++path`](/docs/hoon/library/1#++path).
 
     ~zod/try=/zop> (tope [~zod %main ud/1] /hook/down/sur)
     /~zod/main/1/sur/down/hook

--- a/docs/hoon/syntax.md
+++ b/docs/hoon/syntax.md
@@ -371,7 +371,7 @@ long names and/or kebab-case.
 
 If you came all this way to learn how to write apps, you're all
 set. This is about all you need to know to start getting your
-hands dirty. Refer back here or to the [standard library](/hoon/library) when
-needed, but for now, move on to [Arvo](/arvo) to continue learning. 
+hands dirty. Refer back here or to the [standard library](../../hoon/library) when
+needed, but for now, move on to [Arvo](../../arvo) to continue learning.
 
 If, however, good enough is *not* enough, feel free to dive deeper:


### PR DESCRIPTION
Cleans up the formatting of the Arvo exercises, and fixes a couple of broken examples. Also fixes broken links in Arvo and elsewhere.

There are inconsistencies between relative and absolute links within the docs (there are both styles in this PR, as well). Do you have a preference between the two?