### PR TITLE
Arvo docs section `# Quickstart` to `# Arvo`.

### DIFF
--- a/docs/arvo.md
+++ b/docs/arvo.md
@@ -3,7 +3,7 @@ navhome: /docs/
 sort: 4
 ---
 
-# Quickstart
+# Arvo
 
 Fast, pragmatic tutorials which show you how to build simple programs in Hoon and Arvo.
 


### PR DESCRIPTION
Screenshot:
![screenshot 2017-02-10 11 49 32](https://cloud.githubusercontent.com/assets/13459143/22841618/21a34f1e-ef87-11e6-8744-3ada2a01d0e4.png)

I get that the idea originally here was for this section to be the "get
your hands dirty with Hoon fast" section. But for newcomers, I'd be
shocked if some people didn't confuse this with the place to start
overall. I.e., it doesn't make sense for this to be the Quickstart
section if `Install` is in a different section. Just `# Arvo` is fine.
It also makes the bottom grid row look prettier, as it's then the
progression: Arvo Hoon Nock. Plus, for learning Hoon, we likely want to
direct people to the Urbytes now, as many of us relay in Talk.

The url's are also docs/arvo so this just makes sense.