### PR TITLE
Change navhome path to /doc/. Fixes #127.

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 1
 ---
 

--- a/docs/about/overview.md
+++ b/docs/about/overview.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 next: true
 sort: 1
 title: Technical overview

--- a/docs/about/runtime.md
+++ b/docs/about/runtime.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 2
 title: C runtime system
 ---

--- a/docs/arvo.md
+++ b/docs/arvo.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 4
 ---
 

--- a/docs/arvo/api.md
+++ b/docs/arvo/api.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 next: true
 sort: 12
 title: API Connectors

--- a/docs/arvo/basic.md
+++ b/docs/arvo/basic.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 1
 next: true
 title: Basic Hoon

--- a/docs/arvo/http.md
+++ b/docs/arvo/http.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 next: false
 sort: 9
 title: HTTP Requests and Timers

--- a/docs/arvo/internals.md
+++ b/docs/arvo/internals.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 15
 ---
 

--- a/docs/arvo/internals/ames.md
+++ b/docs/arvo/internals/ames.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 1
 ---
 

--- a/docs/arvo/internals/ames/commentary.md
+++ b/docs/arvo/internals/ames/commentary.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/arvo/internals/behn.md
+++ b/docs/arvo/internals/behn.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 2
 ---
 

--- a/docs/arvo/internals/clay.md
+++ b/docs/arvo/internals/clay.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 3
 ---
 

--- a/docs/arvo/internals/clay/architecture.md
+++ b/docs/arvo/internals/clay/architecture.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/arvo/internals/clay/commentary.md
+++ b/docs/arvo/internals/clay/commentary.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/arvo/internals/dill.md
+++ b/docs/arvo/internals/dill.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 4
 ---
 

--- a/docs/arvo/internals/eyre.md
+++ b/docs/arvo/internals/eyre.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 5
 ---
 

--- a/docs/arvo/internals/eyre/commentary.md
+++ b/docs/arvo/internals/eyre/commentary.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 Eyre: Reference

--- a/docs/arvo/internals/ford.md
+++ b/docs/arvo/internals/ford.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 6
 ---
 

--- a/docs/arvo/internals/ford/commentary.md
+++ b/docs/arvo/internals/ford/commentary.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/arvo/internals/gall.md
+++ b/docs/arvo/internals/gall.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 7
 ---
 

--- a/docs/arvo/marks.md
+++ b/docs/arvo/marks.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 next: true
 sort: 6
 title: Marks

--- a/docs/arvo/network.md
+++ b/docs/arvo/network.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 next: false
 sort: 3
 title: Network messages

--- a/docs/arvo/security-driver.md
+++ b/docs/arvo/security-driver.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 next: false
 sort: 10
 title: Security Drivers

--- a/docs/arvo/state.md
+++ b/docs/arvo/state.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 next: true
 sort: 4
 title: State

--- a/docs/arvo/subject.md
+++ b/docs/arvo/subject.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 2
 next: true
 title: The subject

--- a/docs/arvo/subscriptions.md
+++ b/docs/arvo/subscriptions.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 next: true
 sort: 5
 title: Subscriptions

--- a/docs/arvo/web-apps.md
+++ b/docs/arvo/web-apps.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 next: true
 sort: 7
 title: Web Apps

--- a/docs/byte.md
+++ b/docs/byte.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 3
 ---
 

--- a/docs/byte/0.md
+++ b/docs/byte/0.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 1
 next: true
 title: Setup and nouns

--- a/docs/byte/1.md
+++ b/docs/byte/1.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 2
 next: true
 title: Atoms, auras, types

--- a/docs/byte/2.md
+++ b/docs/byte/2.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 3
 title: Subject-oriented programming
 ---

--- a/docs/hoon.md
+++ b/docs/hoon.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 5
 ---
 

--- a/docs/hoon/advanced.md
+++ b/docs/hoon/advanced.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 7
 next: true
 title: Advanced types

--- a/docs/hoon/basic.md
+++ b/docs/hoon/basic.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 5
 next: true
 title: Basic types

--- a/docs/hoon/concepts.md
+++ b/docs/hoon/concepts.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 3
 next: true
 title: Concepts

