### PR TITLE
Fix a few typos in the common irregulars section

### DIFF
--- a/docs/byte/1.md
+++ b/docs/byte/1.md
@@ -271,16 +271,16 @@ null, loobeans, and of course ships:
 0x6f.6f66
 
 > .n
-.n
+%.n
 
 > |
-.n
+%.n
 
 > .y
-.y
+%.y
 
 > &
-.y
+%.y
 
 > `@ud`&
 0
@@ -292,8 +292,8 @@ null, loobeans, and of course ships:
 0
 
 > ? ~zod
-  ~zod
-@p
+  @p
+~zod
 
 > `@ux`~forseg-bolbyn
 0x885e.8af9


### PR DESCRIPTION
* Add % to .y and .n (based on current dojo output)
* Fix the transposed type and representation of ~zod