### PR TITLE
adds explanation of :moar

### DIFF
--- a/docs/hoon/twig/bar-core/dot-trap.md
+++ b/docs/hoon/twig/bar-core/dot-trap.md
@@ -52,3 +52,6 @@ A more interesting trap:
 
 Note that we can use `:moar()` or `$()` to recurse back into the
 trap, since it's a core with an `$` arm.
+
+> `:moar()` expands to `:make($)` (`%=($)`), accepting a *jogging* body
+> containing a list of changes to the subject.

--- a/docs/hoon/twig/bar-core/hep-loop.md
+++ b/docs/hoon/twig/bar-core/hep-loop.md
@@ -21,6 +21,15 @@ sort: 4
 
 Regular: *1-fixed*.
 
+## Discussion
+
+The `:loop` keyword (and `|-` rune) can be thought of as a "recursion point" -
+since `:loop` makes a `:trap` (a core with one arm named `$`), we can recurse
+back into it with `:moar()` or `$()`.
+
+> `:moar()` expands to `:make($)` (`%=($)`), accepting a *jogging* body
+> containing a list of changes to the subject.
+
 ## Examples
 
 A trivial loop doesn't even recurse:

--- a/docs/hoon/twig/bar-core/tar-gill.md
+++ b/docs/hoon/twig/bar-core/tar-gill.md
@@ -32,6 +32,11 @@ is still only one copy of the code, however).
 Genericity is a powerful and dangerous tool.  Use gills only if
 you think you know what you're doing. 
 
+Just as with a `:gate`, we can recurse back into a `:gill` with `:moar()` or `$()`.
+
+> `:moar()` expands to `:make($)` (`%=($)`), accepting a *jogging* body
+> containing a list of changes to the subject.
+
 ## Examples
 
 Wet and dry gates in a nutshell:

--- a/docs/hoon/twig/bar-core/tis-gate.md
+++ b/docs/hoon/twig/bar-core/tis-gate.md
@@ -24,6 +24,12 @@ Regular: *2-fixed*.
 
 ## Discussion
 
+A gate is a core with one arm named `$`, so, just as with `:loop` (`|-`),
+we can recurse back into it with `:moar()` or `$()`.
+
+> `:moar()` expands to `:make($)` (`%=($)`), accepting a *jogging* body
+> containing a list of changes to the subject.
+
 ## Examples
 
 A trivial gate:


### PR DESCRIPTION
to the relevant twigs (`|=`, `|*`, `|-`, and `|.`)

closes #24