### PR TITLE
Consistently use ctrl-key instead of ^key

### DIFF
--- a/docs/about/runtime.md
+++ b/docs/about/runtime.md
@@ -513,7 +513,7 @@ no means the case.
 
 In deep memory, think of yourself as if in a signal handler.
 Your execution context is extremely fragile and may be terminated
-without warning or cleanup at any time (for instance, by ^C).
+without warning or cleanup at any time (for instance, by `ctrl-c`).
 
 For instance, you can't call `malloc` (or C++ `new`) in your C
 code, because you don't have the right to modify data structures

--- a/docs/byte/0.md
+++ b/docs/byte/0.md
@@ -256,10 +256,11 @@ Each number is an atom; each dot is a cell.
 
 ## And we're done
 
-And we're done!  Press `ctrl-d` to exit:
+And we're done!  Type `|exit` to exit:
 
 ```
-~zod:dojo> ^D
+~zod:dojo> |exit
+%drum-exit
 $
 ```
 

--- a/docs/byte/0.md
+++ b/docs/byte/0.md
@@ -90,7 +90,7 @@ http: live (insecure, loopback) on 12321
 ```
 
 That's super awesome!  You made your first noun!  We'll make a
-few more in a second.  First, quit Urbit with `^D`:
+few more in a second.  First, quit Urbit with `ctrl-d`:
 
 ```
 > (add 2 2)
@@ -121,7 +121,7 @@ http: live (insecure, loopback) on 12321
 ```
 
 Note also that Urbit is an ACID database.  You can stop it
-politely with `^D`, abruptly with `^Z`, even violently with `kill
+politely with `ctrl-d`, abruptly with `ctrl-z`, even violently with `kill
 -9`.  None of these should cause Urbit to lose data.  If you do
 manage to corrupt a pier, it's a bug; please let us know.
 
@@ -256,7 +256,7 @@ Each number is an atom; each dot is a cell.
 
 ## And we're done
 
-And we're done!  Press `^D` to exit:
+And we're done!  Press `ctrl-d` to exit:
 
 ```
 ~zod:dojo> ^D

--- a/docs/byte/1.md
+++ b/docs/byte/1.md
@@ -334,7 +334,7 @@ all its atoms as decimals.
 
 ## And we're done
 
-And we're done!  Press `^D` to exit:
+And we're done!  Press `ctrl-d` to exit:
 
 ```
 ~zod:dojo> ^D

--- a/docs/byte/1.md
+++ b/docs/byte/1.md
@@ -334,10 +334,11 @@ all its atoms as decimals.
 
 ## And we're done
 
-And we're done!  Press `ctrl-d` to exit:
+And we're done!  Type `|exit` to exit:
 
 ```
-~zod:dojo> ^D
+~zod:dojo> |exit
+%drum-exit
 $
 ```
 

--- a/docs/byte/2.md
+++ b/docs/byte/2.md
@@ -36,8 +36,8 @@ are expressions.
 
 (The dojo is not the only command-line app on your Urbit.  By
 default there is one other, `:talk`.  Since you're on a fakezod,
-you can only talk to yourself.  If you accidentally press `^X`,
-it will put you into `:talk`; press `^X` again to switch back.)
+you can only talk to yourself.  If you accidentally press `ctrl-x`,
+it will put you into `:talk`; press `ctrl-x` again to switch back.)
 
 ### Dojo variables
 
@@ -476,7 +476,7 @@ not a particularly interesting mystery.
 
 ## And we're done
 
-And we're done!  Press `^D` to exit:
+And we're done!  Press `ctrl-d` to exit:
 
 ```
 ~zod:dojo> ^D

--- a/docs/byte/2.md
+++ b/docs/byte/2.md
@@ -476,10 +476,11 @@ not a particularly interesting mystery.
 
 ## And we're done
 
-And we're done!  Press `ctrl-d` to exit:
+And we're done!  Type `|exit` to exit:
 
 ```
