### PR TITLE
Fix typo.

### DIFF
--- a/docs/byte/2.md
+++ b/docs/byte/2.md
@@ -152,7 +152,7 @@ A picture might help:
       4   5   6   7
                  / \
                 14 15
-```                
+```
 
 The syntax for a fragment of the subject at a tree address, or
 *axis*, is just `+axis`.  So:
@@ -219,7 +219,7 @@ table here -- just a tree search.
 
 An expression like the label `x` or the axis `+2`, which
 designates a fragment or feature of the subject, is called a
-*limb*.  A list of limbs connected with `.`, is a *wing*.
+*limb*.  A list of limbs connected with `.` is a *wing*.
 
 To remind you that you're not in Kansas anymore, the syntax for a
 wing, like `q.y` above, means means "q inside y."  In a classic


### PR DESCRIPTION
Remove comma to fix potentially confusing syntax typo.