### PR TITLE
Boot comet not fake ~zod in Urbytes.

### DIFF
--- a/docs/byte/0.md
+++ b/docs/byte/0.md
@@ -93,7 +93,7 @@ messages (you are booting an operating system, after all!).
 At the end, you'll see something like:
 
 ```
-ames: on localhost, UDP 58730.
+ames: on localhost, UDP 55360.
 http: live (insecure, public) on 8080
 http: live ("secure", public) on 8443
 http: live (insecure, loopback) on 12321
@@ -108,7 +108,7 @@ But wait, we want to see our actual name! There's actually a
 simple command for that, which will also help us make sure that
 everything is working. We can type this command into our *Dojo*.
 
-On Urbit, the Dojo acts as both our Hoon REPL and our Arvo shell.
+On Urbit, the Dojo acts as both our Hoon [REPL](https://en.wikipedia.org/wiki/Read-eval-print_loop) and our Arvo shell.
 
 Type `our` at the Dojo prompt, then hit Return.
 
@@ -116,7 +116,7 @@ Your Dojo should have printed your full comet name, something
 like this:
 
 ```
-ames: on localhost, UDP 58730.
+ames: on localhost, UDP 55360.
 http: live (insecure, public) on 8080
 http: live ("secure", public) on 8443
 http: live (insecure, loopback) on 12321
@@ -126,13 +126,13 @@ http: live (insecure, loopback) on 12321
 ```
 
 That's a mouthful! You'll find a note towards the end of this Urbyte
-on how you can ask for a "planet", a shorter identity like `~tonret-sigsur`,
+on how you can ask for a *planet*, a shorter identity like `~tonret-sigsur`,
 that you can keep forever.
 
 Let's add some numbers!
 
 ````
-ames: on localhost, UDP 58730.
+ames: on localhost, UDP 55360.
 http: live (insecure, public) on 8080
 http: live ("secure", public) on 8443
 http: live (insecure, loopback) on 12321
@@ -146,7 +146,7 @@ http: live (insecure, loopback) on 12321
 And because you're running Martian software now:
 
 ````
-ames: on localhost, UDP 58730.
+ames: on localhost, UDP 55360.
 http: live (insecure, public) on 8080
 http: live ("secure", public) on 8443
 http: live (insecure, loopback) on 12321
@@ -166,7 +166,11 @@ We'll make a few more in a second.  First, quit Urbit
 with `ctrl-d`:
 
 ```
-> our
+ames: on localhost, UDP 55360.
+http: live (insecure, public) on 8080
+http: live ("secure", public) on 8443
+http: live (insecure, loopback) on 12321
+k our
 ~palnul-wolmev-bonfex-danred--tilwen-midlux-bolfus-nocser
 > (add 2 2)
 4
@@ -190,7 +194,7 @@ means "create").  There are also fewer startup messages:
 ```
 $ urbit mycomet
 [...]
-ames: on localhost, UDP 58730.
+ames: on localhost, UDP 55360.
 http: live (insecure, public) on 8080
 http: live ("secure", public) on 8443
 http: live (insecure, loopback) on 12321
@@ -209,31 +213,31 @@ please let us know.
 
 You've already made three nouns.  Let's make another!
 
-*(We won't show the `~palnul_nocser:dojo> ` prompt from here on out.
+*We won't show the `~palnul_nocser:dojo> ` prompt from here on out.
 We'll just show the echoed command.*
 
 
-*So*
+*So we'll write:*
 
 ```
 ~palnul_nocser:dojo> 42
+42
 ```
 
-*now becomes:*
+*from here on as:*
 
 ```
 > 42
 42
