### PR TITLE
Typo fix: two colons.

### DIFF
--- a/docs/byte/2.md
+++ b/docs/byte/2.md
@@ -143,7 +143,7 @@ which is its address.  The root of the tree is `1`; if the
 address of a cell is `n`, its head is `2n` and its tail is
 `2n+1`.
 
-A picture might help::
+A picture might help:
 ```
             1
          /     \


### PR DESCRIPTION
Fix typo: two colons.