### PR TITLE
Add documentation for ++oust

### DIFF
--- a/docs/hoon/library/2b.md
+++ b/docs/hoon/library/2b.md
@@ -394,6 +394,41 @@ Examples
 
 
 ***
+### `++oust`
+
+Remove
+
+Removes elements from list `c` beginning at inclusive index `a`, removing `b` number of elements.
+
+Accepts
+-------
+
+`c` is a list.
+
+Produces
+--------
+
+A `++list`.
+
+Source
+------
+
+    ++  oust                                                ::  remove
+      ~/  %oust
+      |*  {{a/@ b/@} c/(list)}
+      (weld (scag a c) (slag (add a b) c))
+
+Examples
+--------
+
+    > (oust [4 5] "good day, urbit!")
+    "good urbit!"
+    > (oust [2 2] (limo [1 2 3 4 ~]))
+    [i=1 t=[i=2 t=~]]
+
+
+
+***
 ### `++reap`
 
 Replicate


### PR DESCRIPTION
`++oust`, for deleting elements from lists, got added in urbit/arvo#241. This is the documentation for it.