### PR TITLE
Add python to apt-get dependencies

### DIFF
--- a/docs/using/install.md
+++ b/docs/using/install.md
@@ -75,7 +75,7 @@ Which can usually be installed with the following one-liners:
     $ sudo port install gmp libsigsegv openssl autoconf automake cmake
 
     # Ubuntu or Debian
-    $ sudo apt-get install libgmp3-dev libsigsegv-dev openssl libssl-dev libncurses5-dev make exuberant-ctags automake autoconf libtool g++ ragel cmake re2c libcurl4-gnutls-dev
+    $ sudo apt-get install libgmp3-dev libsigsegv-dev openssl libssl-dev libncurses5-dev make exuberant-ctags automake autoconf libtool g++ ragel cmake python re2c libcurl4-gnutls-dev
 
     # Fedora
     $ sudo dnf install gcc gcc-c++ gmp-devel openssl-devel openssl ncurses-devel libsigsegv-devel ctags automake autoconf libtool ragel cmake re2c libcurl-devel


### PR DESCRIPTION
This is redundant in most environments, but apparently commonmark will fail to build otherwise.