--- a/docs/hoon/demo.md
+++ b/docs/hoon/demo.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 1
 next: true
 title: Demo

--- a/docs/hoon/examples.md
+++ b/docs/hoon/examples.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 8
 title: Examples
 next: true

--- a/docs/hoon/exercises.md
+++ b/docs/hoon/exercises.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 11
 ---
 

--- a/docs/hoon/exercises/data-structures.md
+++ b/docs/hoon/exercises/data-structures.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 4
 comments: true
 ---

--- a/docs/hoon/exercises/fizzbuzz.md
+++ b/docs/hoon/exercises/fizzbuzz.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 1
 comments: true
 ---

--- a/docs/hoon/exercises/life.md
+++ b/docs/hoon/exercises/life.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 5
 comments: true
 ---

--- a/docs/hoon/exercises/lists.md
+++ b/docs/hoon/exercises/lists.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 3
 comments: true
 ---

--- a/docs/hoon/exercises/math.md
+++ b/docs/hoon/exercises/math.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 2
 comments: true
 ---

--- a/docs/hoon/library.md
+++ b/docs/hoon/library.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 10
 title: Standard library
 ---

--- a/docs/hoon/library/1a.md
+++ b/docs/hoon/library/1a.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/1b.md
+++ b/docs/hoon/library/1b.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/1c.md
+++ b/docs/hoon/library/1c.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/2a.md
+++ b/docs/hoon/library/2a.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/2b.md
+++ b/docs/hoon/library/2b.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/2c.md
+++ b/docs/hoon/library/2c.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/2d.md
+++ b/docs/hoon/library/2d.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/2e.md
+++ b/docs/hoon/library/2e.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/2f.md
+++ b/docs/hoon/library/2f.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/2g.md
+++ b/docs/hoon/library/2g.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/2h.md
+++ b/docs/hoon/library/2h.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/2i.md
+++ b/docs/hoon/library/2i.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/2j.md
+++ b/docs/hoon/library/2j.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/2k.md
+++ b/docs/hoon/library/2k.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/2l.md
+++ b/docs/hoon/library/2l.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/2m.md
+++ b/docs/hoon/library/2m.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/2n.md
+++ b/docs/hoon/library/2n.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/2o.md
+++ b/docs/hoon/library/2o.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/2p.md
+++ b/docs/hoon/library/2p.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/2q.md
+++ b/docs/hoon/library/2q.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/3a.md
+++ b/docs/hoon/library/3a.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/3b.md
+++ b/docs/hoon/library/3b.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/3c.md
+++ b/docs/hoon/library/3c.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/3d.md
+++ b/docs/hoon/library/3d.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/3e.md
+++ b/docs/hoon/library/3e.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/3f.md
+++ b/docs/hoon/library/3f.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/3g.md
+++ b/docs/hoon/library/3g.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/4a.md
+++ b/docs/hoon/library/4a.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/4b.md
+++ b/docs/hoon/library/4b.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/4c.md
+++ b/docs/hoon/library/4c.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/4d.md
+++ b/docs/hoon/library/4d.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/4e.md
+++ b/docs/hoon/library/4e.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/4f.md
+++ b/docs/hoon/library/4f.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/4g.md
+++ b/docs/hoon/library/4g.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/4h.md
+++ b/docs/hoon/library/4h.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/4i.md
+++ b/docs/hoon/library/4i.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/4j.md
+++ b/docs/hoon/library/4j.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/4k.md
+++ b/docs/hoon/library/4k.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/4l.md
+++ b/docs/hoon/library/4l.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/4m.md
+++ b/docs/hoon/library/4m.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/4n.md
+++ b/docs/hoon/library/4n.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/4o.md
+++ b/docs/hoon/library/4o.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/5a.md
+++ b/docs/hoon/library/5a.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/5b.md
+++ b/docs/hoon/library/5b.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/5c.md
+++ b/docs/hoon/library/5c.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/5d.md
+++ b/docs/hoon/library/5d.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/5e.md
+++ b/docs/hoon/library/5e.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/5f.md
+++ b/docs/hoon/library/5f.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/5g.md
+++ b/docs/hoon/library/5g.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse.md
+++ b/docs/hoon/library/zuse.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 3
 ---
 

