### PR TITLE
Add community docs to side panel.

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -43,6 +43,14 @@ etc, should start with the [Nock definition](nock/definition) and work upward fr
 
 <br />
 
+<b>Community docs</b>
+<ul>
+<li>The <code>~master-morzod</code><a href="http://micnus-tarwyl-haltem-linhut--dilhul-talbes-wolnyx-lasbud.urbit.org/docs/">docs</a>, and <a href="http://urbit.org/fora/posts/~2016.12.25..06.35.44..a1ec~/"><code>fora</code></a> post.</li>
+<li><a href="https://github.com/Fang-/Urbit-By-Doing">Urbit by Doing</a>, by <code>~palfun-foslup</code>.</li>
+</ul>
+
+<br />
+
 <b>Source code on <a href="https://github.com/urbit">GitHub</a></b>
 <ul>
 <li><a href="https://github.com/urbit/urbit"><code>vere</code></a> - Urbit's VM.</li>


### PR DESCRIPTION
Looks like this:
![screenshot 2017-02-10 09 58 50](https://cloud.githubusercontent.com/assets/13459143/22837938/983d4734-ef77-11e6-99c7-b3dc54c03a5c.png)

Something that will definitely help make the learning process easier in
the meantime as we work on the larger doc reorganization. Added to the
current side panel. This arguably makes things a little long / crowded.
But I think the benefit > the cost as we try and figure out how to
create a better layout (like a Wiki layout of sorts, as we've
discussed).

The two community docs that come to mind are Joe's and Fang's. Are there
any more?

I think in the meantime I also need to revamp our short "readme" there to fill the white space. Can I give that a shot?