### PR TITLE
Replaced incorrect example code in docs/arvo/generators

### DIFF
--- a/docs/arvo/generators.md
+++ b/docs/arvo/generators.md
@@ -72,81 +72,26 @@ We'll need a new mark for our arguments.  Let's call it
 > (/mar/examples/ping/message.hoon).
 
 ```
-::  Up-ness monitor. Accepts atom url, 'on', or 'off'
 ::
-::::  /hoon/up/examples/app
+::::  /hoon/message/ping/examples/app
   ::
 /?    314
-|%
-++  move  {bone card}
-++  card
-  $%  {$hiss wire $~ $httr {$purl p/purl}}
-      {$wait wire @da}
-  ==
-++  action
-  $%  {$on $~}            ::  enable polling('on')
-      {$off $~}           ::  disable polling('off)
-      {$target p/cord}    ::  set poll target('http://...')
-  ==
---
-|_  {hid/bowl on/_| in-progress/_| target/@t}
-++  poke-atom
-  |=  url-or-command/@t  ^-  (quip move +>)
-  =+  ^-  act/action
-      ?:  ?=($on url-or-command)  [%on ~]
-      ?:  ?=($off url-or-command)  [%off ~]
-      [%target url-or-command]
-  ?-  -.act
-    $target  [~ +>.$(target p.act)]
-    $off  [~ +>.$(on |)]
-    $on
-      :-  ?:  |(on in-progress)  ~
-          [ost.hid %hiss /request ~ %httr %purl (need (epur target))]~
-      +>.$(on &, in-progress &)
-  ==
-::
-
-::  ~&  'i get here'
-::  ^-  {(list move) _+>.$}
-::  ?:  =('off' url)
-::    [~ +>.$(on |)]
-::  ?:  =('on' url)
-::    :_  +>.$(on &, in-progress &)
-::    ?:  |(on in-progress)
-::      ~
-::    [ost.hid %them /request ~ (need (epur target)) %get ~ ~]~
-::  [~ +>.$(target url)]
-++  sigh-httr
-  |=  {wir/wire code/@ud headers/mess body/(unit octs)}
-  ~&  'arrive here'
-  ^-  {(list move) _+>.$}
-  ?:  &((gte code 200) (lth code 300))
-    ~&  [%all-is-well code]
-    :_  +>.$
-    [ost.hid %wait /timer (add ~s10 now.hid)]~
-  ~&  [%we-have-a-problem code]
-  ~&  [%headers headers]
-  ~&  [%body body]
-  :_  +>.$
-  [ost.hid %wait /timer (add ~s10 now.hid)]~
-++  wake-timer
-  |=  {wir/wire $~}  ^-  (quip move +>)
-  ?:  on
-    :_  +>.$
-    [ost.hid %hiss /request ~ %httr %purl (need (epur target))]~
-  [~ +>.$(in-progress |)]
-::
-++  prep  ~&  target  _`.  ::
+|_  {to/@p message/@t}
+++  grab
+  |%
+  ++  noun  {@p @t}
+  --
 --
 ```
 
 The app can easily be modified to use this (`/app/examples/ping.hoon`):
 
 ```
+::  Allows one ship to ping another with a string of text
 ::
 ::::  /hoon/ping/examples/app
   ::
-/?    151
+/?    314
 |%
   ++  move  {bone term wire *}
 --
@@ -172,8 +117,6 @@ The app can easily be modified to use this (`/app/examples/ping.hoon`):
 ::
 ++  coup  |=(* `+>)
 --
-
-
 ```
 
 Now we can run this with:

--- a/docs/arvo/generators.md
+++ b/docs/arvo/generators.md
@@ -138,7 +138,7 @@ to `:examples-ping`, let's put it in `/gen/examples/ping/send.hoon`:
 
 ```
 :-  %say
-|=  {^ {{to/@p message/?($~ {text/@t $~})} $~}
+|=  {^ {to/@p message/?($~ {text/@t $~})} $~}
 [%examples-ping-message to ?~(message 'howdy' text.message)]
 ```
 


### PR DESCRIPTION
Arvo's documentation on generators was showing hoon code for an unrelated application, rather than the appropriate mark. I replaced that with the `mar/examples/ping/message.hoon` mark's code [as available in the examples repository](https://github.com/urbit/examples/blob/master/gall/ping/mar/examples/ping/message.hoon), and simultaneously updated the code given for `app/examples/ping.hoon` (specifically, its header) to match that from the examples repository as well.

(Also fixed a small error in the generator code provided on that page, it had a `{` too many.)