### PR TITLE
rogue links in arvo/generators.md

### DIFF
--- a/docs/arvo/generators.md
+++ b/docs/arvo/generators.md
@@ -1,192 +1,178 @@
 ---
-navhome: /docs
-next: true
+navhome: '/docs'
+next: True
 sort: 8
 title: Using Generators with Apps
 ---
 
 # Generators
 
-Up until now we've poked apps directly.  This requires the user
-to specify the mark, and it requires the app to accept the
-arguments in a way that's convenient for users to input.  This is
-the "plumbing" way to interact with apps.  Generators are the
-"porcelain" layer.  This is why when you run a command like `+ls` or
-`|merge`, there are no marks in sight.
+Up until now we've poked apps directly. This requires the user to
+specify the mark, and it requires the app to accept the arguments in a
+way that's convenient for users to input. This is the "plumbing" way to
+interact with apps. Generators are the "porcelain" layer. This is why
+when you run a command like `+ls` or `|merge`, there are no marks in
+sight.
 
 We've used generators before, back in [Basic
-Operation](/docs/using/admin).  At that point, we just used the generators
-to produce values -- we didn't pipe their results into apps.  In
-the dojo cast, the role of a generator is to take a list of
-arguments and produce a value, which is often, though not always,
-piped into an app.  Generators are pure, stateless functions, and
-they cannot send moves.
+Operation](/docs/using/admin). At that point, we just used the
+generators to produce values -- we didn't pipe their results into apps.
+In the dojo cast, the role of a generator is to take a list of arguments
+and produce a value, which is often, though not always, piped into an
+app. Generators are pure, stateless functions, and they cannot send
+moves.
 
 `+ls` and `+cat` are commonly-used generators that produce a directory
-listing and print out a file, respectively.  These are useful in
+listing and print out a file, respectively. These are useful in
 themselves, so we generally don't pipe the results into an app.
 
-Another generator is `+hood/merge`.  Try running `+hood/merge`
-with the normal arguments for `|merge`:
+Another generator is `+hood/merge`. Try running `+hood/merge` with the
+normal arguments for `|merge`:
 
-```
-~fintud-macrep:dojo> +hood/merge %home our %they
-[syd=%home her=~fintud-macrep sud=%they gem=%auto]
-~fintud-macrep:dojo> +hood/merge %home our %they, =gem %this
-[syd=%home her=~fintud-macrep sud=%they gem=%auto]
-```
+    ~fintud-macrep:dojo> +hood/merge %home our %they
+    [syd=%home her=~fintud-macrep sud=%they gem=%auto]
+    ~fintud-macrep:dojo> +hood/merge %home our %they, =gem %this
+    [syd=%home her=~fintud-macrep sud=%they gem=%auto]
 
-This didn't run any merge, it just constructed the command that,
-if sent to `:hood`, would run it.  Note first that, even though
-it's not printed, this value has mark `kiln-merge`.  Also, the
-merge strategy `gem=%auto` was added automatically.  Optional
-arguments are straightforward with generators.
+This didn't run any merge, it just constructed the command that, if sent
+to `:hood`, would run it. Note first that, even though it's not printed,
+this value has mark `kiln-merge`. Also, the merge strategy `gem=%auto`
+was added automatically. Optional arguments are straightforward with
+generators.
 
-In general, generators are prepended by either `+` or `|`.  The
-general form is `+generator`, but often generators are created
-specifically to work with a single app, they're usually placed in
-a subdirectory of gen and run with `|`.  Thus, if `my-generator`
-generator is made for use with `:my-app`, then `my-generator` is
-put in `/gen/my-app/my-generator.hoon`, and can be run directly
-with `+my-app/my-generator <args>`.  If you want to pipe the
-result into `:my-app`, then run `:my-app +my-app/my-generator
-<args>`.  Because this pattern is so common, this can be
-abbreviated to `:my-app|my-generator <args>`.  Because most
-built-in commands are generators for the `:hood` app,
-`:hood|generator <args>` can be shortened to `|generator <args>`.
+In general, generators are prepended by either `+` or `|`. The general
+form is `+generator`, but often generators are created specifically to
+work with a single app, they're usually placed in a subdirectory of gen
+and run with `|`. Thus, if `my-generator` generator is made for use with
+`:my-app`, then `my-generator` is put in
+`/gen/my-app/my-generator.hoon`, and can be run directly with
+`+my-app/my-generator <args>`. If you want to pipe the result into
+`:my-app`, then run `:my-app +my-app/my-generator <args>`. Because this
+pattern is so common, this can be abbreviated to
+`:my-app|my-generator <args>`. Because most built-in commands are
+generators for the `:hood` app, `:hood|generator <args>` can be
+shortened to `|generator <args>`.
 
 Let's write a generator for a modified version of `:examples-pong` from
-the chapter on [Network Messages](/docs/programming/system/network).  Recall that `:examples-pong`
-takes an urbit address, which is of mark `urbit`, and sends that
-urbit the message `'howdy'`.  First--without a generator--let's
-make `:examples-ping` that does the same, except that it lets the user
-optionally specify the message as well.
+the chapter on [Network Messages](/docs/arvo/system/network). Recall
+that `:examples-pong` takes an urbit address, which is of mark `urbit`,
+and sends that urbit the message `'howdy'`. First--without a
+generator--let's make `:examples-ping` that does the same, except that
+it lets the user optionally specify the message as well.
 
