### PR TITLE
Remove `bin/` from docs/using commands.

### DIFF
--- a/docs/using/admin.md
+++ b/docs/using/admin.md
@@ -10,7 +10,7 @@ title: Basic operation
 <div class="row">
 <div class="col-md-8">
 
-Your Urbit is a persistent Unix process that you mainly control from the console.  For some things, a browser will also work. 
+Your Urbit is a persistent Unix process that you mainly control from the console.  For some things, a browser will also work.
 
 </div>
 </div>
@@ -23,18 +23,18 @@ You can turn your Urbit off with `ctrl-d` from the `:talk` or `:dojo` prompts.
 
 To restart your Urbit simply pass the name of your pier:
 
-    $ bin/urbit some-planet
+    $ urbit some-planet
 
 or
 
-    $ bin/urbit comet
+    $ urbit comet
 
 
 ## Logging
 
 To log Urbit's command line output to a file, use `script`:
 
-    $ script urbit.log bin/urbit your-urbit
+    $ script urbit.log urbit your-urbit
 
 ## Console
 

--- a/docs/using/install.md
+++ b/docs/using/install.md
@@ -101,6 +101,14 @@ After running `make`, your Urbit executable is in `bin/urbit`. Install it wherev
 
     # sudo install -m 0755 bin/urbit /usr/local/bin
 
+Test that it works:
+
+    $ urbit
+    simple usage:
+       urbit -c <mycomet> to create a comet (anonymous urbit)
+       urbit -w <myplanet> -t <myticket> if you have a ticket
+       urbit <myplanet or mycomet> to restart an existing urbit
+
 ## Setting up swap
 
 Urbit wants to map 2GB of memory when it boots up.  We won’t

--- a/docs/using/setup.md
+++ b/docs/using/setup.md
@@ -24,7 +24,7 @@ If you have an Urbit invitation, you'll have a planet like
 `~fintud-macrep` and `~fortyv-tombyt-tabsen-sonres`. To create your
 pier:
 
-    $ bin/urbit -w fintud-macrep -t fortyv-tombyt-tabsen-sonres
+    $ urbit -w fintud-macrep -t fortyv-tombyt-tabsen-sonres
 
 This will create a directory `fintud-macrep/` and begin building your
 urbit. This may take a few minutes.
@@ -33,7 +33,7 @@ If you do not have a ticket, you can still make a 'comet', a wild urbit
 drifting through cyberspace. Pick your own directory name, it doesn't
 matter:
 
-    $ bin/urbit -c mycomet
+    $ urbit -c mycomet
 
 This will create the directory `mycomet/` and generate a 128-bit
 identity for your urbit.


### PR DESCRIPTION
Most of our users are either likely simply getting their Urbit binary via 
`brew install`, or are following our docs/using/install step when building
from source to install the binary to usr/local/bin. Thus, the `bin/`
prefix to the Urbit admin commands in our current docs is kind of
unneeded and worse might cause confusion if the command doens't work 
the first time.

In this PR I added a note after our docs/using/install building-from-source 
blip to test that the `$ urbit` command works after installing to the user's path.