### PR TITLE
added space to fix conjoined hyperlink on docs.md

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -43,7 +43,7 @@ etc, should start with the [Nock definition](nock/definition) and work upward fr
 <b>Community / contact</b>
 <ul>
 <li>We use <code>:talk</code> on Urbit to chat.</li>
-<li>Our <a href="http://urbit.org/fora/">discussion forum</a> on urbit.org</li>
+<li>Our <a href="http://urbit.org/fora/">discussion forum</a>  on urbit.org</li>
 <li><a href="https://reddit.com/r/urbit">/r/urbit on Reddit</a></li>
 <li><a href="https://twitter.com/urbit_">@urbit_ on Twitter</a></li>
 <li><a href="https://groups.google.com/forum/#!forum/urbit-dev">urbit-dev mailing list</a></li>


### PR DESCRIPTION
Fixed a weird hyperlinking bug on docs.md with respect to hyperlinking. I checked on both firefox and chrome and the bug was present. HTML showed it /shouldn't/ have been hyperlinking wrong and yet still was. Editing it via console by adding an extra space fixed it so I forked it and just added another space.

![screenshot from 2017-02-08 10-40-59](https://cloud.githubusercontent.com/assets/18218174/22747067/9075f132-edeb-11e6-9c5d-7a7d895083f0.png)