-We'll need a new mark for our arguments.  Let's call it
+We'll need a new mark for our arguments. Let's call it
 `examples-ping-message`.
 
-> For app-specific marks, it's good style to prefix the name of
-> the mark with the name of the app.  Since many apps have
-> several such marks, subdirectories in `/mar` are rendered as
-> `-`, so that `ping-message` is written in
-> (/mar/examples/ping/message.hoon).
+> For app-specific marks, it's good style to prefix the name of the mark
+> with the name of the app. Since many apps have several such marks,
+> subdirectories in `/mar` are rendered as `-`, so that `ping-message`
+> is written in (/mar/examples/ping/message.hoon).
 
-```
-::
-::::  /hoon/message/ping/examples/app
-  ::
-/?    314
-|_  {to/@p message/@t}
-++  grab
-  |%
-  ++  noun  {@p @t}
-  --
---
-```
+    ::
+    ::::  /hoon/message/ping/examples/app
+      ::
+    /?    314
+    |_  {to/@p message/@t}
+    ++  grab
+      |%
+      ++  noun  {@p @t}
+      --
+    --
 
 The app can easily be modified to use this (`/app/examples/ping.hoon`):
 
-```
-::  Allows one ship to ping another with a string of text
-::
-::::  /hoon/ping/examples/app
-  ::
-/?    314
-|%
-  ++  move  {bone term wire *}
---
-!:
-|_  {bowl state/$~}
-::
-++  poke-examples-ping-message
-  |=  {to/@p message/@t}
-  ~&  'sent'
-  ^-  {(list move) _+>.$}
-  :-  ^-  (list move)
-      :~  `move`[ost %poke /sending [to dap] %atom message]
-      ==
-  +>.$
-::
-++  poke-atom
-  |=  arg/@
-  ~&  'received'
-  ^-  {(list move) _+>.$}
-  ::
-  ~&  [%receiving (@t arg)]
-  [~ +>.$]
-::
-++  coup  |=(* `+>)
---
-```
+    ::  Allows one ship to ping another with a string of text
+    ::
+    ::::  /hoon/ping/examples/app
+      ::
+    /?    314
+    |%
+      ++  move  {bone term wire *}
+    --
+    !:
+    |_  {bowl state/$~}
+    ::
+    ++  poke-examples-ping-message
+      |=  {to/@p message/@t}
+      ~&  'sent'
+      ^-  {(list move) _+>.$}
+      :-  ^-  (list move)
+          :~  `move`[ost %poke /sending [to dap] %atom message]
+          ==
+      +>.$
+    ::
+    ++  poke-atom
+      |=  arg/@
+      ~&  'received'
+      ^-  {(list move) _+>.$}
+      ::
+      ~&  [%receiving (@t arg)]
+      [~ +>.$]
+    ::
+    ++  coup  |=(* `+>)
+    --
 
 Now we can run this with:
 
-```
-~fintud-macrep:dojo> |start %examples-ping
->=
-~fintud-macrep:dojo> :examples-ping &examples-ping-message [~sampel-sipnym 'heyya']
->=
-```
+    ~fintud-macrep:dojo> |start %examples-ping
+    >=
+    ~fintud-macrep:dojo> :examples-ping &examples-ping-message [~sampel-sipnym 'heyya']
+    >=
 
 And on `~sampel-sipnym`, assuming it's running `:examples-ping` as well,
 we see `[%receiving 'heyya']`.
 
-This is an annoying way to invoke the app, though.  The `[]` are
-mandatory, and optional arguments are hard.  Let's make a
-generator, `+examples-send` to make everything nicer.  Since it's specific
-to `:examples-ping`, let's put it in `/gen/examples/ping/send.hoon`:
+This is an annoying way to invoke the app, though. The `[]` are
+mandatory, and optional arguments are hard. Let's make a generator,
+`+examples-send` to make everything nicer. Since it's specific to
+`:examples-ping`, let's put it in `/gen/examples/ping/send.hoon`:
 
-```
-:-  %say
-|=  {^ {to/@p message/?($~ {text/@t $~})} $~}
-[%examples-ping-message to ?~(message 'howdy' text.message)]
-```
+    :-  %say
+    |=  {^ {to/@p message/?($~ {text/@t $~})} $~}
+    [%examples-ping-message to ?~(message 'howdy' text.message)]
 
-A couple of new things here.  Firstly, `message/?($~ {text/@t $~})`
-should be read as "the message is either null or a pair of text
-and null".  Generator argument lists are always null-terminated,
-which makes it convenient to accept lists in tail position (which
-are particularly annoying without generators).  `?(a b)` is the
-irregular form of `$?(a b)`, which is a union type.  Thus, `?(a
-b)` means the type of anything that's in either `a` or `b`.
-Thus, in our case, `?(~ [text=@t ~])` is either null or a pair of
-text and null.
+A couple of new things here. Firstly, `message/?($~ {text/@t $~})`
+should be read as "the message is either null or a pair of text and
+null". Generator argument lists are always null-terminated, which makes
+it convenient to accept lists in tail position (which are particularly
+annoying without generators). `?(a b)` is the irregular form of
+`$?(a b)`, which is a union type. Thus, `?(a b)` means the type of
+anything that's in either `a` or `b`. Thus, in our case,
+`?(~ [text=@t ~])` is either null or a pair of text and null.
 