-~zod:dojo>
 ```
 
-*Awesome.)*
+*Awesome.*
 
 ## Understanding nouns
 
 A value in Urbit is called a *noun*.  A noun is either an *atom*
-(an unsigned integer of any size) or a *cell* (an ordered pair of
-any two nouns).
+or a *cell*. An atom is a natural number of any size. A cell is an
+ordered pair of any two nouns.
 
 In a sentence, a noun is a binary tree whose leaves are numbers.
 If you know Lisp, a noun is a minimalist S-expression.  A noun

--- a/docs/byte/0.md
+++ b/docs/byte/0.md
@@ -5,7 +5,7 @@ next: true
 title: Setup and nouns
 ---
 
-# Urbyte 0: setup and nouns
+# Urbyte 0: Setup and nouns
 
 This is the first post in our new Urbyte series.
 
@@ -36,44 +36,25 @@ While you're downloading, read about Urbit ships:
 
 ## Ships
 
-In the Urbyte exercises, and in your entire Urbit experience,
-you'll be running what we call a *ship*.
+In the Urbyte exercises you'll be running what we call a "comet". A string starting with `~`, like `~zod`, is what Urbit
+calls a *ship*.
 
-On Urbit, a *ship* is a single number which means four things:
-a network address, a cryptographic identity, a memorable name,
-and a virtual computer.
+A *ship* is one number which means four things: a network address,
+a cryptographic identity, a memorable name, and a single virtual
+computer.
 
-We write this number in a base-256 format, but where each digit
-is instead a syllable. So when strung out, your number becomes
-a kind of name, like if your phone number was a pronounceable
-string that sounded like a name in an alien language. We designate
-ships by tagging on `~` to the front of this string. Thus, your
-future ship might be something like `~palfun-foslup`, which on
-Urbit is literally just the number 1,245,952.
+We write this number in a base-256 format, where each digit is a
+syllable.  Imagine if your phone number was a pronounceable
+string which sounded like a name in a foreign language. `~zod`
+is ship zero (making it a very important ship indeed!). An ordinary
+user-level ship is a "planet", a 32-bit number which becomes
+a four-syllable string, like `~talsur-todres`.
 
-For this exercise series, you'll be running a specific kind of
-ship called a *comet*. Unlike other ships, comets are disposable
-identities, making them ideal for playing around with Hoon (in
-case you break something!) and showing off Urbit to your friends.
-
-In the future, if you wish to contribute to Urbit itself, an even
-more ideal sandbox for Urbit development is what we call a *fake
-`~zod`* (~zod is ship 0 on the Urbit network, and is a very
-important ship indeed!). More information on that can be found
-[here](http://urbit.org/fora/posts/~2017.1.5..21.31.04..20f3~/).
-
-You can also read more about the Urbit address space and Urbit's
-different classes of ships [here](https://urbit.org/posts/address-space/).
-
-Please keep in mind that Urbit is still alpha software and bugs
-will be found. If you think you've find one somewhere along this
-series, please don't hesitate to file an issue on Github, or even
-better, [find us on Talk](https://urbit.org/stream)! But our team
-and our contributors are working hard to make Urbit real. More on
-our mission [here](http://urbit.org/posts/overview/).
-
-Without further ado, let's learn Hoon!
-
+*Comets*, at 128-bits or 16 syllables, are
+disposable identities that anyone can make for free to
+join the live network. Thus, comets make the ideal ship for
+playing around with Hoon, asking for help from other Urbit devs in [`:talk`](http://urbit.org/docs/using/messaging/) if you
+need it, and showing off Urbit to your hacker friends.
 
 ## Create and restart
 
@@ -88,9 +69,7 @@ $ urbit -c mycomet
 ```
 
 This will take a few minutes and will spin out a bunch of boot
-messages (you are booting an operating system, after all!).
-
-At the end, you'll see something like:
+messages. At the end, you'll see something like:
 
 ```
 ames: on localhost, UDP 55360.
@@ -100,82 +79,29 @@ http: live (insecure, loopback) on 12321
 ~palnul_nocser:dojo>
 ```
 