--- a/docs/hoon/library/zuse/core/crua.md
+++ b/docs/hoon/library/zuse/core/crua.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/core/epur.md
+++ b/docs/hoon/library/zuse/core/epur.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/core/fu.md
+++ b/docs/hoon/library/zuse/core/fu.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/core/jo.md
+++ b/docs/hoon/library/zuse/core/jo.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/core/poja.md
+++ b/docs/hoon/library/zuse/core/poja.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/core/poxa.md
+++ b/docs/hoon/library/zuse/core/poxa.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/core/poxo.md
+++ b/docs/hoon/library/zuse/core/poxo.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/core/yu.md
+++ b/docs/hoon/library/zuse/core/yu.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/diff.md
+++ b/docs/hoon/library/zuse/diff.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/clan.md
+++ b/docs/hoon/library/zuse/gate/clan.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/dawn.md
+++ b/docs/hoon/library/zuse/gate/dawn.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/daws.md
+++ b/docs/hoon/library/zuse/gate/daws.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/deal.md
+++ b/docs/hoon/library/zuse/gate/deal.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/deft.md
+++ b/docs/hoon/library/zuse/gate/deft.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/dust.md
+++ b/docs/hoon/library/zuse/gate/dust.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/earl.md
+++ b/docs/hoon/library/zuse/gate/earl.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/earn.md
+++ b/docs/hoon/library/zuse/gate/earn.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/fain.md
+++ b/docs/hoon/library/zuse/gate/fain.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/feel.md
+++ b/docs/hoon/library/zuse/gate/feel.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/file.md
+++ b/docs/hoon/library/zuse/gate/file.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/foal.md
+++ b/docs/hoon/library/zuse/gate/foal.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/fray.md
+++ b/docs/hoon/library/zuse/gate/fray.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/fuel.md
+++ b/docs/hoon/library/zuse/gate/fuel.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/furl.md
+++ b/docs/hoon/library/zuse/gate/furl.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/glam.md
+++ b/docs/hoon/library/zuse/gate/glam.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/glon.md
+++ b/docs/hoon/library/zuse/gate/glon.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/gnom.md
+++ b/docs/hoon/library/zuse/gate/gnom.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/jape.md
+++ b/docs/hoon/library/zuse/gate/jape.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/jesc.md
+++ b/docs/hoon/library/zuse/gate/jesc.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/joba.md
+++ b/docs/hoon/library/zuse/gate/joba.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/jobe.md
+++ b/docs/hoon/library/zuse/gate/jobe.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/jone.md
+++ b/docs/hoon/library/zuse/gate/jone.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/lead.md
+++ b/docs/hoon/library/zuse/gate/lead.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/mang.md
+++ b/docs/hoon/library/zuse/gate/mang.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/meat.md
+++ b/docs/hoon/library/zuse/gate/meat.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/moon.md
+++ b/docs/hoon/library/zuse/gate/moon.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/mung.md
+++ b/docs/hoon/library/zuse/gate/mung.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/perk.md
+++ b/docs/hoon/library/zuse/gate/perk.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/pojo.md
+++ b/docs/hoon/library/zuse/gate/pojo.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/saxo.md
+++ b/docs/hoon/library/zuse/gate/saxo.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/scanf.md
+++ b/docs/hoon/library/zuse/gate/scanf.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/sein.md
+++ b/docs/hoon/library/zuse/gate/sein.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/sifo.md
+++ b/docs/hoon/library/zuse/gate/sifo.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/stud.md
+++ b/docs/hoon/library/zuse/gate/stud.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/taco.md
+++ b/docs/hoon/library/zuse/gate/taco.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/tact.md
+++ b/docs/hoon/library/zuse/gate/tact.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/tame.md
+++ b/docs/hoon/library/zuse/gate/tame.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/tell.md
+++ b/docs/hoon/library/zuse/gate/tell.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/tome.md
+++ b/docs/hoon/library/zuse/gate/tome.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/tope.md
+++ b/docs/hoon/library/zuse/gate/tope.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/txml.md
+++ b/docs/hoon/library/zuse/gate/txml.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/unt.md
+++ b/docs/hoon/library/zuse/gate/unt.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/urld.md
+++ b/docs/hoon/library/zuse/gate/urld.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/gate/urle.md
+++ b/docs/hoon/library/zuse/gate/urle.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/mold/udal.md
+++ b/docs/hoon/library/zuse/mold/udal.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/mold/udon.md
+++ b/docs/hoon/library/zuse/mold/udon.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/mold/umph.md
+++ b/docs/hoon/library/zuse/mold/umph.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/mold/unce.md
+++ b/docs/hoon/library/zuse/mold/unce.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/mold/upas.md
+++ b/docs/hoon/library/zuse/mold/upas.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/mold/urge.md
+++ b/docs/hoon/library/zuse/mold/urge.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/library/zuse/rsa.md
+++ b/docs/hoon/library/zuse/rsa.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 ---
 
 

