### PR TITLE
Remove unimplemented ;who <station> command

### DIFF
--- a/docs/using/messaging.md
+++ b/docs/using/messaging.md
@@ -188,8 +188,6 @@ you're subscribed to.
 
 `;who` - list everyone in all your stations
 
-`;who station` - list everyone in that station
-
 ### Station Glyphs
 
 Glyphs are assigned by station hash out of the following list


### PR DESCRIPTION
I've tried to learn my way around :talk twice now, and both times this unimplemented command has tripped me up. This seems like our good friend "premature documentation." Can we remove it to spare future urbit pioneers the confusion?