### PR TITLE
Remove solution to exercise in Arvo's State chapter

### DIFF
--- a/docs/arvo/state.md
+++ b/docs/arvo/state.md
@@ -20,8 +20,6 @@ running the sum of all the atoms we poke it with. Here's
     ++  poke-atom
       |=  arg/@
       ^-  {(list) _+>.$}
-      ?:  =(arg 0)  
-        [~ +>.$(state 0)]
       ~&  [%so-far (add state arg)]
       [~ +>.$(state (add state arg))]
     --


### PR DESCRIPTION
As proposed in the discussion for PR https://github.com/urbit/docs/pull/48, removes the solution to the Arvo/State chapter's first exercise ("Modify :examples-sum to reset the counter when you poke it with 0.") from the example code given. The code in the docs now matches that in the examples repo.