### PR TITLE
Fix: Several Documentation Issues

### DIFF
--- a/docs/hoon/syntax.md
+++ b/docs/hoon/syntax.md
@@ -159,7 +159,7 @@ with the [original](../demo).
   |=  end/atom
   =/  count  1
   |-  ^-  (list tape)
-  ?:  =(100 count)  ~
+  ?:  =(end count)  ~
   :_  $(count (add 1 count))
   ?:  =(0 (mod count 15))
     "FizzBuzz"
@@ -167,7 +167,7 @@ with the [original](../demo).
     "Fizz"
   ?:  =(0 (mod count 3))
     "Buzz"
-  (text !>(count))
+  (pave !>(count))
 ```
 
 ## Tall regular form

--- a/docs/using/web.md
+++ b/docs/using/web.md
@@ -42,6 +42,9 @@ To host a file on the web try putting the following in `/home/web/test.md` (from
 
 Create the directory `/home/web/test/` and add two more markdown files in it.
 
+NOTE: Due to a bug in Urbit you may have to create the directory and the file in it in rapid
+succession using something like `mkdir home/web/test && touch home/web/test/first.md`.
+
 Now modify `/home/web/test.md` to list the children using the `<list/>` JSX:
 
     # Hello
@@ -49,6 +52,10 @@ Now modify `/home/web/test.md` to list the children using the `<list/>` JSX:
     This is a simple markdown file.
 
     <div><list /></div>
+    
+To view your file rendered using tree:
+
+    http://localhost:8080/test/
 
 To view your file as raw `md`:
 


### PR DESCRIPTION
**Overview**
In Hoon overview Syntax documentation, idiomatic rune FizzBuzz example:
- Actually use `end` face to determine program termination.
- Replace `text` with `pave` so output is identical to non-idiomatic rune example.

In Web usage documentation:
- Add note regarding file deletion bug in order to prevent confusion for new users attempting to follow documentation.
- Provide link to tree rendered version of `test.md` so users know where to go to see fully rendered result of JSX tag.