### PR TITLE
Provide actual ++hard source code.

### DIFF
--- a/docs/hoon/library/2n.md
+++ b/docs/hoon/library/2n.md
@@ -145,10 +145,12 @@ not.
 Source
 ------
 
-    ++  cury                                                ::  curry left
-      |*  {a/_|=(^ **) b/*}
-      |*  c/_+<+.a
-      (a b c)
+    ++  hard                                                ::  force coerce to span
+      |*  han/mold
+      |=  fud/*  ^-  han
+      ~|  %hard
+      =+  gol=(han fud)
+      ?>(=(gol fud) gol)
     ::
 
 Examples


### PR DESCRIPTION
`++cury`'s source code was being shown under `++hard`'s documentation. Replaced it with `++hard`'s actual source code.