-Secondly, `?~(a b c)` is a rune which means "if the `a` is null,
-do `b`, else `c`".  It is roughly equivalent to `?:(=(~ a) b c)`.
+Secondly, `?~(a b c)` is a rune which means "if the `a` is null, do `b`,
+else `c`". It is roughly equivalent to `?:(=(~ a) b c)`.
 
-> `?~(a b c)` is actually equivalent to `?:=(?=(~ a) b c)`,
-> which, although identical at run time, is subtly different at
-> compile time.  Specifically, using `?=` rather than `=` means
-> that we're checking whether `a` is in the *type* of `~`, and so
-> the compiler knows that in the `b` case `a` is null, and in the
-> `c` case `a` is not null.  Since `=` is purely a runtime value
-> check with no type implications, the compiler doesn't gain any
-> information.
+> `?~(a b c)` is actually equivalent to `?:=(?=(~ a) b c)`, which,
+> although identical at run time, is subtly different at compile time.
+> Specifically, using `?=` rather than `=` means that we're checking
+> whether `a` is in the *type* of `~`, and so the compiler knows that in
+> the `b` case `a` is null, and in the `c` case `a` is not null. Since
+> `=` is purely a runtime value check with no type implications, the
+> compiler doesn't gain any information.
 >
-> At any rate, this is the reason why we can refer to
-> `text.message` in the `c` clause.  The compiler knows that
-> `message` is not null, so it must have `text` within it.  If
-> you used `?:(=(~ message) 'howdy' text.message)` the compiler
-> would complain that it doesn't know whether `message` has
-> `text` within it.
+> At any rate, this is the reason why we can refer to `text.message` in
+> the `c` clause. The compiler knows that `message` is not null, so it
+> must have `text` within it. If you used
+> `?:(=(~ message) 'howdy' text.message)` the compiler would complain
+> that it doesn't know whether `message` has `text` within it.
 
 This is run as follows:
 
-```
-~fintud-macrep:dojo> :examples-ping|send ~sampel-sipnym
->=
-~fintud-macrep:dojo> :examples-ping|send ~sampel-sipnym 'how do you do'
->=
-```
+    ~fintud-macrep:dojo> :examples-ping|send ~sampel-sipnym
+    >=
+    ~fintud-macrep:dojo> :examples-ping|send ~sampel-sipnym 'how do you do'
+    >=
 
 Which causes `~sampel-sipnym` to print `[%receiving 'howdy']` and
 `[%receiving 'how do you do']`.
 
 **Exercises**:
 
-- Create a generator for `:examples-sum` from [State](state) so that
-  you can run `:examples-sum|add 5` to add numbers to it.
+-   Create a generator for `:examples-sum` from
+    [State](/docs/arvo/state) so that you can run `:examples-sum|add 5`
+    to add numbers to it.
 
-- Create a generator for `:examples-click` from [Web Apps](web-apps) so
-  that you can run `:examplesclick|poke` to poke it.
+-   Create a generator for `:examples-click` from [Web
+    Apps](/docs/arvo/web-apps) so that you can run
+    `:examples-click|poke` to poke it.

--- a/docs/arvo/subscriptions.md
+++ b/docs/arvo/subscriptions.md
@@ -93,8 +93,8 @@ Cheat sheet:
     `?:($=(%type value) %tru %false)`. `$=`
     ([buctis](../../hoon/twig/buc-mold/tis-coat/)) tests whether value `q` is
     of type `p`.
-    <!--One thing to watch out for in hoon: if you do `?~`, it
-      affects the type of the conditional value: XXexample-->
+<!-- One thing to watch out for in hoon: if you do `?~`, it
+      affects the type of the conditional value: XXexample -->
 
 -   `:_` ([colcab](../../hoon/twig/col-cell/cab-scon/)) is inverted `:-`: it
     accepts `p` and `q`, and produces `[q p]`.
@@ -106,7 +106,8 @@ Cheat sheet:
 -   `$%` ([buccen](../../hoon/twig/buc-mold/cen-book/)) is a type
     constructor: it defines a new type, composed of `n` types that it is
     passed. For example `$%  @  *  ^  ==` is the type of either `@`,
-    `*`, or a cell `^`. <!--XX this is a union, right?-->
+    `*`, or a cell `^`. 
+<!-- XX this is a union, right? -->
 
 -   You may have noticed the separate `|%`
     ([barcen](../../hoon/twig/bar-core/cen-core/)) above the application core


### PR DESCRIPTION
sorry for the noisy diff. will pandoc separately in future.

* change 3 relative links to absolute ( which where broken: href="state" --> href="/docs/arvo/state" ) 
* pandoc