-~zod:dojo> ^D
+~zod:dojo> |exit
+%drum-exit
 $
 ```
 

--- a/docs/hoon/troubleshooting.md
+++ b/docs/hoon/troubleshooting.md
@@ -145,7 +145,7 @@ If your code crashes at runtime or overflows the stack, you'll
 see a stack trace that looks just like the trace above.  Don't
 confuse runtime crashes with compilation errors, though.
 
-If your code goes into an infinite loop, kill it with `^C` (you'll
+If your code goes into an infinite loop, kill it with `ctrl-c` (you'll
 need to be developing on the local console; otherwise, the
 infinite loop will time out either too slowly or too fast).  The
 stack trace will show what your code was doing when interrupted.

--- a/docs/hoon/twig/sig-hint/lus-memo.md
+++ b/docs/hoon/twig/sig-hint/lus-memo.md
@@ -29,7 +29,7 @@ This may pause for a second:
 121.393
 ```
 
-This may make you want to press ^C:
+This may make you want to press `ctrl-c`:
 
 ```
 ~zod:dojo> %.(30 |=(a/@ ?:((lth a 2) 1 (add $(a (sub a 2)) $(a (dec a))))))

--- a/docs/using/admin.md
+++ b/docs/using/admin.md
@@ -17,7 +17,7 @@ Your Urbit is a persistent Unix process that you mainly control from the console
 
 ## Shutdown
 
-You can turn your Urbit off with `^D` from the `:talk` or `:dojo` prompts.
+You can turn your Urbit off with `ctrl-d` from the `:talk` or `:dojo` prompts.
 
 ## Restart
 
@@ -35,29 +35,29 @@ Your Urbit terminal is separated into two parts: the prompt (the bottom line) an
 
 In the CLI Urbit apps can process your input before you hit return.  To see this in action try entering `)` as the first character at the `:dojo` prompt.  Since there is no dojo command or hoon expression that starts with ')', the dojo rejects it.
 
-`^X` - Switches the prompt between running console apps
+`ctrl-x` - Switches the prompt between running console apps
 
-`^C` - Crash current event.  Processed at the Unix layer and prints a stack trace.
+`ctrl-c` - Crash current event.  Processed at the Unix layer and prints a stack trace.
 
-`^D` - From `:talk` or `:dojo` stops your Urbit process.
+`ctrl-d` - From `:talk` or `:dojo` stops your Urbit process.
 
 `↑` / `↓` - History navigation
 
 The following emacs-style key bindings are available:
 
-    ^A    cursor to beginning of the line (Home)
-    ^B    cursor one character backward (left-arrow)
-    ^E    cursor to the end of the line (End)
-    ^F    cursor one character forward (right-arrow)
-    ^G    beep; cancel reverse-search
-    ^K    kill to end of line
-    ^L    clear the screen
-    ^N    next line in history (down-arrow)
-    ^P    previous line in history (up-arrow)
-    ^R    reverse-search
-    ^T    transpose characters
-    ^U    kill to beginning of line
-    ^Y    yank from kill buffer
+    ctrl-a    cursor to beginning of the line (Home)
+    ctrl-b    cursor one character backward (left-arrow)
+    ctrl-e    cursor to the end of the line (End)
+    ctrl-f    cursor one character forward (right-arrow)
+    ctrl-g    beep; cancel reverse-search
+    ctrl-k    kill to end of line
+    ctrl-l    clear the screen
+    ctrl-n    next line in history (down-arrow)
+    ctrl-p    previous line in history (up-arrow)
+    ctrl-r    reverse-search
+    ctrl-t    transpose characters
+    ctrl-u    kill to beginning of line
+    ctrl-y    yank from kill buffer
 
 Full coverage of the Urbit shell, the `:dojo` is covered in the [Shell walkthrough](/docs/using/shell).
 

--- a/docs/using/setup.md
+++ b/docs/using/setup.md
@@ -62,7 +62,7 @@ Good.
 
 ### Messaging — `:talk`
 
-Use `^X` (ctrl-x) to change your prompt. Let's join the main Urbit chat
+Use `ctrl-x` to change your prompt. Let's join the main Urbit chat
 channel.
 
 For planets:


### PR DESCRIPTION
As proposed in #36, all instances of key combo notations like `^X` have been replaced with `ctrl-x`.

Not entirely sure what to do about the output examples in Urbytes, ie:

> And we're done!  Press `ctrl-d` to exit:
```
~zod:dojo> ^D
$
```

I'd completely remove the `^D` there because it doesn't show up in the CLI either, but then what would those two lines be there for. Are they even necessary to begin with?