--- a/docs/hoon/mission.md
+++ b/docs/hoon/mission.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 2
 next: true
 title: Mission

--- a/docs/hoon/reference.md
+++ b/docs/hoon/reference.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 9
 title: Twig reference
 ---

--- a/docs/hoon/syntax.md
+++ b/docs/hoon/syntax.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 4
 next: true
 title: Syntax

--- a/docs/hoon/troubleshooting.md
+++ b/docs/hoon/troubleshooting.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 12
 title: Troubleshooting
 next: true

--- a/docs/hoon/twig.md
+++ b/docs/hoon/twig.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 6
 next: true
 title: Expressions

--- a/docs/hoon/twig/atom.md
+++ b/docs/hoon/twig/atom.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 1
 
 ---

--- a/docs/hoon/twig/atom/knit.md
+++ b/docs/hoon/twig/atom/knit.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 3
 
 ---

--- a/docs/hoon/twig/atom/path.md
+++ b/docs/hoon/twig/atom/path.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 4
 ---
 

--- a/docs/hoon/twig/atom/rock.md
+++ b/docs/hoon/twig/atom/rock.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 2
 
 ---

--- a/docs/hoon/twig/atom/sand.md
+++ b/docs/hoon/twig/atom/sand.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 1
 
 ---

--- a/docs/hoon/twig/bar-core.md
+++ b/docs/hoon/twig/bar-core.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 5
 
 ---

--- a/docs/hoon/twig/bar-core/cab-door.md
+++ b/docs/hoon/twig/bar-core/cab-door.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 5
 
 ---

--- a/docs/hoon/twig/bar-core/cen-core.md
+++ b/docs/hoon/twig/bar-core/cen-core.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 1
 
 ---

--- a/docs/hoon/twig/bar-core/dot-trap.md
+++ b/docs/hoon/twig/bar-core/dot-trap.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 3
 
 ---

--- a/docs/hoon/twig/bar-core/hep-loop.md
+++ b/docs/hoon/twig/bar-core/hep-loop.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 4
 
 ---

--- a/docs/hoon/twig/bar-core/tar-gill.md
+++ b/docs/hoon/twig/bar-core/tar-gill.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 6
 ---
 

--- a/docs/hoon/twig/bar-core/tis-gate.md
+++ b/docs/hoon/twig/bar-core/tis-gate.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 2
 
 ---

--- a/docs/hoon/twig/buc-mold.md
+++ b/docs/hoon/twig/buc-mold.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 7
 
 ---

--- a/docs/hoon/twig/buc-mold/base.md
+++ b/docs/hoon/twig/buc-mold/base.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 1
 
 ---

--- a/docs/hoon/twig/buc-mold/cab-shoe.md
+++ b/docs/hoon/twig/buc-mold/cab-shoe.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 9
 ---
 

--- a/docs/hoon/twig/buc-mold/cen-book.md
+++ b/docs/hoon/twig/buc-mold/cen-book.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 4
 
 ---

--- a/docs/hoon/twig/buc-mold/col-bank.md
+++ b/docs/hoon/twig/buc-mold/col-bank.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 2
 
 ---

--- a/docs/hoon/twig/buc-mold/hep-lamb.md
+++ b/docs/hoon/twig/buc-mold/hep-lamb.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 8
 
 ---

--- a/docs/hoon/twig/buc-mold/ket-bush.md
+++ b/docs/hoon/twig/buc-mold/ket-bush.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 6
 
 ---