-where `~palnul_nocser` is actually a shortened version of our
-full comet identity (comets are 128-bits, or 16 syllables!).
-Think of the `_` here as an ellipsis.
-
-But wait, we want to see our actual name! There's actually a
-simple command for that, which will also help us make sure that
-everything is working. We can type this command into our *Dojo*.
-
-On Urbit, the Dojo acts as both our Hoon [REPL](https://en.wikipedia.org/wiki/Read-eval-print_loop) and our Arvo shell.
-
-Type `our` at the Dojo prompt, then hit Return.
-
-Your Dojo should have printed your full comet name, something
-like this:
-
-```
-ames: on localhost, UDP 55360.
-http: live (insecure, public) on 8080
-http: live ("secure", public) on 8443
-http: live (insecure, loopback) on 12321
-> our
-~palnul-wolmev-bonfex-danred--tilwen-midlux-bolfus-nocser
-~palnul_nocser:dojo>
-```
-
-That's a mouthful! You'll find a note towards the end of this Urbyte
-on how you can ask for a *planet*, a shorter identity like `~tonret-sigsur`,
-that you can keep forever.
-
-Let's add some numbers!
+To make sure everything is working, type `(add 2 2)` at the
+prompt, then hit return.  Your screen should now show:
 
 ````
 ames: on localhost, UDP 55360.
 http: live (insecure, public) on 8080
 http: live ("secure", public) on 8443
 http: live (insecure, loopback) on 12321
-> our
-~palnul-wolmev-bonfex-danred--tilwen-midlux-bolfus-nocser
 > (add 2 2)
 4
 ~palnul_nocser:dojo>
 ````
 
-And because you're running Martian software now:
-
-````
-ames: on localhost, UDP 55360.
-http: live (insecure, public) on 8080
-http: live ("secure", public) on 8443
-http: live (insecure, loopback) on 12321
-> our
-~palnul-wolmev-bonfex-danred--tilwen-midlux-bolfus-nocser
-> (add 2 2)
-4
-> 'Hello Mars!'
-'Hello Mars!'
-~palnul_nocser:dojo>
-````
-
-
-Congratulations!  You made your first nouns!
-
-We'll make a few more in a second.  First, quit Urbit
-with `ctrl-d`:
+That's super awesome!  You made your first nouns!  We'll make a
+few more in a second.  First, quit Urbit with `ctrl-d`:
 
 ```
 ames: on localhost, UDP 55360.
 http: live (insecure, public) on 8080
 http: live ("secure", public) on 8443
 http: live (insecure, loopback) on 12321
-k our
-~palnul-wolmev-bonfex-danred--tilwen-midlux-bolfus-nocser
 > (add 2 2)
 4
-> 'Hello Mars!'
-'Hello Mars!'
 ~palnul_nocser:dojo>
 $
 ```
@@ -201,17 +127,29 @@ http: live (insecure, loopback) on 12321
 ~palnul_nocser:dojo>
 ```
 
-Not too scary, right?
-
 Note also that Urbit is an ACID database.  You can stop it
 politely with `ctrl-d`, abruptly with `ctrl-z`, even violently with `kill
 -9`.  None of these should cause Urbit to lose data.  If you do
-manage to corrupt a pier, it's a bug;
-please let us know.
+manage to corrupt a pier, it's a bug; please let us know.
+
+## Wait, where are we?
+
+We're playing in the Urbit `:dojo`.  The dojo is sort of like a
+cross between a Lisp REPL and the Unix shell.  (If you know the
+Unix shell, the Urbit command line has the same history model and
+Emacs editing commands.)
+
+The dojo has its own command language, which is a superset of
+Hoon.  Any Hoon expression is a command.  But not all commands
+are expressions.
+
+(The dojo is not the only command-line app on your Urbit.  By
+default there is one other, `:talk`.  If you accidentally press `ctrl-x`,
+it will put you into `:talk`; press `ctrl-x` again to switch back.)
 
 ## Let's make a noun
 
-You've already made three nouns.  Let's make another!
+You've already made a noun.  Let's make another!
 
 *We won't show the `~palnul_nocser:dojo> ` prompt from here on out.
 We'll just show the echoed command.*
@@ -366,15 +304,3 @@ The question today is: what is the right way to represent common
 data structures as nouns?  A linked list?  A string?  A *signed*
 integer?  A table or associative array?  Just try to picture
 these structures in your head, or draw them on a piece of paper.
-
-## Ask for a planet
-
-If you think Urbit is cool and want to jump on for the ride,
-first **subscribe to our mailing list**
-[on our homepage](http://urbit.org/) and
-[join us](http://urbit.org/docs/using/messaging/)
-in our `/urbit-meta` chatroom to talk and hang out!
-[We're also on Twitter](https://twitter.com/urbit_). Once on
-`/urbit-meta`, our devs will try and hook you up with a planet.
-
-##### Thanks for joining!

--- a/docs/byte/0.md
+++ b/docs/byte/0.md
@@ -81,6 +81,9 @@ Assuming you've installed Urbit as per above, to create your
 comet, run:
 
 ```
+$ cd ~
+$ mkdir urbit
+$ cd urbit
 $ urbit -c mycomet
 ```
 
@@ -363,7 +366,7 @@ these structures in your head, or draw them on a piece of paper.
 ## Ask for a planet
 
 If you think Urbit is cool and want to jump on for the ride,
-first **subscribe to our mailing list**
+first **subscribe to our mailing list_**
 [on our homepage](http://urbit.org/) and
 [join us](http://urbit.org/docs/using/messaging/)
 in our `/urbit-meta` chatroom to talk and hang out!

--- a/docs/byte/0.md
+++ b/docs/byte/0.md
@@ -36,112 +36,195 @@ While you're downloading, read about Urbit ships:
 
 ## Ships
 
-In the Urbyte exercises you'll be running what we call a "fake
-`~zod`."  A string starting with `~`, like `~zod`, is what Urbit
-calls a *ship*.
+In the Urbyte exercises, and in your entire Urbit experience,
+you'll be running what we call a *ship*.
 
-A *ship* is one number which means four things: a network address,
-a cryptographic identity, a memorable name, and a single virtual
-computer.
+On Urbit, a *ship* is a single number which means four things:
+a network address, a cryptographic identity, a memorable name,
+and a virtual computer.
 
-We write this number in a base-256 format, where each digit is a
-syllable.  Imagine if your phone number was a pronounceable
-string which sounded like a name in a foreign language.
+We write this number in a base-256 format, but where each digit
+is instead a syllable. So when strung out, your number becomes
+a kind of name, like if your phone number was a pronounceable
+string that sounded like a name in an alien language. We designate
+ships by tagging on `~` to the front of this string. Thus, your
+future ship might be something like `~palfun-foslup`, which on
+Urbit is literally just the number 1,245,952.
 
-`~zod` is ship zero, making it a very important ship indeed.
-Your "fakezod" thinks it's `~zod`, but no one can talk to it.
-(An ordinary user-level ship is a 32-bit number which becomes
-a four-syllable string, like `~talsur-todres`.)
+For this exercise series, you'll be running a specific kind of
+ship called a *comet*. Unlike other ships, comets are disposable
+identities, making them ideal for playing around with Hoon (in
+case you break something!) and showing off Urbit to your friends.
 
-A fakezod is not the true Urbit experience, of course.  But it's
-ideal if all you want to do is play around with Hoon.  If you
-have a real urbit ship, of course you can use that instead.
+In the future, if you wish to contribute to Urbit itself, an even
+more ideal sandbox for Urbit development is what we call a *fake
+`~zod`* (~zod is ship 0 on the Urbit network, and is a very
+important ship indeed!). More information on that can be found
+[here](http://urbit.org/fora/posts/~2017.1.5..21.31.04..20f3~/).
+
+You can also read more about the Urbit address space and Urbit's
+different classes of ships [here](https://urbit.org/posts/address-space/).
+
+Please keep in mind that Urbit is still alpha software and bugs
+will be found. If you think you've find one somewhere along this
+series, please don't hesitate to file an issue on Github, or even
+better, [find us on Talk](https://urbit.org/stream)! But our team
+and our contributors are working hard to make Urbit real. More on
+our mission [here](http://urbit.org/posts/overview/).
+
+Without further ado, let's learn Hoon!
+
 
 ## Create and restart
 
-To create your fakezod, run:
+Assuming you've installed Urbit as per above, to create your
+comet, run:
 
 ```
-$ git clone https://github.com/urbit/arvo/
-$ urbit -FI ~zod -A arvo -c myship
+$ urbit -c mycomet
 ```
 
-This will take about 30 seconds and spin out a bunch of boot
-messages.  At the end, you'll see:
+This will take a few minutes and will spin out a bunch of boot
+messages (you are booting an operating system, after all!).
+
+At the end, you'll see something like:
 
 ```
-ames: on localhost, UDP 31337.
+ames: on localhost, UDP 58730.
 http: live (insecure, public) on 8080
 http: live ("secure", public) on 8443
 http: live (insecure, loopback) on 12321
-~zod:dojo>
+~palnul_nocser:dojo>
 ```
 
-To make sure everything is working, type `(add 2 2)` at the
-prompt, then hit return.  Your screen now shows:
+where `~palnul_nocser` is actually a shortened version of our
+full comet identity (comets are 128-bits, or 16 syllables!).
+Think of the `_` here as an ellipsis.
+
+But wait, we want to see our actual name! There's actually a
+simple command for that, which will also help us make sure that
+everything is working. We can type this command into our *Dojo*.
+
+On Urbit, the Dojo acts as both our Hoon REPL and our Arvo shell.
+
+Type `our` at the Dojo prompt, then hit Return.
+
+Your Dojo should have printed your full comet name, something
+like this:
 
 ```
-ames: on localhost, UDP 31337.
+ames: on localhost, UDP 58730.
 http: live (insecure, public) on 8080
 http: live ("secure", public) on 8443
 http: live (insecure, loopback) on 12321
-> (add 2 2)
-4
-~zod:dojo>
+> our
+~palnul-wolmev-bonfex-danred--tilwen-midlux-bolfus-nocser
+~palnul_nocser:dojo>
 ```
 
-That's super awesome!  You made your first noun!  We'll make a
-few more in a second.  First, quit Urbit with `ctrl-d`:
+That's a mouthful! We'll add a note towards the end on how you can
+ask for a "planet", a shorter identity like `~tonret-sigsur`, that
+you can keep forever.
 
-```
+Let's add some numbers!
+
+````
+ames: on localhost, UDP 58730.
+http: live (insecure, public) on 8080
+http: live ("secure", public) on 8443
+http: live (insecure, loopback) on 12321
+> our
+~palnul-wolmev-bonfex-danred--tilwen-midlux-bolfus-nocser
 > (add 2 2)
 4
-~zod:dojo>
+~palnul_nocser:dojo>
+````
+
+And because you're running Martian software now:
+
+````
+ames: on localhost, UDP 58730.
+http: live (insecure, public) on 8080
+http: live ("secure", public) on 8443
+http: live (insecure, loopback) on 12321
+> our
+~palnul-wolmev-bonfex-danred--tilwen-midlux-bolfus-nocser
+> (add 2 2)
+4
+> 'Hello Mars!'
+'Hello Mars!'
+~palnul_nocser:dojo>
+````
+
+
+Congratulations!  You made your first nouns!
+
+We'll make a few more in a second.  First, quit Urbit
+with `ctrl-d`:
+
+```
+> our
+~palnul-wolmev-bonfex-danred--tilwen-midlux-bolfus-nocser
+> (add 2 2)
+4
+> 'Hello Mars!'
+'Hello Mars!'
+~palnul_nocser:dojo>
 $
 ```
 
-You now have an Urbit image, or *pier*, in the `myship` directory.
+You now have an Urbit image, or *pier*, in the `mycomet` directory.
 Right now the only thing in your pier is Urbit's system files:
 
 ```
-$ ls -a myship
+$ ls -a /path/to/mycomet
 ./  ../ .urb/
 ```
 
-Restarting uses almost the same command, but without `-c` (which 
+Restarting uses almost the same command, but without `-c` (which
 means "create").  There are also fewer startup messages:
 
 ```
-$ urbit -FI ~zod myship
+$ urbit mycomet
 [...]
-ames: on localhost, UDP 31337.
+ames: on localhost, UDP 58730.
 http: live (insecure, public) on 8080
 http: live ("secure", public) on 8443
 http: live (insecure, loopback) on 12321
-~zod:dojo>
+~palnul_nocser:dojo>
 ```
+
+Not too scary, right?
 
 Note also that Urbit is an ACID database.  You can stop it
 politely with `ctrl-d`, abruptly with `ctrl-z`, even violently with `kill
 -9`.  None of these should cause Urbit to lose data.  If you do
-manage to corrupt a pier, it's a bug; please let us know.
+manage to corrupt a pier, it's a bug;
+please let us know.
 
 ## Let's make a noun
 
-We already made a noun.  Let's make another.  (We won't show the
-`~zod:dojo> ` prompt in future, just the echoed command.)
+You've already made three nouns.  Let's make another!
+
+*(We won't show the `~palnul_nocser:dojo> ` prompt from here on out.
+We'll just show the echoed command.*
+
+
+*So*
 
 ```
-~zod:dojo> 42
+~palnul_nocser:dojo> 42
 ```
 
-You'll see:
+*now becomes:*
 
 ```
 > 42
 42
 ~zod:dojo>
 ```
+
+*Awesome.)*
 
 ## Understanding nouns
 
@@ -189,7 +272,7 @@ Why not try it again to make sure?
 Can we add another zero?
 
 ```
-~zod:dojo> 420
+> 420
 ```
 
 Wat?  When you tried to type that next zero and turn `420` into
@@ -204,6 +287,7 @@ But the syntax is actually `4.200`:
 > (mul 42 100)
 4.200
 ```
+
 
 Just think of it as "4,200", written the German way with a dot.
 
@@ -260,7 +344,7 @@ Each number is an atom; each dot is a cell.
 And we're done!  Type `|exit` to exit:
 
 ```
-~zod:dojo> |exit
+~palnul_nocser:dojo> |exit
 %drum-exit
 $
 ```
@@ -275,3 +359,15 @@ The question today is: what is the right way to represent common
 data structures as nouns?  A linked list?  A string?  A *signed*
 integer?  A table or associative array?  Just try to picture
 these structures in your head, or draw them on a piece of paper.
+
+## Ask for a planet
+
+If you think Urbit is cool and want to jump on for the ride,
+first **subscribe to our mailing list**
+[on our homepage](http://urbit.org/) and
+[join us](http://urbit.org/docs/using/messaging/)
+in our `/urbit-meta` chatroom to talk and hang out!
+[We're also on Twitter](https://twitter.com/urbit_). Once on
+`/urbit-meta`, our devs will try and hook you up with a planet.
+
+##### Thanks for joining!

--- a/docs/byte/0.md
+++ b/docs/byte/0.md
@@ -92,7 +92,7 @@ http: live (insecure, loopback) on 12321
 ~palnul_nocser:dojo>
 ````
 
-That's super awesome!  You made your first nouns!  We'll make a
+That's super awesome!  You made your first noun!  We'll make a
 few more in a second.  First, quit Urbit with `ctrl-d`:
 
 ```
@@ -168,8 +168,6 @@ We'll just show the echoed command.*
 > 42
 42
 ```
-
-*Awesome.*
 
 ## Understanding nouns
 

--- a/docs/byte/0.md
+++ b/docs/byte/0.md
@@ -125,9 +125,9 @@ http: live (insecure, loopback) on 12321
 ~palnul_nocser:dojo>
 ```
 
-That's a mouthful! We'll add a note towards the end on how you can
-ask for a "planet", a shorter identity like `~tonret-sigsur`, that
-you can keep forever.
+That's a mouthful! You'll find a note towards the end of this Urbyte
+on how you can ask for a "planet", a shorter identity like `~tonret-sigsur`,
+that you can keep forever.
 
 Let's add some numbers!
 

--- a/docs/byte/0.md
+++ b/docs/byte/0.md
@@ -366,7 +366,7 @@ these structures in your head, or draw them on a piece of paper.
 ## Ask for a planet
 
 If you think Urbit is cool and want to jump on for the ride,
-first **subscribe to our mailing list_**
+first **subscribe to our mailing list**
 [on our homepage](http://urbit.org/) and
 [join us](http://urbit.org/docs/using/messaging/)
 in our `/urbit-meta` chatroom to talk and hang out!

--- a/docs/byte/1.md
+++ b/docs/byte/1.md
@@ -13,13 +13,13 @@ more deeply at atoms and other simple noun types.
 Let's restart our engines:
 
 ```
-$ urbit -FI ~zod myship
+$ urbit mycomet
 [...]
-ames: on localhost, UDP 31337.
+ames: on localhost, UDP 64351.
 http: live (insecure, public) on 8080
 http: live ("secure", public) on 8443
 http: live (insecure, loopback) on 12321
-~zod:dojo>
+~palnul_nocser:dojo>
 ```
 
 ## What's in an atom?
@@ -41,7 +41,7 @@ string starting with `@`, like `@ud` for unsigned decimal.
 Hoon has a wide (but not extensible) variety of atom syntaxes.
 Each syntax for an atom produces an appropriate predefined aura.
 And Hoon's printer can invertibly print any aura Hoon can parse.
-Because atoms make great path nodes and paths make great URLs, 
+Because atoms make great path nodes and paths make great URLs,
 all regular atom syntaxes use only URL-safe characters.
 
 ## Examples
@@ -164,7 +164,7 @@ course, `~` is URL-safe and `'` is not.
 ```
 > ? now
   @da
-~2016.7.11..01.32.04..2c0d
+~2017.2.6..23.04.16..6ded
 
 > ? ~h6
   @dr
@@ -176,10 +176,10 @@ course, `~` is URL-safe and `'` is not.
 
 > ? (add ~h6 now)
   @
-170.141.184.502.236.089.414.812.327.632.537.911.296
+170.141.184.502.572.218.057.853.493.278.891.048.960
 
 > `@da`(add ~h6 now)
-~2016.7.11..07.32.28..842f
+~2017.2.7..05.05.14..6d00
 
 > ? .3.14
   @rs
@@ -211,7 +211,7 @@ strings, which nothing in Hoon recognizes.  The set of syntaxes
 that Hoon knows how to parse and/or print is fixed.  But there
 are plenty of good reasons to use your own user-defined auras.
 
-If your program uses both fortnights and furlongs, Hoon will not 
+If your program uses both fortnights and furlongs, Hoon will not
 parse a user-defined fortnight syntax. It will not print furlongs
 in the dojo.  But the type system will keep you from accidentally
 passing a furlong to a function that expects a fortnight.
@@ -295,8 +295,14 @@ null, loobeans, and of course ships:
   @p
 ~zod
 
-> `@ux`~forseg-bolbyn
-0x885e.8af9
+> `@ud`~zod
+0
+
+> `@ud`~master-morzod
+1.742.733.824
+
+> `@ux`~master-morzod
+0x67e0.0200
 ```
 
 `%symbol` is a constant with aura `@tas` (text, ASCII, symbol).
@@ -337,7 +343,7 @@ all its atoms as decimals.
 And we're done!  Type `|exit` to exit:
 
 ```
-~zod:dojo> |exit
+~palnul_nocser:dojo> |exit
 %drum-exit
 $
 ```

--- a/docs/byte/1.md
+++ b/docs/byte/1.md
@@ -5,7 +5,7 @@ next: true
 title: Atoms, auras, types
 ---
 
-# Urbyte 1: atoms, auras, types
+# Urbyte 1: Atoms, auras, types
 
 Thanks for reading Urbyte 0!  In Urbyte 1, we'll look a little
 more deeply at atoms and other simple noun types.

--- a/docs/byte/2.md
+++ b/docs/byte/2.md
@@ -12,32 +12,33 @@ nouns for granted and have some real fun with them.
 Let's restart our engines:
 
 ```
-$ urbit -FI ~zod myship
+$ urbit mycomet
 [...]
-ames: on localhost, UDP 31337.
+ames: on localhost, UDP 63166.
 http: live (insecure, public) on 8080
 http: live ("secure", public) on 8443
 http: live (insecure, loopback) on 12321
-~zod:dojo>
+~palnul_nocser:dojo>
 ```
 
-## Welcome to the dojo
+## Welcome to the Dojo
 
-Wait, where are we?
+Wait, where are we again?
 
-We're playing in the Urbit `:dojo`.  The dojo is sort of like a
-cross between a Lisp REPL and the Unix shell.  (If you know the
-Unix shell, the Urbit command line has the same history model and
-Emacs editing commands.)
+As a reminder, this whole time we've been playing in the Urbit
+`:dojo`, which is both our Hoon REPL and our Arvo shell. If you know
+the Unix shell, the Urbit command line has the same history model and
+Emacs editing commands.
 
 The dojo has its own command language, which is a superset of
 Hoon.  Any Hoon expression is a command.  But not all commands
 are expressions.
 
 (The dojo is not the only command-line app on your Urbit.  By
-default there is one other, `:talk`.  Since you're on a fakezod,
-you can only talk to yourself.  If you accidentally press `ctrl-x`,
-it will put you into `:talk`; press `ctrl-x` again to switch back.)
+default there is one other, `:talk`. You may have found you've
+accidentally pressed `ctrl-x` and switched into it. Press `ctrl-x`
+again to switch back, or feel free to follow our `:talk`
+[quickstart](http://urbit.org/docs/using/messaging/#-quickstart) tutorial to join us all on our `/urbit-meta` chatroom!)
 
 ### Dojo variables
 
@@ -434,12 +435,13 @@ directly at the real dojo subject:
 [ [ [ a=[x=42 y=[p=%foo q=.6.28 r=~m45] x=0xdead.beef]
       b=<2.spy {x/@ud y/{p/$foo q/@rs r/@dr} x/@ux}>
     ]
-    our=~zod
-    now=~2016.7.18..08.05.15..0b5c
-    eny=0vl.hsfrh.tg642.g5o21.1n80b.0h141.0vuan.pm8o4.77ovg.96rk0.n26nn
+    our=~palnul-wolmev-bonfex-danred--tilwen-midlux-bolfus-nocser
+    now=~2017.2.6..23.10.43..21a0
+      eny
+    0vpm.on54j.k1hu2.b8f6k.h6gvi.ia2ln.ompb3.f2r87.vr0k8.65qme.h52aa.lgq0i.vpa4m.cgvho.60ruu.856qk.1llkq.cnn9j.u2nrg.46k01.7iodu
   ]
   ~
-  <283.xzp 42.ajz 407.xtr 110.xht 1.ztu $151>
+  <288.ama 42.mqo 409.gfq 110.xht 1.ztu $151>
 ]
 ```
 
@@ -447,8 +449,8 @@ We see a bunch of surfaces: our custom `a` and `b`; standard
 surfaces for identity, date, and entropy; and a ginormous core
 stack with *over eight hundred* total arms.
 
-To be exact, the syntax `<283.xzp 42.ajz 407.xtr 110.xht 1.ztu
-$151>` denotes a stack of six cores, each of whose payload is
+To be exact, the syntax `<288.ama 42.mqo 409.gfq 110.xht 1.ztu $151>`
+denotes a stack of six cores, each of whose payload is
 another core, until the innermost payload `%151` (the Hoon
 version number).  This stack is our standard library, from which
 comes `add` and other fine functions.  (We don't know how to
@@ -461,12 +463,13 @@ Let's clean up our subject, just to be hygienic:
 > =b
 
 > +1
-[ [ our=~zod
-    now=~2016.7.18..08.10.42..36a0
-    eny=0vf.8j71j.hlqim.k340u.q0ual.v2cd8.cfa65.vkbte.e733g.ehihg.e8aog
+[ [ our=~palnul-wolmev-bonfex-danred--tilwen-midlux-bolfus-nocser
+    now=~2017.2.6..23.12.30..441b
+      eny
+    0vvg.5g34t.41hv1.a7ge5.u5h5u.k3k7c.irocf.v0k5m.0i8ff.hr8ok.no5mu.llcu8.g7vta.nph7p.k0t92.unf4e.qnheu.b38gj.dmq0n.i0rvk.i5l59
   ]
   ~
-  <283.xzp 42.ajz 407.xtr 110.xht 1.ztu $151>
+  <288.ama 42.mqo 409.gfq 110.xht 1.ztu $151>
 ]
 ```
 
@@ -479,7 +482,7 @@ not a particularly interesting mystery.
 And we're done!  Type `|exit` to exit:
 
 ```
-~zod:dojo> |exit
+~palnul_nocser:dojo> |exit
 %drum-exit
 $
 ```

--- a/docs/byte/2.md
+++ b/docs/byte/2.md
@@ -4,7 +4,7 @@ sort: 3
 title: Subject-oriented programming
 ---
 
-# Urbyte 2: subject-oriented programming
+# Urbyte 2: Subject-oriented programming
 
 Thanks for reading Urbytes 0 and 1!  In Urbyte 2, we'll take
 nouns for granted and have some real fun with them.
@@ -20,25 +20,6 @@ http: live ("secure", public) on 8443
 http: live (insecure, loopback) on 12321
 ~palnul_nocser:dojo>
 ```
-
-## Welcome to the Dojo
-
-Wait, where are we again?
-
-As a reminder, this whole time we've been playing in the Urbit
-`:dojo`, which is both our Hoon REPL and our Arvo shell. If you know
-the Unix shell, the Urbit command line has the same history model and
-Emacs editing commands.
-
-The dojo has its own command language, which is a superset of
-Hoon.  Any Hoon expression is a command.  But not all commands
-are expressions.
-
-(The dojo is not the only command-line app on your Urbit.  By
-default there is one other, `:talk`. You may have found you've
-accidentally pressed `ctrl-x` and switched into it. Press `ctrl-x`
-again to switch back, or feel free to follow our `:talk`
-[quickstart](http://urbit.org/docs/using/messaging/#-quickstart) tutorial to join us all on our `/urbit-meta` chatroom!)
 
 ### Dojo variables
 

--- a/docs/nock/explanation.md
+++ b/docs/nock/explanation.md
@@ -32,8 +32,8 @@ For instance, it's common to represent strings (or even whole
 text files) as atoms, arranging them LSB first - so "foo" becomes
 `0x6f6f66`.  How do we know to print this as "foo", not `0x6f6f66`?
 We need external information - such as a Hoon type.  Similarly,
-other common atomic types - signed integers, floating point, etc
-- are all straightforward to map into atoms.
+other common atomic types - signed integers, floating point, etc - 
+are all straightforward to map into atoms.
 
 It's also important to note that, unlike Lisp, Nock cannot create
 cyclical data structures.  It is normal and common for nouns in a


### PR DESCRIPTION
Fake ~zods are kind of orthogonal to learning Hoon as a newbie, and having to checkout from Arvo master to the maintenance branch to get a working ship to boot is both cumbersome and confusing.

Switching the Urbytes instructions to boot comets makes setup as easy as `brew install urbit && urbit -c comet`. Plus, the devs coming to learn Hoon are people we want on comets hanging out in Talk in case they get stuck. So if they haven't joined already through the Quickstart, then it's just one `join ~star/urbit-meta` command away from getting in, not having to wait for another boot cycle. There's also a greater sense of identity in the comet model, as our current Talk underscore `~nocsur_soczod` notation is as memorable as planets outside of `our` and my-really-long-comet.urbit.org.
 
Really, the only downside is you lose that kind of badass feeling that you are coding as `~zod`, the ruler of the Urbit universe.

So either master needs to become stables and always remain that way (as I assume the Urbytes were written presuming a stable master), or this should probably be merged.

I updated Urbyte 0 to satisfy all of the above to give a flavor of what it might look like. If y'all think this is a good idea, I'll go ahead and update Urbytes 1 and 2 next and we can merge this.

I also tried to improve the onboarding to get people into Talk who could not be already and to subscribe to our mailing list (*hint*).

Also one small doc change I must have made a while ago but didn't PR.