### PR TITLE
Change Urbytes comet name to more generic ~sampel_sipnem.

### DIFF
--- a/docs/byte/0.md
+++ b/docs/byte/0.md
@@ -75,7 +75,7 @@ ames: on localhost, UDP 31337.
 http: live (insecure, public) on 8080
 http: live ("secure", public) on 8443
 http: live (insecure, loopback) on 12321
-~palnul_nocser:dojo>
+~sampel_sipnem:dojo>
 ```
 
 To make sure everything is working, type `(add 2 2)` at the
@@ -89,7 +89,7 @@ http: live (insecure, loopback) on 12321
 > (add 2 2)
 4
 ```
-~palnul_nocser:dojo>
+~sampel_sipnem:dojo>
 
 That's super awesome!  You made your first noun!  We'll make a
 few more in a second.  First, quit Urbit with `ctrl-d`:
@@ -97,7 +97,7 @@ few more in a second.  First, quit Urbit with `ctrl-d`:
 ```
 > (add 2 2)
 4
-~palnul_nocser:dojo>
+~sampel_sipnem:dojo>
 $
 ```
 
@@ -119,7 +119,7 @@ ames: on localhost, UDP 31337.
 http: live (insecure, public) on 8080
 http: live ("secure", public) on 8443
 http: live (insecure, loopback) on 12321
-~palnul_nocser:dojo>
+~sampel_sipnem:dojo>
 ```
 
 Note also that Urbit is an ACID database.  You can stop it
@@ -131,12 +131,12 @@ manage to corrupt a pier, it's a bug; please let us know.
 
 You've already made a noun.  Let's make another!
 
-*We won't show the `~palnul_nocser:dojo> ` prompt from here on out.
+*We won't show the `~sampel_sipnem:dojo> ` prompt from here on out.
 We'll just show the echoed command.*
 
 
 ```
-~palnul_nocser:dojo> 42
+~sampel_sipnem:dojo> 42
 42
 ```
 
@@ -264,7 +264,7 @@ Each number is an atom; each dot is a cell.
 And we're done!  Type `|exit` to exit:
 
 ```
-~palnul_nocser:dojo> |exit
+~sampel_sipnem:dojo> |exit
 %drum-exit
 $
 ```

--- a/docs/byte/1.md
+++ b/docs/byte/1.md
@@ -19,7 +19,7 @@ ames: on localhost, UDP 31337.
 http: live (insecure, public) on 8080
 http: live ("secure", public) on 8443
 http: live (insecure, loopback) on 12321
-~palnul_nocser:dojo>
+~sampel_sipnem:dojo>
 ```
 
 ## What's in an atom?
@@ -337,7 +337,7 @@ all its atoms as decimals.
 And we're done!  Type `|exit` to exit:
 
 ```
-~palnul_nocser:dojo> |exit
+~sampel_sipnem:dojo> |exit
 %drum-exit
 $
 ```

--- a/docs/byte/2.md
+++ b/docs/byte/2.md
@@ -18,7 +18,7 @@ ames: on localhost, UDP 31337.
 http: live (insecure, public) on 8080
 http: live ("secure", public) on 8443
 http: live (insecure, loopback) on 12321
-~palnul_nocser:dojo>
+~sampel_sipnem:dojo>
 ```
 
 ## Welcome to the dojo
@@ -479,7 +479,7 @@ not a particularly interesting mystery.
 And we're done!  Type `|exit` to exit:
 
 ```
-~palnul_nocser:dojo> |exit
+~sampel_sipnem:dojo> |exit
 %drum-exit
 $
 ```


### PR DESCRIPTION
Try to make the comet name in the Urbytes more general ("sample ship name"). Gave me a
laugh too (thanks Raymond).