--- a/docs/hoon/twig/buc-mold/pat-claw.md
+++ b/docs/hoon/twig/buc-mold/pat-claw.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 5
 
 ---

--- a/docs/hoon/twig/buc-mold/tis-coat.md
+++ b/docs/hoon/twig/buc-mold/tis-coat.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 3
 
 ---

--- a/docs/hoon/twig/buc-mold/wut-pick.md
+++ b/docs/hoon/twig/buc-mold/wut-pick.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 7
 
 ---

--- a/docs/hoon/twig/cen-call.md
+++ b/docs/hoon/twig/cen-call.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 6
 
 ---

--- a/docs/hoon/twig/cen-call/cab-keep.md
+++ b/docs/hoon/twig/cen-call/cab-keep.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 2
 
 ---

--- a/docs/hoon/twig/cen-call/dot-lace.md
+++ b/docs/hoon/twig/cen-call/dot-lace.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 5
 ---
 

--- a/docs/hoon/twig/cen-call/hep-call.md
+++ b/docs/hoon/twig/cen-call/hep-call.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 4
 ---
 

--- a/docs/hoon/twig/cen-call/ket-calq.md
+++ b/docs/hoon/twig/cen-call/ket-calq.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 7
 ---
 

--- a/docs/hoon/twig/cen-call/lus-calt.md
+++ b/docs/hoon/twig/cen-call/lus-calt.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 6
 ---
 

--- a/docs/hoon/twig/cen-call/sig-open.md
+++ b/docs/hoon/twig/cen-call/sig-open.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 3
 ---
 

--- a/docs/hoon/twig/cen-call/tis-make.md
+++ b/docs/hoon/twig/cen-call/tis-make.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 1
 ---
 

--- a/docs/hoon/twig/col-cell.md
+++ b/docs/hoon/twig/col-cell.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 3
 
 ---

--- a/docs/hoon/twig/col-cell/cab-scon.md
+++ b/docs/hoon/twig/col-cell/cab-scon.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 6
 ---
 

--- a/docs/hoon/twig/col-cell/hep-cons.md
+++ b/docs/hoon/twig/col-cell/hep-cons.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 1
 ---
 

--- a/docs/hoon/twig/col-cell/ket-conq.md
+++ b/docs/hoon/twig/col-cell/ket-conq.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 3
 ---
 

--- a/docs/hoon/twig/col-cell/lus-cont.md
+++ b/docs/hoon/twig/col-cell/lus-cont.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 2
 ---
 

--- a/docs/hoon/twig/col-cell/sig-conl.md
+++ b/docs/hoon/twig/col-cell/sig-conl.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 5
 ---
 

--- a/docs/hoon/twig/col-cell/tar-conp.md
+++ b/docs/hoon/twig/col-cell/tar-conp.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 4
 ---
 

--- a/docs/hoon/twig/dot-nock.md
+++ b/docs/hoon/twig/dot-nock.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 10
 
 ---

--- a/docs/hoon/twig/dot-nock/ket-wish.md
+++ b/docs/hoon/twig/dot-nock/ket-wish.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 5
 ---
 

--- a/docs/hoon/twig/dot-nock/lus-bump.md
+++ b/docs/hoon/twig/dot-nock/lus-bump.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 3
 ---
 

--- a/docs/hoon/twig/dot-nock/tar-nock.md
+++ b/docs/hoon/twig/dot-nock/tar-nock.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 1
 ---
 

--- a/docs/hoon/twig/dot-nock/tis-same.md
+++ b/docs/hoon/twig/dot-nock/tis-same.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 4
 ---
 

--- a/docs/hoon/twig/dot-nock/wut-deep.md
+++ b/docs/hoon/twig/dot-nock/wut-deep.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 2 
 ---
 

--- a/docs/hoon/twig/ket-cast.md
+++ b/docs/hoon/twig/ket-cast.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 9
 
 ---

--- a/docs/hoon/twig/ket-cast/bar-iron.md
+++ b/docs/hoon/twig/ket-cast/bar-iron.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 5
 ---
 

--- a/docs/hoon/twig/ket-cast/hep-cast.md
+++ b/docs/hoon/twig/ket-cast/hep-cast.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 2
 ---
 

--- a/docs/hoon/twig/ket-cast/lus-like.md
+++ b/docs/hoon/twig/ket-cast/lus-like.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 1
 ---
 

--- a/docs/hoon/twig/ket-cast/sig-burn.md
+++ b/docs/hoon/twig/ket-cast/sig-burn.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 6
 ---
 

--- a/docs/hoon/twig/ket-cast/tis-name.md
+++ b/docs/hoon/twig/ket-cast/tis-name.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 3
 ---
 

--- a/docs/hoon/twig/ket-cast/wut-lead.md
+++ b/docs/hoon/twig/ket-cast/wut-lead.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 4
 ---
 

--- a/docs/hoon/twig/limb.md
+++ b/docs/hoon/twig/limb.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 2
 ---
 

--- a/docs/hoon/twig/limb/limb.md
+++ b/docs/hoon/twig/limb/limb.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 1
 
 ---

--- a/docs/hoon/twig/limb/wing.md
+++ b/docs/hoon/twig/limb/wing.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 2
 ---
 

--- a/docs/hoon/twig/sem-make.md
+++ b/docs/hoon/twig/sem-make.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 11
 
 ---

--- a/docs/hoon/twig/sem-make/col-wad.md
+++ b/docs/hoon/twig/sem-make/col-wad.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 3
 ---
 

--- a/docs/hoon/twig/sem-make/fas-nub.md
+++ b/docs/hoon/twig/sem-make/fas-nub.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 4
 ---
 

--- a/docs/hoon/twig/sem-make/sem-fry.md
+++ b/docs/hoon/twig/sem-make/sem-fry.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 1
 ---
 

--- a/docs/hoon/twig/sem-make/sig-dip.md
+++ b/docs/hoon/twig/sem-make/sig-dip.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 2
 ---
 

--- a/docs/hoon/twig/sig-hint.md
+++ b/docs/hoon/twig/sig-hint.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 12
 
 ---

--- a/docs/hoon/twig/sig-hint/bar-show.md
+++ b/docs/hoon/twig/sig-hint/bar-show.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 2
 ---
 

--- a/docs/hoon/twig/sig-hint/buc-poll.md
+++ b/docs/hoon/twig/sig-hint/buc-poll.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 12
 ---
 

--- a/docs/hoon/twig/sig-hint/cab-lurk.md
+++ b/docs/hoon/twig/sig-hint/cab-lurk.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 3
 ---
 

--- a/docs/hoon/twig/sig-hint/cen-fast.md
+++ b/docs/hoon/twig/sig-hint/cen-fast.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 10
 ---
 

--- a/docs/hoon/twig/sig-hint/fas-funk.md
+++ b/docs/hoon/twig/sig-hint/fas-funk.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 11
 ---
 

--- a/docs/hoon/twig/sig-hint/gal-thin.md
+++ b/docs/hoon/twig/sig-hint/gal-thin.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 6
 ---
 

--- a/docs/hoon/twig/sig-hint/gar-hint.md
+++ b/docs/hoon/twig/sig-hint/gar-hint.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 5
 ---
 

--- a/docs/hoon/twig/sig-hint/lus-memo.md
+++ b/docs/hoon/twig/sig-hint/lus-memo.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 7
 ---
 

--- a/docs/hoon/twig/sig-hint/pam-dump.md
+++ b/docs/hoon/twig/sig-hint/pam-dump.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 1
 ---
 

--- a/docs/hoon/twig/sig-hint/tis-ddup.md
+++ b/docs/hoon/twig/sig-hint/tis-ddup.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 8
 ---
 

--- a/docs/hoon/twig/sig-hint/wut-warn.md
+++ b/docs/hoon/twig/sig-hint/wut-warn.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 4
 ---
 

--- a/docs/hoon/twig/sig-hint/zap-peep.md
+++ b/docs/hoon/twig/sig-hint/zap-peep.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 9
 ---
 

--- a/docs/hoon/twig/tis-flow.md
+++ b/docs/hoon/twig/tis-flow.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 4
 
 ---

--- a/docs/hoon/twig/tis-flow/bar-new.md
+++ b/docs/hoon/twig/tis-flow/bar-new.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 5
 ---
 

--- a/docs/hoon/twig/tis-flow/col-fix.md
+++ b/docs/hoon/twig/tis-flow/col-fix.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 9
 ---
 

--- a/docs/hoon/twig/tis-flow/dot-set.md
+++ b/docs/hoon/twig/tis-flow/dot-set.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 8
 ---
 

--- a/docs/hoon/twig/tis-flow/fas-var.md
+++ b/docs/hoon/twig/tis-flow/fas-var.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 6
 ---
 

--- a/docs/hoon/twig/tis-flow/gal-rap.md
+++ b/docs/hoon/twig/tis-flow/gal-rap.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 2
 ---
 

--- a/docs/hoon/twig/tis-flow/gar-per.md
+++ b/docs/hoon/twig/tis-flow/gar-per.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 1
 ---
 

--- a/docs/hoon/twig/tis-flow/hep-nip.md
+++ b/docs/hoon/twig/tis-flow/hep-nip.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 4
 ---
 

--- a/docs/hoon/twig/tis-flow/ket-sip.md
+++ b/docs/hoon/twig/tis-flow/ket-sip.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 10
 ---
 

--- a/docs/hoon/twig/tis-flow/lus-pin.md
+++ b/docs/hoon/twig/tis-flow/lus-pin.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 3
 ---
 

--- a/docs/hoon/twig/tis-flow/sem-rev.md
+++ b/docs/hoon/twig/tis-flow/sem-rev.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 7
 ---
 

--- a/docs/hoon/twig/tis-flow/sig-tow.md
+++ b/docs/hoon/twig/tis-flow/sig-tow.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 12
 ---
 

--- a/docs/hoon/twig/tis-flow/tar-aka.md
+++ b/docs/hoon/twig/tis-flow/tar-aka.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 11
 ---
 

--- a/docs/hoon/twig/wut-test.md
+++ b/docs/hoon/twig/wut-test.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 8
 ---
 

--- a/docs/hoon/twig/wut-test/bar-or.md
+++ b/docs/hoon/twig/wut-test/bar-or.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 9
 ---
 

--- a/docs/hoon/twig/wut-test/col-if.md
+++ b/docs/hoon/twig/wut-test/col-if.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 1
 ---
 

--- a/docs/hoon/twig/wut-test/dot-lest.md
+++ b/docs/hoon/twig/wut-test/dot-lest.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 2
 ---
 

--- a/docs/hoon/twig/wut-test/gal-deny.md
+++ b/docs/hoon/twig/wut-test/gal-deny.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 10
 ---
 

--- a/docs/hoon/twig/wut-test/gar-sure.md
+++ b/docs/hoon/twig/wut-test/gar-sure.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 11
 ---
 

--- a/docs/hoon/twig/wut-test/hep-case.md
+++ b/docs/hoon/twig/wut-test/hep-case.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 12
 ---
 

--- a/docs/hoon/twig/wut-test/ket-ifcl.md
+++ b/docs/hoon/twig/wut-test/ket-ifcl.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 5
 ---
 

--- a/docs/hoon/twig/wut-test/lus-deft.md
+++ b/docs/hoon/twig/wut-test/lus-deft.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 13
 ---
 

--- a/docs/hoon/twig/wut-test/pam-and.md
+++ b/docs/hoon/twig/wut-test/pam-and.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 8
 ---
 

--- a/docs/hoon/twig/wut-test/pat-ifat.md
+++ b/docs/hoon/twig/wut-test/pat-ifat.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 4
 ---
 

--- a/docs/hoon/twig/wut-test/sig-ifno.md
+++ b/docs/hoon/twig/wut-test/sig-ifno.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 3
 ---
 

--- a/docs/hoon/twig/wut-test/tis-fits.md
+++ b/docs/hoon/twig/wut-test/tis-fits.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 6
 ---
 

--- a/docs/hoon/twig/wut-test/zap-not.md
+++ b/docs/hoon/twig/wut-test/zap-not.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 7
 ---
 

--- a/docs/hoon/twig/zap-wild.md
+++ b/docs/hoon/twig/zap-wild.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 13
 
 ---

--- a/docs/hoon/twig/zap-wild/gar-wrap.md
+++ b/docs/hoon/twig/zap-wild/gar-wrap.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 2
 ---
 

--- a/docs/hoon/twig/zap-wild/tis-code.md
+++ b/docs/hoon/twig/zap-wild/tis-code.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 3
 ---
 

--- a/docs/hoon/twig/zap-wild/wut-need.md
+++ b/docs/hoon/twig/zap-wild/wut-need.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 4
 ---
 

--- a/docs/hoon/twig/zap-wild/zap-fail.md
+++ b/docs/hoon/twig/zap-wild/zap-fail.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 1
 ---
 

--- a/docs/nock.md
+++ b/docs/nock.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 6
 title: Nock
 ---

--- a/docs/nock/definition.md
+++ b/docs/nock/definition.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 1
 next: true
 title: Definition

--- a/docs/nock/example.md
+++ b/docs/nock/example.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 3
 next: true
 title: Example

--- a/docs/nock/explanation.md
+++ b/docs/nock/explanation.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 2
 next: true
 title: Explanation

--- a/docs/nock/implementations.md
+++ b/docs/nock/implementations.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 4
 title: Implementations
 ---

--- a/docs/nock/implementations/c.md
+++ b/docs/nock/implementations/c.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 title: C
 sort: 6
 next: true

--- a/docs/nock/implementations/clojure.md
+++ b/docs/nock/implementations/clojure.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 title: Clojure
 sort: 5
 next: true

--- a/docs/nock/implementations/csharp.md
+++ b/docs/nock/implementations/csharp.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 title: C#
 sort: 12
 next: true

--- a/docs/nock/implementations/groovy.md
+++ b/docs/nock/implementations/groovy.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 title: Groovy
 sort: 7
 next: true

--- a/docs/nock/implementations/haskell.md
+++ b/docs/nock/implementations/haskell.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 title: Haskell
 sort: 3
 next: true

--- a/docs/nock/implementations/hoon.md
+++ b/docs/nock/implementations/hoon.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 title: Hoon
 sort: 11
 ---

--- a/docs/nock/implementations/javascript.md
+++ b/docs/nock/implementations/javascript.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 title: Javascript
 sort: 9
 next: true

--- a/docs/nock/implementations/python.md
+++ b/docs/nock/implementations/python.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 title: Python
 sort: 1
 next: true

--- a/docs/nock/implementations/ruby.md
+++ b/docs/nock/implementations/ruby.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 title: Ruby
 sort: 2
 next: true

--- a/docs/nock/implementations/scala.md
+++ b/docs/nock/implementations/scala.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 title: Scala
 sort: 4
 next: true

--- a/docs/nock/implementations/scheme.md
+++ b/docs/nock/implementations/scheme.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 title: Scheme
 sort: 8
 next: true

--- a/docs/nock/implementations/swift.md
+++ b/docs/nock/implementations/swift.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 title: Swift
 sort: 10
 next: true

--- a/docs/using.md
+++ b/docs/using.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 2
 ---
 

--- a/docs/using/admin.md
+++ b/docs/using/admin.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 next: true
 sort: 3
 title: Basic operation

--- a/docs/using/install.md
+++ b/docs/using/install.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 next: true
 sort: 1
 title: Install

--- a/docs/using/layout.md
+++ b/docs/using/layout.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 9
 title: Source layout
 ---

--- a/docs/using/urb.md
+++ b/docs/using/urb.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 8
 title: From Unix
 ---

--- a/docs/using/web.md
+++ b/docs/using/web.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 next: true
 sort: 7
 title: Web

--- a/docs/using/web/blog.md
+++ b/docs/using/web/blog.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 1
 title: A simple blog
 next: true

--- a/docs/using/web/comments.md
+++ b/docs/using/web/comments.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 2
 title: Blog comments
 next: true

--- a/docs/using/web/static.md
+++ b/docs/using/web/static.md
@@ -1,5 +1,5 @@
 ---
-navhome: /docs
+navhome: /docs/
 sort: 3
 title: A static site
 ---


### PR DESCRIPTION
Fixes a bug in our YAML where navigating home via our tilde icon in the top left corner of the docs wouldn’t put a `/` after urbit.org/docs. So clicking on a link like ‘Hoon syntax’ would direct to urbit.org/hoon/syntax not urbit.org/docs/hoon/syntax, causing an `Error: empty path`.