### PR TITLE
Push to www-ship.

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -12,7 +12,7 @@ sort: 4
 
 <div class="col-md-12 head">
 
-<div class="col-md-8">
+<div class="col-md-10">
 
 **Urbit** is a secure peer-to-peer network of personal servers, built on a clean-slate system software stack.
 

--- a/docs/byte.md
+++ b/docs/byte.md
@@ -1,0 +1,10 @@
+---
+navhome: /docs/
+sort: 2
+---
+
+# Learn
+
+Learn Hoon in short, self-contained, bottom-up tutorials through our in-house Urbyte series. A work in progress. Still ideal for the complete newbie.
+
+<list/>

--- a/docs/byte/0.md
+++ b/docs/byte/0.md
@@ -1,0 +1,281 @@
+---
+navhome: /docs/
+sort: 1
+next: true
+title: Setup and nouns
+---
+
+# Urbyte 0: Setup and nouns
+
+This is the first post in our new Urbyte series.
+
+The Urbyte concept is that you, an ordinary programmer, not a
+kernel hacker or a Haskell magician (not that there's anything
+wrong with kernel hackers or Haskell magicians) can learn Hoon,
+Urbit's programming language.
+
+We're going to test this daring idea by teaching you Hoon, in
+easily digestible, byte-size chunks.  Each post in the "Urbytes"
+series is designed to take about 15 minutes to consume.  (Maybe
+10, if you're a kernel hacker or a Haskell magician.)
+
+We'll assume no knowledge of Urbit except for previous lessons.
+Ideally you have some basic familiarity with programming and can
+operate the Unix command line.
+
+We strongly encourage you to type in all the examples in each
+Urbyte.  Urbytes are short, but not meant to be skimmed.
+
+## Install
+
+First, [install Urbit](http://urbit.org/docs/using/install/) on any
+Mac or Unix machine.  On Windows, make a virtual Linux machine
+using VirtualBox or a similar tool.
+
+While you're downloading, read about Urbit ships:
+
+## Ships
+
+In the Urbyte exercises you'll be running what we call a "comet". A string starting with `~`, like `~zod`, is what Urbit
+calls a *ship*.
+
+A *ship* is one number which means four things: a network address,
+a cryptographic identity, a memorable name, and a single virtual
+computer.
+
+We write this number in a base-256 format, where each digit is a
+syllable.  Imagine if your phone number was a pronounceable
+string which sounded like a name in a foreign language. `~zod`
+is ship zero (making it a very important ship indeed!). An ordinary
+user-level ship is a "planet", a 32-bit number which becomes
+a four-syllable string, like `~talsur-todres`.
+
+*Comets*, at 128-bits or 16 syllables, are
+disposable identities that anyone can make for free to
+join the live network. Thus, comets make the ideal ship for
+playing around with Hoon, asking for help from other Urbit devs in [`:talk`](http://urbit.org/docs/using/messaging/) if you
+need it, and showing off Urbit to your hacker friends.
+
+## Create and restart
+
+To create your comet, run:
+
+```
+$ cd ~
+$ mkdir urbit
+$ cd urbit
+$ urbit -c mycomet
+```
+
+This will take a few minutes and will spin out a bunch of boot
+messages. At the end, you'll see something like:
+
+```
+ames: on localhost, UDP 31337.
+http: live (insecure, public) on 8080
+http: live ("secure", public) on 8443
+http: live (insecure, loopback) on 12321
+~palnul_nocser:dojo>
+```
+
+To make sure everything is working, type `(add 2 2)` at the
+prompt, then hit return.  Your screen now shows:
+
+```
+ames: on localhost, UDP 31337.
+http: live (insecure, public) on 8080
+http: live ("secure", public) on 8443
+http: live (insecure, loopback) on 12321
+> (add 2 2)
+4
+```
+~palnul_nocser:dojo>
+
+That's super awesome!  You made your first noun!  We'll make a
+few more in a second.  First, quit Urbit with `ctrl-d`:
+
+```
+> (add 2 2)
+4
+~palnul_nocser:dojo>
+$
+```
+
+You now have an Urbit image, or *pier*, in the `mycomet` directory.
+Right now the only thing in your pier is Urbit's system files:
+
+```
+$ ls -a /path/to/mycomet
+./  ../ .urb/
+```
+
+Restarting uses almost the same command, but without `-c` (which
+means "create").  There are also fewer startup messages:
+
+```
+$ urbit mycomet
+[...]
+ames: on localhost, UDP 31337.
+http: live (insecure, public) on 8080
+http: live ("secure", public) on 8443
+http: live (insecure, loopback) on 12321
+~palnul_nocser:dojo>
+```
+
+Note also that Urbit is an ACID database.  You can stop it
+politely with `ctrl-d`, abruptly with `ctrl-z`, even violently with `kill
+-9`.  None of these should cause Urbit to lose data.  If you do
+manage to corrupt a pier, it's a bug; please let us know.
+
+## Let's make a noun
+
+You've already made a noun.  Let's make another!
+
+*We won't show the `~palnul_nocser:dojo> ` prompt from here on out.
+We'll just show the echoed command.*
+
+
+```
+~palnul_nocser:dojo> 42
+42
+```
+
+You'll see:
+
+```
+> 42
+42
+```
+
+## Understanding nouns
+
+A value in Urbit is called a *noun*.  A noun is either an *atom*
+(an unsigned integer of any size) or a *cell* (an ordered pair of
+any two nouns).
+
+In a sentence, a noun is a binary tree whose leaves are numbers.
+If you know Lisp, a noun is a minimalist S-expression.  A noun
+can't have cycles (pointer loops).  An implementation can use
+dags (shared subtrees), but the programmer can't detect them
+(there's no pointer equality test).
+
+The absence of graph cycles makes nouns much easier to save in
+persistent storage, send over the network, manage memory for
+(Urbit has no tracing garbage collector), etc.
+
+## Let's make some atoms
+
+So one kind of atom is a number.  And the syntax (or at least one
+syntax) for a number is a decimal, like `42`.  Seems legit.
+
+But just to be sure we understand this decimal thing, let's make
+some atoms:
+
+```
+> 4
+4
+```
+
+Seems pretty straightforward.
+
+```
+> 42
+42
+```
+
+Why not try it again to make sure?
+
+```
+> 420
+420
+```
+
+Can we add another zero?
+
+```
+> 420
+```
+
+Wat?  When you tried to type that next zero and turn `420` into
+`4200`, Urbit actually *deleted the `0` and beeped at you.*
+
+But isn't an atom an unsigned integer of any size?  It is.
+But the syntax is actually `4.200`:
+
+```
+> 4.200
+4.200
+> (mul 42 100)
+4.200
+```
+
+Just think of it as "4,200", written the German way with a dot.
+
+Why?  Long decimals are unreadable.  Human beings know this, so
+we group them in threes.  For some historical reason, programming
+languages never copied this marvelous usability innovation.
+
+English notation for decimals is more common than German
+notation.  Unfortunately, dot is URL-safe and comma isn't, and
+it's nice to have a regular syntax for atoms that's URL-safe.
+
+As for why Urbit deleted your zero: it parses your command line
+as you type, and rejects any characters after the parser stops.
+
+## Let's make some cells
+
+There's not much mystery about cells.  A cell has a head and a
+tail, and puts brackets around them:
+
+```
+> [42 420]
+[42 420]
+```
+
+`42` is the *head* and `420` is the *tail* of the cell.  Cell
+syntax nests to the right:
+
+```
+> [4 [42 420]]
+[4 42 420]
+
+> [4 42 420]
+[4 42 420]
+
+> [[4 42] 420]
+[[4 42] 420]
+```
+
+If you look at these nouns as binary trees, you see
+
+```
+ [4 [42 420]]       [[4 42] 420]
+     .                  .
+    / \                /  \
+   4   .              .   420
+      / \            / \
+    42  420         4  42
+```
+
+Each number is an atom; each dot is a cell.
+
+## And we're done
+
+And we're done!  Type `|exit` to exit:
+
+```
+~palnul_nocser:dojo> |exit
+%drum-exit
+$
+```
+
+## Questions and/or exercises
+
+And we're done with our very first Urbyte!  Here's a question to
+think about.  These exercises are never mandatory, but they may
+be fun and/or interesting.  Skip them if they're obvious.
+
+The question today is: what is the right way to represent common
+data structures as nouns?  A linked list?  A string?  A *signed*
+integer?  A table or associative array?  Just try to picture
+these structures in your head, or draw them on a piece of paper.

--- a/docs/byte/1.md
+++ b/docs/byte/1.md
@@ -1,0 +1,369 @@
+---
+navhome: /docs/
+sort: 2
+next: true
+title: Atoms, auras, types
+---
+
+# Urbyte 1: Atoms, auras, types
+
+Thanks for reading Urbyte 0!  In Urbyte 1, we'll look a little
+more deeply at atoms and other simple noun types.
+
+Let's restart our engines:
+
+```
+$ urbit mycomet
+[...]
+ames: on localhost, UDP 31337.
+http: live (insecure, public) on 8080
+http: live ("secure", public) on 8443
+http: live (insecure, loopback) on 12321
+~palnul_nocser:dojo>
+```
+
+## What's in an atom?
+
+It seems limiting to have only one kind of atom, the unsigned
+decimal.  How are signed integers represented?  Symbols?
+Floating-point values?  Dates?  IP addresses?  Even just hex?
+
+Lisp's S-expression, with its own cells and atoms, is very
+similar to Hoon's nouns.  But languages in the Lisp family mark
+each atom with a dynamic tag that defines the atom's meaning.
+These tags are effectively dynamic types.
+
+Hoon also tracks the meaning of atoms.  But Hoon is statically
+typed, so an atom description is obviously a type.  An atomic type
+in Hoon is called an *aura*.  The aura syntax is just an ASCII
+string starting with `@`, like `@ud` for unsigned decimal.
+
+Hoon has a wide (but not extensible) variety of atom syntaxes.
+Each syntax for an atom produces an appropriate predefined aura.
+And Hoon's printer can invertibly print any aura Hoon can parse.
+Because atoms make great path nodes and paths make great URLs,
+all regular atom syntaxes use only URL-safe characters.
+
+## Examples
+
+With the dojo command `? expression`, you tell the dojo to print
+both the product of the expression, and the product's type.
+
+Let's type in some aura examples:
+
+### Unsigned integers
+
+```
+> 42
+42
+
+> ? 42
+  @ud
+42
+
+> ? 0x42
+  @ux
+0x42
+
+> ? (add 0x42 42)
+  @
+108
+
+> ? `@ud`0x42
+  @ud
+66
+
+```
+
+So decimal is aura `@ud`, hexadecimal is `@ux`.  Note the cast
+syntax, which lets us change the type of an atom, converting hex
+`0x42` to a decimal `66`.
+
+An aura is soft type.   The programmer can always insist on how
+to interpret an atom.  Hoon doesn't have "dependent types"; it
+can't enforce any constraints the aura puts on the atom's value.
+
+### Signed integers
+
+```
+> -7
+-7
+
+> ? -7
+  @sd
+
+> --7
+--7
+
+> ? --7
+  @sd
+--7
+
+> ? (sum:si -7 --7)
+  @s
+--0
+
+> `@ud`-7
+13
+
+> `@ud`--7
+14
+```
+
+`--7` means "positive 7."  `+7` might have been better, but `+`
+is not URL-safe.
+
+Hoon needs `--` to distinguish positive signed numbers because
+Hoon's type system doesn't feed back into its parser.  The
+expression itself needs to control whether it's `@sd` or `@ud`.
+
+With unlimited atom width, traditional sign extension makes no
+sense.  The sign bit is the low bit.  Even atoms are positive,
+odd atoms are negative.
+
+And Hoon has no overloading or type detection; we need to use a
+different function to add signed integers.  We'll always choose
+slightly clunkier syntax in exchange for much simpler semantics.
+
+### Symbols
+
+```
+> ? 'Ürbit'
+  @t
+'Ürbit'
+
+> ? `@ux`'Ürbit'
+  @ux
+0x7469.6272.9cc3
+
+> ? ~~Ürbit
+  @t
+'Ürbit'
+
+> ? ~.urbit
+  @ta
+~.urbit
+
+> ? `@ux`'foo'
+  @ux
+0x6f.6f66
+```
+
+The `@t` aura is UTF-8 text, with the first byte low.  Again,
+Hoon doesn't actually have the power to check statically that
+your UTF-8 is valid.  Auras don't tell you what an atom is, just
+what you think it is.
+
+The familiar single-quote syntax for `@t` is an irregular form of
+the more unusual `~~` prefix.  The `~.` prefix, aura `@ta`, is
+restricted to lowercase ASCII (a great common denominator).  Of
+course, `~` is URL-safe and `'` is not.
+
+### Dates, floats, IP addresses...
+
+```
+> ? now
+  @da
+~2016.7.11..01.32.04..2c0d
+
+> ? ~h6
+  @dr
+~h6
+
+> `@ux`~h6
+  @ux
+0x5460.0000.0000.0000.0000
+
+> ? (add ~h6 now)
+  @
+170.141.184.502.236.089.414.812.327.632.537.911.296
+
+> `@da`(add ~h6 now)
+~2016.7.11..07.32.28..842f
+
+> ? .3.14
+  @rs
+.3.14
+
+> ? .127.0.0.1
+  @if
+.127.0.0.1
+```
+
+`@da` is a 128-bit absolute date (64 bits for fractions of a
+second, 64 bits for seconds); `@dr` is a relative date;  `@rs` is
+a single-precision IEEE real; `@if` is an IPv4 address.  This is
+not all Hoon's aura syntax, just a good range of examples.
+
+`(add ~h6 now)` is a good example of the use and limits of
+the aura system.  Unlike the signed-integer sum, offsetting a
+date can use plain atomic addition.  But the product of `add` is
+a flavorless atom with no aura, `@`.  So we have to cast it back
+to an absolute date `@da`.
+
+## Auras explained
+
+Does an aura represent the units of the atom, its syntax, its
+semantics, its constraints?
+
+Any or all of the above.  Programmers can even use their own aura
+strings, which nothing in Hoon recognizes.  The set of syntaxes
+that Hoon knows how to parse and/or print is fixed.  But there
+are plenty of good reasons to use your own user-defined auras.
+
+If your program uses both fortnights and furlongs, Hoon will not
+parse a user-defined fortnight syntax. It will not print furlongs
+in the dojo.  But the type system will keep you from accidentally
+passing a furlong to a function that expects a fortnight.
+
+Hoon does interpret the aura string in one way: auras specialize
+to the right.  For example, `@u` is any unsigned integer; `@ux`
+is an unsigned integer that likes to be printed as hex.
+
+Hoon's typechecker lets you go up or down the specialization
+ladder.  It complains if you try to move across.  For example,
+`@u` can silently convert into `@ux` or `@ux` into `@u`, but
+turning `@ud` into `@ux`, `@ux` into `@da`, etc, requires an
+explicit cast.
+
+## Constants, symbols, loobeans and null
+
+An atom type isn't just an aura.  There's another choice: the
+type can be *general* and contain all atoms (like the types we've
+seen above), or *constant* and contain just one atom.
+
+A type describes a set of values.  While auras may informally
+describe a format for which not all atoms are valid, any atom can
+be cast into the aura whether valid or invalid.  But in a
+constant, the type contains just one atom.
+
+The regular syntax for an atomic constant is just to put `%` in
+front of the constant.  Like:
+
+```
+> ? 42
+  @ud
+42
+
+> ? %42
+  $42
+%42
+
+> ? %~h6
+  $~h6
+%~h6
+```
+
+The `$` on the type indicates the constant.  Note that constants
+still have auras; `~h6` (6 hours) is still a `@dr`.
+
+## Common irregulars
+
+There are a few special forms worth learning early: symbols,
+null, loobeans, and of course ships:
+
+```
+> ? %foo
+  $foo
+%foo
+
+> `@ux`%foo
+0x6f.6f66
+
+> .n
+%.n
+
+> |
+%.n
+
+> .y
+%.y
+
+> &
+%.y
+
+> `@ud`&
+0
+
+> ~
+~
+
+> `@ud`~
+0
+
+> ? ~zod
+  @p
+~zod
+
+> `@ux`~forseg-bolbyn
+0x885e.8af9
+```
+
+`%symbol` is a constant with aura `@tas` (text, ASCII, symbol).
+The symbol rules, which are enforced by the Hoon parser but not
+(as we've discussed) the type system: a symbol is lowercase with
+infix hyphens ("kebab-case").
+
+Loobeans are not true and false, but yes (`.y` or `&`) and no
+(`.n` or `|`).  This is because *yes is zero and no is one*.
+This makes sense at a certain mathematical level, though it
+was probably a mistake from a practical perspective.
+
+`~` is Hoon's nil: constant `0`, aura `@n`.
+
+And of course, `@p` is the phonemic base used for ship names.
+(It's useful for any kind of memorable number.)
+
+## Cells and types
+
+Naturally, all these atoms fit neatly into cells, and retain
+their types within the cells.
+
+```
+> ? [~h6 [.3.14 %foo] 0xdead.beef]
+  {@dr {@rs $foo} @ux}
+[~h6 [.3.14 %foo] 0xdead.beef]
+
+> `*`[~h6 [.3.14 %foo] 0xdead.beef]
+[398.449.671.992.126.314.905.600 [1.078.523.331 7.303.014] 3.735.928.559]
+```
+
+Another fun trick is to cast any noun to the `*` type, ie,
+generic noun.  We then know nothing about the noun, so we print
+all its atoms as decimals.
+
+## And we're done
+
+And we're done!  Type `|exit` to exit:
+
+```
+~palnul_nocser:dojo> |exit
+%drum-exit
+$
+```
+
+## Questions and/or exercises
+
+As always, these questions are optional and only for fun.
+
+We didn't include anywhere near all Hoon's auras or syntaxes in
+this lesson.  It's just a set of examples.
+
+Try using the dojo's magic error erasure to stumble around the
+rest of Hoon's atom syntax.  Any string that can't be extended
+into a valid expression will be trimmed back, with a beep, until
+it can.  Return will beep if the expression is not complete.
+This feedback is harmless and does not use an electric shock.
+It enables stochastic reinforcement learning of Hoon syntax.
+
+If `~h6` is six hours, how do you write forty-five minutes?  Two
+days, six hours and forty-five minutes?
+
+What would you expect the syntax for double-precision float to
+be?  What about base64?
+
+Does an absolute date have to include every zillisecond, or can
+it be pruned to a day or a year?
+
+If there's an IP syntax, what about bitcoin addresses?  What
+other auras do you think should be supported?

--- a/docs/byte/2.md
+++ b/docs/byte/2.md
@@ -1,0 +1,495 @@
+---
+navhome: /docs/
+sort: 3
+title: Subject-oriented programming
+---
+
+# Urbyte 2: Subject-oriented programming
+
+Thanks for reading Urbytes 0 and 1!  In Urbyte 2, we'll take
+nouns for granted and have some real fun with them.
+
+Let's restart our engines:
+
+```
+$ urbit mycomet
+[...]
+ames: on localhost, UDP 31337.
+http: live (insecure, public) on 8080
+http: live ("secure", public) on 8443
+http: live (insecure, loopback) on 12321
+~palnul_nocser:dojo>
+```
+
+## Welcome to the dojo
+
+Wait, where are we?
+
+We're playing in the Urbit `:dojo`.  The dojo is sort of like a
+cross between a Lisp REPL and the Unix shell.  (If you know the
+Unix shell, the Urbit command line has the same history model and
+Emacs editing commands.)
+
+The dojo has its own command language, which is a superset of
+Hoon.  Any Hoon expression is a command.  But not all commands
+are expressions.
+
+(The dojo is not the only command-line app on your Urbit.  By
+default there is one other, `:talk`.  Since you're on a fakezod,
+you can only talk to yourself.  If you accidentally press `ctrl-x`,
+it will put you into `:talk`; press `ctrl-x` again to switch back.)
+
+### Dojo variables
+
+Like the Unix shell, the dojo has command variables.  Type
+
+```
+> =a 42
+```
+
+You've set the dojo variable `a` to the value `42`.  The dojo
+puts this binding in the Hoon subject for expressions to use.
+So you can write:
+
+```
+> a
+42
+
+> [4 a]
+[4 42]
+
+> ? [4 a]
+  {@ud @ud}
+[4 42]
+```
+
+To unbind `a`, just omit the value:
+
+```
+> =a
+```
+
+You removed `a` from the subject.  (We can bind it again later, or
+bind over it without removing it.)
+
+```
+> [4 a]
+-find.a
+```
+
+Now trying to use `a` is an error.
+
+## Subject-oriented programming
+
+What is this *subject* thing, anyway?  We put `a` in what?
+
+Most programming languages have something called a *scope* or an
+*environment* or a *context*.  This is a data structure that
+contains the variables and functions an expression can use.
+
+In a normal language, the environment is not a first-class value.
+You cannot save an environment in a variable, compute an
+expression against the environment in the variable, etc, etc.
+
+In Hoon or any "subject-oriented" language, an expression is
+executed against one normal value, the *subject*.  In Hoon, of
+course, the subject is a noun.
+
+## First experiments
+
+Up to now, we've only built constants.  By definition, a constant
+doesn't use the subject.
+
+It would be nice to start with the subject every dojo expression
+gets.  But that subject is pretty complex.  Instead, let's make a
+simple noun from the kinds of atoms we've already learned about:
+
+```
+> =a [42 [%foo .6.28 ~m45] 0xdead.beef]
+
+> ? a
+  {@ud {$foo @rs @dr} @ux}
+[42 [%foo .3.14 ~m45] 0xdead.beef]
+
+> 420:a
+420
+```
+
+The syntax `expression:expression` uses the product of the second
+expression as the subject of the first.  So we're using `a` as
+the subject of the expression `420`.
+
+Of course, `420` is a constant expression.  It doesn't care what
+the subject is.  But:
+
+```
+> (add 2 2):a
+-find.add
+```
+
+We can't use `a` as the subject of even a simple addition.  How
+could we?  There's no `add` function in our `a`.  It sometimes
+takes new Hoon programmers a little while before they realize
+that there really isn't a scope or environment in Hoon.
+
+## Tree geometry
+
+So what can we do with this subject?  How can we get data out of
+it?  Let's keep working with our little test subject `a`.
+
+The most basic way to access the subject is *tree geometry*.
+Every noun is a binary tree; every noun in the tree has a number
+which is its address.  The root of the tree is `1`; if the
+address of a cell is `n`, its head is `2n` and its tail is
+`2n+1`.
+
+A picture might help:
+```
+            1
+         /     \
+        2       3
+       / \     / \
+      4   5   6   7
+                 / \
+                14 15
+```
+
+The syntax for a fragment of the subject at a tree address, or
+*axis*, is just `+axis`.  So:
+
+```
+> +3:a
+[[%foo .3.14 ~m45] 0xdead.beef]
+
+> ? +7:a
+  @ux
+0xdead.beef
+
+> ? +13:a
+  {@rs @dr}
+[.3.14 ~m45]
+```
+
+Of course, the fragment retains the type it had when we built it.
+
+## Labeled surfaces
+
+We can obviously get anything we want out of the subject by tree
+geometry.  But that's not really how we'd like to program.  We'd
+much rather *label* subtrees with convenient, memorable symbols.
+
+For example, suppose our tree looked like:
+
+```
+            1
+         /     \
+       x=2      3
+               / \
+             y=6  z=7
+            /   \
+           p=14  15
+                /  \
+              q=30  r=31
+```
+
+Then instead of writing `+2`, we could write `x`, and so on.
+
+Let's replace our test subject `a` with a new noun built around
+this tree of *labeled surfaces*.
+
+```
+> =a [x=42 y=[p=%foo q=.6.28 r=~m45] z=0xdead.beef]
+
+> ? x:a
+ @ud
+42
+
+> ? y:a
+  {p/$foo q/@rs r/@dr}
+[p=%foo q=.6.28 r=~m45]
+
+> ? q.y:a
+  @rs
+.6.28
+```
+
+Surfaces might remind you of attributes in an object.  But again,
+attributes in an object are a symbol table.  There is no symbol
+table here -- just a tree search.
+
+An expression like the label `x` or the axis `+2`, which
+designates a fragment or feature of the subject, is called a
+*limb*.  A list of limbs connected with `.` is a *wing*.
+
+To remind you that you're not in Kansas anymore, the syntax for a
+wing, like `q.y` above, means means "q inside y."  In a classic
+object-oriented system, of course, this would be written `y.q`,
+that is, attribute `q` within object `y`.  In Hoon, `q.y` means
+"find limb `y`, then find limb `q` inside that."
+
+## Surfaces versus fragments
+
+Once again, Hoon has no symbol tables.  When we put a surface
+on a noun, the surface label is part of that noun's type.  It's
+not part of the cell or other structure that contains the noun.
+This will take a little getting used to:
+
+```
+> ? x:a
+  @ud
+42
+
+> ? +2:a
+  x/@ud
+x=42
+
+? x.+2:a
+  @ud
+42
+```
+
+When we take fragment 2 of the labeled subject, the *surface
+comes with it*.  `+2` is not `42` but rather `x=42`.  We can
+take the surface off with `x.+2`.
+
+## The search algorithm
+
+In resolving a label to a fragment axis, we search the subject
+type in a depth-first traverse.
+
+If we find a surface that matches the limb, we succeed.  If we
+find a surface that doesn't match the limb, we fail.  If we find
+a cell, we search first head, then tail.
+
+## Skipping
+
+What if the same label appears twice in one noun?  Let's modify
+our subject slightly as a test case:
+
+```
+> ? +7:a
+  z/@ux
+z=0xdead.beef
+
+> =a a(+7 x=z:a)
+
+> ? a
+  {x/@ud y/{p/$foo q/@rs r/@dr} x/@ux}
+[x=42 y=[p=%foo q=.6.28 r=~m45] x=0xdead.beef]
+
+> ? x:a
+  @ud
+42
+
+> ? ^x:a
+  @ux
+0xdead.beef
+```
+
+We don't want to hide any part of the noun from an expression.
+So the modified limb `^x` *skips* the first match with a surface
+`x`, getting us to our `0xdead.beef`.  This is a unary notation:
+`^^x` would skip the first two matches.
+
+## Editing
+
+Above, we mutated our first noun with the flashy `a(+7 x=z:a)`.
+
+Of course we are not really "modifying" a noun.  Hoon is a pure
+language.  We are making an edited copy.  `a(+7 x=z:a)` means "a
+copy of `a`, with limb `+7` replaced by the product of `x=z:a`."
+
+We can edit multiple (disjoint) wings in one expression:
+
+```
+> ? a(+7 [%hello %world], q.y .3.14)
+  {x/@ud y/{p/$foo q/@rs r/@dr} $hello $world}
+[x=42 y=[p=%foo q=.3.14 r=~m45] %hello %world]
+```
+
+Notice that nothing stopped us from changing `+7` from
+`x=0xdead.beef` to `[%hello %world]`.  Since the mutated
+copy is a different noun, it has a different type.
+
+(And remember that since `[x y z]` means `[x [y z]]`,
+`[x y [%hello %world]]` means `[x y %hello %world]`.)
+
+## Cores and arms
+
+It should be reasonably clear how Hoon's system of fragments and
+surfaces parallels variables, records or structures in a
+classical language.  But where is Hoon's equivalent of objects:
+values which bind code to data?
+
+The Hoon equivalent of an object is a *core*.  As usual in Hoon,
+the resemblance is inexact.  A core has a set of computed
+attributes, or *arms*.  Each arm is an expression whose subject
+is the core.  There is no argument, so an arm is not a method.
+
+Physically, a core is always a cell `[battery payload]`, where
+the *payload* is any noun, and the *battery* is a tree of
+formulas in Nock (Hoon's functional assembly language) that
+implements the arms.  (A battery is like a C++ vtable, sort of.)
+
+## The search algorithm
+
+As you'd expect with a computed attribute, there is only one
+namespace and one search algorithm.  We just extend the algorithm
+described above.  And an expression which uses a label can't know
+whether the subject will resolve it to a surface fragment (a
+*leg*) or to an arm.
+
+If we're searching a core and the label matches one of the core's
+arms, we compute the arm against the core.  If the label is not
+found, we search into the payload of the core.
+
+## Some core examples
+
+When you type these examples, make sure you get the number of
+spaces exactly right.  Hoon syntax is not whitespace-sensitive
+in general, except that "one space" is always a different token
+from "two or more spaces."
+
+```
+> ? x:a
+  @ud
+42
+
+> ? :per  a  x
+  @ud
+42
+
+> =b :per  a  :core  ++  foo  x  ++  bar  [q.y foo]  --
+```
+
+We're seeing some Hoon regular forms for the first time.  `x:a`
+turns out to be an irregular relative of the regular `:per` form.
+
+We'll get more into syntax in a later Urbyte.  If some of these
+examples seem syntactically a little funky, this isn't usually
+way we'd do them in "real life."  We don't normally write cores
+on a single command line.  In a file this would be:
+
+```
+  :per  a
+  :core
+  ++  foo  x
+  ++  bar  [q.y foo]
+  --
+```
+
+which is much more readable, at least once you get used to it.
+Let's look at the core itself:
+
+```
+> b
+<2.spy {x/@ud y/{p/$foo q/@rs r/@dr} x/@ux}>
+
+> ? +2:b
+  *
+[[0 6] [0 58] 9 4 0 1]
+
+> ? +3:b
+  {x/@ud y/{p/$foo q/@rs r/@dr} x/@ux}
+[x=42 y=[p=%foo q=.6.28 r=~m45] x=0xdead.beef]
+```
+
+When we print `b`, or any core, we see that typed noun printing
+can't be an invertible function in Hoon.
+
+We actually can read the battery (with `+2:b` above), but it's
+just Nock code, not typed data.  `<2.spy>` tells us the battery
+has two arms and hashes to the three-letter code `spy`.
+
+When printing a full core, we don't even print the payload data,
+just its type.  But our `+3:b` confirms the `[battery payload]`
+structure of the core.  Remember, `+2` is the head and `+3` is
+the tail.
+
+Finally, let's use this thing:
+
+```
+> ? foo:b
+  @ud
+42
+
+> ? bar:b
+  {@rs @ud}
+[.6.28 42]
+
+? x:b
+  @ud
+42
+```
+
+Seems legit.
+
+## The dojo subject
+
+Now that we've made a test subject which is a core, we can look
+directly at the real dojo subject:
+
+```
+> +1
+[ [ [ a=[x=42 y=[p=%foo q=.6.28 r=~m45] x=0xdead.beef]
+      b=<2.spy {x/@ud y/{p/$foo q/@rs r/@dr} x/@ux}>
+    ]
+    now=~2016.7.18..08.05.15..0b5c
+    eny=0vl.hsfrh.tg642.g5o21.1n80b.0h141.0vuan.pm8o4.77ovg.96rk0.n26nn
+    our=~palnul-wolmev-bonfex-danred--tilwen-midlux-bolfus-nocser
+  ]
+  ~
+  <283.xzp 42.ajz 407.xtr 110.xht 1.ztu $151>
+]
+```
+
+We see a bunch of surfaces: our custom `a` and `b`; standard
+surfaces for identity, date, and entropy; and a ginormous core
+stack with *over eight hundred* total arms.
+
+To be exact, the syntax `<283.xzp 42.ajz 407.xtr 110.xht 1.ztu
+$151>` denotes a stack of six cores, each of whose payload is
+another core, until the innermost payload `%151` (the Hoon
+version number).  This stack is our standard library, from which
+comes `add` and other fine functions.  (We don't know how to
+write a Hoon function yet, but we're getting way closer.)
+
+Let's clean up our subject, just to be hygienic:
+
+```
+> =a
+> =b
+
+> +1
+    now=~2016.7.18..08.10.42..36a0
+    eny=0vf.8j71j.hlqim.k340u.q0ual.v2cd8.cfa65.vkbte.e733g.ehihg.e8aog
+[ [ our=~palnul-wolmev-bonfex-danred--tilwen-midlux-bolfus-nocser
+  ]
+  ~
+  <283.xzp 42.ajz 407.xtr 110.xht 1.ztu $151>
+]
+```
+
+Again, remember that `=a` is not Hoon syntax, but `:dojo` syntax.
+How the dojo assembles this subject remains a mystery.  But it's
+not a particularly interesting mystery.
+
+## And we're done
+
+And we're done!  Type `|exit` to exit:
+
+```
+~palnul_nocser:dojo> |exit
+%drum-exit
+$
+```
+
+## Questions and/or exercises
+
+As always, these questions are optional and only for fun.
+
+What's the best way to construct a core which acts as a function?
+What do you do to call the function?
+
+Why don't any other languages use subject-oriented programming?
+Which languages are most similar to it?

--- a/docs/community-docs.md
+++ b/docs/community-docs.md
@@ -1,0 +1,31 @@
+---
+navhome: /docs/
+sort: 7
+---
+
+
+# Community docs
+
+<div>
+
+<ul>
+
+<li><code>~master-morzod</code>
+<br />
+<a href="https://micnus-tarwyl-haltem-linhut--dilhul-talbes-wolnyx-lasbud.urbit.org/docs/">docs</a>, <code>fora</code> <a href="https://urbit.org/fora/posts/~2016.12.25..06.35.44..a1ec~/">post</a></li>
+
+<li><code>~hidduc-posmeg</code>
+<br />
+<a href="https://fosnut-dandut.urbit.org/pages/hidducs-notes/tutorial/docs/">docs</a>, <code>fora</code> <a href="https://urbit.org/fora/posts/~2017.2.12..21.54.40..6fde~/">post</a></li>
+
+<li><code>~palfun-foslup</code>
+<br />
+<a href="https://github.com/Fang-/Urbit-By-Doing">Urbit by Doing</a></li>
+
+<li><code>@knubie</code>
+<br />
+<a href="https://github.com/knubie/learning-hoon">Learning Hoon</a></li>
+
+</ul>
+
+</div>

--- a/docs/community-projects.md
+++ b/docs/community-projects.md
@@ -1,0 +1,30 @@
+---
+navhome: /docs/
+sort: 8
+---
+
+
+# Community projects
+
+<div>
+
+<ul>
+
+<li><a href="https://github.com/ponnys-podfer/yint">Yint: A Tiny MUD</a>
+<br />
+<code>~ponnys-podfer</code></li>
+
+<li><a href="https://github.com/Fang-/talkbot">~talkbot</a>
+<br />
+<code>~palfun-foslup</code></li>
+
+<li><a href="https://github.com/Fang-/urbit-string">String processing</a>
+<br />
+<code>~palfun-foslup</code></li>
+
+<li><a href="community-projects/nock-implementations">Nock implementations</a>
+</li>
+
+</ul>
+
+</div>

--- a/docs/community-projects/nock-implementations.md
+++ b/docs/community-projects/nock-implementations.md
@@ -1,0 +1,10 @@
+---
+navhome: /docs/
+sort: 4
+title: Nock implementations
+next: true
+---
+
+# Community Nock implementations
+
+<list src="."></list>

--- a/docs/community-projects/nock-implementations/clojure.md
+++ b/docs/community-projects/nock-implementations/clojure.md
@@ -1,0 +1,125 @@
+---
+navhome: /docs/
+title: Clojure
+sort: 5
+next: true
+---
+
+# Clojure
+
+From [Matt Earnshaw](https://github.com/mattearnshaw/anock/blob/master/src/anock/core.clj):
+
+```
+(ns anock.core
+  (:import anock.NockException))
+
+(declare atom? cell? cell)
+
+(defn noun?
+  "A noun is an atom or a cell."
+  [noun & ns]
+  (if ns false
+      (or (atom? noun) (cell? noun))))
+
+(defn atom?
+  "An atom is a natural number."
+  [noun & ns]
+  (if ns false
+   (and (integer? noun) (>= noun 0))))
+
+(defn cell?
+  "A cell is an ordered pair of nouns."
+  [noun]
+  (cond 
+   (atom? noun) false
+   (nil? noun) false
+   (not= 2 (count noun)) false
+   :else (and (noun? (first noun)) 
+              (noun? (second noun)))))
+
+(defn tis
+  "= (pronounced 'tis') tests a cell for equality."
+  [noun]
+  (if (atom? noun) (throw (anock.NockException. "Cannot tis an atom."))
+      (let [[a b] noun]
+        (if (= a b) 0 1))))
+
+(defn wut
+  "? (pronounced 'wut') tests whether a noun is a cell."
+  [noun]
+  (cond
+   (atom? noun) 1
+   (cell? noun) 0
+   :else (throw (anock.NockException. "Invalid noun."))))
+
+(defn lus
+  "+ (pronounced 'lus') adds 1 to an atom."
+  [noun]
+  (if (atom? noun) (inc noun)
+      (throw (anock.NockException. "Can only lus atoms."))))
+
+(defn fas
+  "/ (pronounced 'fas') is a tree address function."
+  [noun]
+  (if (atom? noun) (throw (anock.NockException. "Cannot fas an atom."))
+      (let [[a b] (cell noun)]
+        (assert (and (pos? a) (atom? a)) "Subject of fas must be a positive atom.")
+        (if (and (not (coll? b)) (or (= 2 a) (= 3 a)))
+          (throw (anock.NockException. (str "Cannot fas noun: " noun))))
+        (cond
+          (= 1 a) b
+          (= 2 a) (first b)
+          (= 3 a) (second b)
+          (even? a) (fas [2 (fas [(/ a 2) b])])
+          (odd? a) (fas [3 (fas [(/ (dec a) 2) b])])))))
+
+(defn tar
+  "* (pronounced 'tar') means Nock"
+  [noun]
+  (if (atom? noun) (throw (anock.NockException. "Cannot tar an atom."))
+      (try
+        (let [noun (cell noun) [x [y z]] noun]
+          (cond
+            (cell? y) (cell (tar [x y]) (tar [x z]))
+            (zero? y) (fas [z x])
+            (= 1 y) z
+            (= 3 y) (wut (tar [x z]))
+            (= 4 y) (lus (tar [x z]))
+            (= 5 y) (tis (tar [x z]))
+            :else (let [[p q] z]
+                    (cond
+                      (= 2 y) (tar [(tar [x p]) (tar [x q])])
+                      (= 6 y) (tar [x 2 [0 1] 2 [1 (first q) (second q)]
+                                    [1 0] 2 [1 2 3] [1 0] 4 4 p])
+                      (= 7 y) (tar [x 2 p 1 q])
+                      (= 8 y) (tar [x 7 [[7 [0 1] p] 0 1] q])
+                      (= 9 y) (tar [x 7 q 2 [0 1] 0 p])
+                      (= 10 y) (if (cell? p)
+                                 (tar [x 8 (second p) 7 [0 3] q])
+                                 (tar [x q]))))))
+        (catch RuntimeException e
+          (throw (anock.NockException. (str "Cannot tar the noun " noun)))))))
+
+(def nock tar)
+
+; Some convenience functions
+(defn apply* [f x]
+  (if (and (= 1 (count x)) (coll? (first x)))
+    (apply f x)
+    (f x)))
+
+(defn bracket
+  "[a b c] -> [a [b c]]"
+  [[a & b :as c]]
+  (let [b (vec b)]
+    (cond
+      (and (noun? a) (apply noun? b)) (vec c)
+      (apply noun? b) (apply vector (bracket a) b)
+      (noun? a) [a (apply* bracket b)]
+      :else [(bracket a) (apply* bracket b)])))
+
+(defn cell [& nouns]
+  (if (apply atom? nouns)
+    (throw (anock.NockException. "Cannot convert atom to cell."))
+    (apply* bracket nouns)))
+```

--- a/docs/community-projects/nock-implementations/csharp.md
+++ b/docs/community-projects/nock-implementations/csharp.md
@@ -1,0 +1,478 @@
+---
+navhome: /docs/
+title: C#
+sort: 12
+next: true
+---
+
+# C#
+
+From [Julien Beasley](https://github.com/zass30/Nock5KCSharp):
+
+```
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace NockInterpreter
+{
+    class Interpreter
+    {
+        static Dictionary<string, Noun> memocache = new Dictionary<string, Noun>();
+
+        public static Noun Nock(Noun noun)
+        {
+        Start:
+            Noun cache_noun;
+            if (memocache.TryGetValue(noun.ToString(), out cache_noun))
+            {
+                return cache_noun;
+            }
+
+            if (Atom.IsAtom(noun))
+                throw new Exception("Infinite loop nocking an atom: " + noun.ToString());
+            else
+            {
+                Noun subject = noun.n1;
+                if (Noun.IsCell(noun.n2))
+                {
+                    Cell formula = (Cell)noun.n2;
+                    if (Noun.IsAtom(formula.n1)) // we have lines 25-37 of spec
+                    {
+                        Atom op = (Atom)formula.n1;
+                        Noun operands = formula.n2;
+
+                        switch (op.value)
+                        {
+                            case 0: // 25 ::    *[a 0 b]         /[b a]
+                                memocache[noun.ToString()] = fas(operands, subject);
+                                return memocache[noun.ToString()];
+                            case 1: // 26 ::    *[a 1 b]         b
+                                memocache[noun.ToString()] = operands;
+                                return memocache[noun.ToString()];
+                            case 2: // 27 ::    *[a 2 b c]       *[*[a b] *[a c]]
+                                if (Noun.IsCell(operands))
+                                {
+                                    Noun a = Nock(subject, operands.n1);
+                                    Noun b = Nock(subject, operands.n2);
+                                    noun = Noun.CreateNoun(a, b);
+                                    goto Start;
+                                    //                                    return Nock(Nock(subject, operands.n1), Nock(subject, operands.n2));
+                                }
+                                throw new Exception("Atom after operand 2: " + operands.ToString());
+                            case 3: // 28 ::    *[a 3 b]         ?*[a b]
+                                memocache[noun.ToString()] = wut(Nock(subject, operands));
+                                return memocache[noun.ToString()];
+                            case 4: // 29 ::    *[a 4 b]         +*[a b]
+                                memocache[noun.ToString()] = lus(Nock(subject, operands));
+                                return memocache[noun.ToString()];
+                            case 5: // 30 ::    *[a 5 b]         =*[a b]
+                                memocache[noun.ToString()] = tis(Nock(subject, operands));
+                                return memocache[noun.ToString()];
+                            case 6: // 32 ::    *[a 6 b c d]     *[a 2 [0 1] 2 [1 c d] [1 0] 2 [1 2 3] [1 0] 4 4 b]
+                                if (Noun.IsCell(operands) && Noun.IsCell(operands.n2))
+                                {
+                                    Noun b = operands.n1;
+                                    Noun c = operands.n2.n1;
+                                    Noun d = operands.n2.n2;
+                                    noun = Noun.CreateNoun("[" + subject + " 2 [0 1] 2 [1 " + c + " " + d + "] [1 0] 2 [1 2 3] [1 0] 4 4 " + b + "]");
+                                    goto Start;
+                                    //                                    return Nock(Noun.CreateNoun("[" + subject + " 2 [0 1] 2 [1 " + c + " " + d + "] [1 0] 2 [1 2 3] [1 0] 4 4 " + b + "]"));
+                                }
+                                throw new Exception("Unhandled pattern for operand 6");
+                            case 7: // 33 ::    *[a 7 b c]       *[a 2 b 1 c]
+                                if (Noun.IsCell(operands))
+                                {
+                                    Noun b = operands.n1;
+                                    Noun c = operands.n2;
+                                    noun = Noun.CreateNoun("[" + subject + " 2 " + b + " 1 " + c + "]");
+                                    goto Start;
+                                    //                                    return Nock(Noun.CreateNoun("[" + subject + " 2 " + b + " 1 " + c + "]"));
+                                }
+                                throw new Exception("Atom after operand 7: " + operands.ToString());
+                            case 8: // 34 ::    *[a 8 b c]       *[a 7 [[7 [0 1] b] 0 1] c]
+                                if (Noun.IsCell(operands))
+                                {
+                                    Noun b = operands.n1;
+                                    Noun c = operands.n2;
+                                    noun = Noun.CreateNoun("[" + subject + " 7 [[7 [0 1] " + b + "] 0 1] " + c + "]");
+                                    goto Start;
+                                    //                                    return Nock(Noun.CreateNoun("[" + subject + " 7 [[7 [0 1] " + b + "] 0 1] " + c + "]"));
+                                }
+                                throw new Exception("Atom after operand 8: " + operands.ToString());
+                            case 9: // 35 ::    *[a 9 b c]       *[a 7 c 2 [0 1] 0 b]
+                                if (Noun.IsCell(operands))
+                                {
+                                    Noun b = operands.n1;
+                                    Noun c = operands.n2;
+                                    noun = Noun.CreateNoun("[" + subject + " 7 " + c + " 2 [0 1] 0 " + b + "]");
+                                    goto Start;
+                                    //                                    return Nock(Noun.CreateNoun("[" + subject + " 7 " + c + " 2 [0 1] 0 " + b + "]"));
+                                }
+                                throw new Exception("Atom after operand 9: " + operands.ToString());
+                            case 10:
+                                if (Noun.IsCell(operands))
+                                {
+                                    if (Noun.IsCell(operands.n1)) // 36 ::    *[a 10 [b c] d]  *[a 8 c 7 [0 3] d]
+                                    {
+                                        Noun b = operands.n1.n1;
+                                        Noun c = operands.n1.n2;
+                                        Noun d = operands.n2;
+                                        noun = Noun.CreateNoun("[" + subject + " 8 " + c + " 7 [0 3] " + d + "]");
+                                        goto Start;
+                                        //                                        return Nock(Noun.CreateNoun("[" + subject + " 8 " + c + " 7 [0 3] " + d + "]"));
+                                    }
+                                    else // 37 ::    *[a 10 b c]      *[a c]
+                                    {
+                                        Noun c = operands.n2;
+                                        noun = Noun.CreateNoun(subject, c);
+                                        goto Start;
+                                        //                                        return Nock(subject, c);
+                                    }
+                                }
+                                throw new Exception("Atom after operand 10: " + operands.ToString());
+                            default:
+                                throw new Exception("Unknown operand: " + op.value);
+                        }
+                    }
+                    else // 23 ::    *[a [b c] d]     [*[a b c] *[a d]]
+                    {
+                        memocache[noun.ToString()] = Noun.CreateNoun(Nock(subject, formula.n1), Nock(subject, formula.n2));
+                        return memocache[noun.ToString()];
+                    }
+                }
+            }
+            throw new Exception("Unhandled pattern");
+        }
+
+        public static Noun Nock(string program)
+        {
+            Noun noun = Noun.CreateNoun(program);
+            return Nock(noun);
+        }
+
+        public static Noun Nock(Noun n1, Noun n2)
+        {
+            Noun noun = Noun.CreateNoun(n1, n2);
+            return Nock(noun);
+        }
+
+        private static Noun tis(Noun noun)
+        {
+            if (Noun.IsAtom(noun.ToString()))
+                throw new Exception("Infinite loop tising an atom: " + noun.ToString());
+            else
+            {
+                Cell cell = (Cell)noun;
+
+                if (cell.n1.ToString() == cell.n2.ToString())
+                    return Noun.CreateNoun("0");
+                else
+                    return Noun.CreateNoun("1");
+            }
+        }
+
+        private static Noun lus(Noun noun)
+        {
+            if (Noun.IsAtom(noun.ToString()))
+            {
+                Atom a = (Atom)noun;
+                int v = a.value + 1;
+                return Noun.CreateNoun(v.ToString());
+            }
+            else
+                throw new Exception("Infinite loop lusing a cell: " + noun.ToString());
+        }
+
+        private static Noun wut(Noun noun)
+        {
+            if (Noun.IsAtom(noun.ToString()))
+                return Noun.CreateNoun("1");
+            else
+                return Noun.CreateNoun("0");
+        }
+
+        private static Noun fas(Noun n1, Noun n2)
+        {
+            Noun noun = Noun.CreateNoun(n1, n2);
+            return fas(noun);
+        }
+
+        private static Noun fas(Noun noun)
+        {
+            if (Noun.IsAtom(noun.ToString()))
+                throw new Exception("Infinite loop fasing an atom: " + noun.ToString());
+            else
+            {
+                Cell c = (Cell)noun;
+                // If n1 isn't an atom, I assume we throw? This isn't defined in the spec. Confirmed by John B by email. This spins forever.
+                if (Noun.IsCell(c.n1.ToString()))
+                    throw new Exception("Axis must be an atom: " + c.ToString());
+                else
+                {
+                    Atom a = (Atom)c.n1;
+                    if (a.value == 1)
+                        return c.n2;
+                    else if (a.value >= 2)
+                    {
+                        if (!Noun.IsCell(c.n2.ToString()))
+                        {
+                            throw new Exception("Only a cell can have an axis of 2 or 3: " + c.n2.ToString());
+                        }
+                        else
+                        {
+                            Cell c2 = (Cell)c.n2;
+                            if (a.value == 2)
+                                return c2.n1;
+                            else if (a.value == 3)
+                                return c2.n2;
+                            else if (a.value % 2 == 0)
+                            {
+                                int half = a.value / 2;
+                                return fas(Noun.CreateNoun("2", fas(Noun.CreateNoun(half.ToString(), c2))));
+                            }
+                            else if (a.value % 2 == 1)
+                            {
+                                int half = a.value / 2;
+                                return fas(Noun.CreateNoun("3", fas(Noun.CreateNoun(half.ToString(), c2))));
+                            }
+                            else
+                            {
+                                throw new Exception("Infinite loop somewhere in fasing: " + c.n2.ToString());
+                            }
+                        }
+                    }
+                }
+                throw new Exception("Infinite loop somewhere in fasing: " + c.n2.ToString());
+            }
+        }
+    }
+
+    class Noun
+    {
+        public Noun n1;
+        public Noun n2;
+
+        // takes a program, returns a pair of nouns, stringified.
+        public static Tuple<string, string> SplitCell(string program)
+        {
+
+            int stackCount = 0;
+            int i = 0;
+            // split the string right after the first space
+            foreach (char c in program)
+            {
+                if (IsValidChar(c))
+                {
+                    if (c == '[')
+                        stackCount++;
+                    else if (c == ']')
+                        stackCount--;
+                    else if (c == ' ')
+                    {
+                        // if we see a space, and our stack count is at 1, then we've found our split point
+                        if (stackCount == 1)
+                        {
+                            string a = program.Substring(1, i - 1);
+                            string b = program.Substring(i + 1, program.Length - (i + 2));
+
+                            // to implement proper bracket closing, surround b with brackets if it isn't a cell and isn't an atom
+                            if (!IsCell(b) && !IsAtom(b))
+                                b = "[" + b + "]";
+                            Tuple<string, string> tuple = new Tuple<string, string>(a, b);
+                            return tuple;
+                        }
+                    }
+                }
+                else
+                    throw new Exception("Invalid char in cell: " + c);
+                i++;
+            }
+            throw new Exception("Invalid cell: " + program);
+        }
+
+        public static bool IsCell(string program)
+        {
+            // check if cell is valid, as above but make sure no space after bracket
+            // valid tokens are: space, int, [, ]
+            // from [ => [, int
+            // from int => space, ], int
+            // from ] => space, ]
+            // from space => int, [
+
+            // stack count must always be nonzero
+            // first and last elements must be [ and ] 
+
+            int i = 0; // i is the stack count for brackets. 
+            int counter = 0;
+            char s = '\0'; // s is the last seen character
+            // split the string right after the first space
+            foreach (char c in program)
+            {
+                if (s == '\0')
+                {
+                    if (c != '[')
+                        return false;
+                }
+                else if (s == '[')
+                {
+                    if (!(c == '[' || IsInt(c)))
+                        return false;
+                }
+                else if (IsInt(s))
+                {
+                    if (!(IsInt(c) || c == ' ' || c == ']'))
+                        return false;
+                }
+                else if (s == ']')
+                {
+                    if (!(c == ']' || c == ' '))
+                        return false;
+                }
+                else if (s == ' ')
+                {
+                    if (!(c == '[' || IsInt(c)))
+                        return false;
+                }
+                s = c;
+                counter++;
+                if (c == '[')
+                    i++;
+                else if (c == ']')
+                    i--;
+                if (i <= 0 && counter != program.Length) // stack count can't be zero unless it's the last character
+                    return false;
+            }
+
+            // We should end with stack count of zero
+            if (i == 0)
+                return true;
+            else
+                return false;
+        }
+
+        public static bool IsInt(char c)
+        {
+            if (c == '0' ||
+                c == '1' ||
+                c == '2' ||
+                c == '3' ||
+                c == '4' ||
+                c == '5' ||
+                c == '6' ||
+                c == '7' ||
+                c == '8' ||
+                c == '9')
+                return true;
+            else
+                return false;
+        }
+
+        public static bool IsValidChar(char c)
+        {
+            if (c == ' ' ||
+                c == '[' ||
+                c == ']' ||
+                IsInt(c))
+                return true;
+            else
+                return false;
+        }
+
+        public static bool IsAtom(string program)
+        {
+            int i = 0;
+            if (int.TryParse(program, out i))
+            {
+                if (i >= 0)
+                    return true;
+            }
+            return false;
+        }
+
+        public static bool IsAtom(Noun noun)
+        {
+            return IsAtom(noun.ToString());
+        }
+
+        public static bool IsCell(Noun noun)
+        {
+            return IsCell(noun.ToString());
+        }
+
+        public static Noun CreateNoun(string program)
+        {
+            if (IsAtom(program))
+                return new Atom(program);
+            else
+                return new Cell(program);
+        }
+
+        public static Noun CreateNoun(Noun n1, Noun n2)
+        {
+            return CreateNoun("[" + n1.ToString() + " " + n2.ToString() + "]");
+        }
+
+        public static Noun CreateNoun(string p1, Noun n2)
+        {
+            return CreateNoun("[" + p1 + " " + n2.ToString() + "]");
+        }
+
+        public static Noun CreateNoun(Noun n1, string p2)
+        {
+            return CreateNoun("[" + n1.ToString() + " " + p2 + "]");
+        }
+
+        public static Noun CreateNoun(string p1, string p2)
+        {
+            return CreateNoun("[" + p1 + " " + p2 + "]");
+        }
+    }
+
+    class Atom : Noun
+    {
+        public int value;
+
+        public override string ToString()
+        {
+            return value.ToString();
+        }
+
+        public Atom(string program)
+        {
+            if (IsAtom(program))
+            {
+                int i = 0;
+                bool result = int.TryParse(program, out i);
+                value = i;
+            }
+            else
+                throw new ArgumentException("Invalid Atom: " + program);
+            n1 = null;
+            n2 = null;
+        }
+    }
+
+    class Cell : Noun
+    {
+        public override string ToString()
+        {
+            return "[" + n1.ToString() + " " + n2.ToString() + "]";
+        }
+
+        public Cell(string program)
+        {
+            if (IsCell(program))
+            {
+                Tuple<string, string> split = SplitCell(program);
+                n1 = CreateNoun(split.Item1);
+                n2 = CreateNoun(split.Item2);
+            }
+            else
+                throw new ArgumentException("Invalid Cell: " + program);
+        }
+    }
+}
+```

--- a/docs/community-projects/nock-implementations/groovy.md
+++ b/docs/community-projects/nock-implementations/groovy.md
@@ -1,0 +1,206 @@
+---
+navhome: /docs/
+title: Groovy
+sort: 7
+next: true
+---
+
+# Groovy 
+
+From [Kohányi Róbert](https://github.com/kohanyirobert/gnock/blob/master/gnock.groovy):
+
+```
+@Memoized
+def i(def a) {
+  a.class in [
+    byte, Byte,
+    char, Character,
+    short, Short,
+    int, Integer,
+    long, Long,
+    BigInteger
+  ] && a >= 0
+}
+
+@Memoized
+def n(def a) {
+  def r
+  n(a, { r = it })
+  r
+}
+
+@TailRecursive
+def n(def a, def r) {
+  if (a in List) {
+    if (a.size() == 1) {
+      r(a[0])
+    } else if (a.size() >= 2) {
+      n(a[0], { t ->
+        n(a.size() == 2 ? a[1] : a.tail(), { h ->
+          r([t, h])
+        })
+      })
+    } else {
+      throw new IllegalStateException()
+    }
+  } else if (i(a)) {
+    r((BigInteger) a)
+  } else {
+    throw new IllegalStateException()
+  }
+}
+
+@Memoized
+def wut(def a) {
+  i(a) ? 1 : 0
+}
+
+@Memoized
+def lus(def a) {
+  if (wut(a) == 0) {
+    throw new IllegalStateException()
+  }
+  1 + a
+}
+
+@Memoized
+def tis(def a) {
+  if (wut(a) == 1) {
+    throw new IllegalStateException()
+  }
+  a[0] == a[1] ? 0 : 1
+}
+
+@Memoized
+def fas(def a) {
+  def r
+  fas(a, { r = it })
+  r
+}
+
+@TailRecursive
+def fas(def a, def r) {
+  if (wut(a) == 1) {
+    throw new IllegalStateException()
+  }
+  def h = a[0]
+  if (!i(h)) {
+    throw new IllegalStateException()
+  }
+  def t = a[1]
+  if (h == 0) {
+    throw new IllegalStateException()
+  } else if (h == 1) {
+    r(t)
+  } else {
+    if (i(t)) {
+      throw new IllegalStateException()
+    }
+    if (h == 2) {
+      r(t[0])
+    } else if (h == 3) {
+      r(t[1])
+    } else {
+      fas([h.intdiv(2), t], { p ->
+        fas([2 + h.mod(2), p], { q ->
+          r(q)
+        })
+      })
+    }
+  }
+}
+
+@Memoized
+def tar(def a) {
+  def r
+  tar(a, { r = it})
+  r
+}
+
+@TailRecursive
+def tar(def a, def r) {
+  if (wut(a) == 1) {
+    throw new IllegalStateException()
+  }
+  def s = a[0]
+  def f = a[1]
+  if (wut(f) == 1) {
+    throw new IllegalStateException()
+  }
+  def o = f[0]
+  def v = f[1]
+  if (wut(o) == 0) {
+    tar([s, o], { p ->
+      tar([s, v], { q ->
+        r([p, q])
+      })
+    })
+  } else {
+    if (o == 0) {
+      r(fas([v, s]))
+    } else if (o == 1) {
+      r(v)
+    } else if (o == 3) {
+      tar([s, v], {
+        r(wut(it))
+      })
+    } else if (o == 4) {
+      tar([s, v], {
+        r(lus(it))
+      })
+    } else if (o == 5) {
+      tar([s, v], {
+        r(tis(it))
+      })
+    } else {
+      if (wut(v) == 1) {
+        throw new IllegalStateException()
+      }
+      def x = v[0]
+      def y = v[1]
+      if (o == 2) {
+        tar([s, x], { p ->
+          tar([s, y], { q ->
+            tar([p, q], {
+              r(it)
+            })
+          })
+        })
+      } else if (o == 7) {
+        tar(n([s, 2, x, 1, y]), {
+          r(it)
+        })
+      } else if (o == 8) {
+        tar(n([s, 7, [[7, [0, 1], x], 0, 1], y]), {
+          r(it)
+        })
+      } else if (o == 9) {
+        tar(n([s, 7, y, 2, [0, 1], 0, x]), {
+          r(it)
+        })
+      } else if (o == 10) {
+        if (wut(x) == 1) {
+          tar([s, y], {
+            r(it)
+          })
+        } else {
+          tar(n([s, 8, x[1], 7, [0, 3], y]), {
+            r(it)
+          })
+        }
+      } else {
+        if (wut(y) == 1) {
+          throw new IllegalStateException()
+        }
+        if (o == 6) {
+          tar(n([s, 2, [0, 1], 2, [1, y[0], y[1]], [1, 0], 2, [1, 2, 3], [1, 0], 4, 4, x]), {
+            r(it)
+          })
+        } else {
+          throw new IllegalStateException()
+        }
+      }
+    }
+  }
+}
+```

--- a/docs/community-projects/nock-implementations/haskell.md
+++ b/docs/community-projects/nock-implementations/haskell.md
@@ -1,0 +1,63 @@
+---
+navhome: /docs/
+title: Haskell
+sort: 3
+next: true
+---
+
+# Haskell
+
+From [Steve Dee](https://github.com/mrdomino/hsnock/blob/master/Language/Nock5K/Spec.hs):
+
+```
+module Language.Nock5K.Spec where
+import Control.Monad.Instances
+
+wut (a :- b)                         = return $ Atom 0
+wut a                                = return $ Atom 1
+
+lus (a :- b)                         = Left "+[a b]"
+lus (Atom a)                         = return $ Atom (1 + a)
+
+tis (a :- a') | a == a'              = return $ Atom 0
+tis (a :- b)                         = return $ Atom 1
+tis a                                = Left "=a"
+
+fas (Atom 1 :- a)                    = return a
+fas (Atom 2 :- a :- b)               = return a
+fas (Atom 3 :- a :- b)               = return b
+fas (Atom a :- b) | a > 3            = do  x <- fas $ Atom (a `div` 2) :- b
+                                           fas $ Atom (2 + (a `mod` 2)) :- x
+fas a                                = Left "/a"
+
+tar (a :- (b :- c) :- d)             = do x <- tar (a :- b :- c)
+                                          y <- tar (a :- d)
+                                          return $ x :- y
+
+tar (a :- Atom 0 :- b)               = fas $ b :- a
+tar (a :- Atom 1 :- b)               = return b
+tar (a :- Atom 2 :- b :- c)          = do  x <- tar (a :- b)
+                                           y <- tar (a :- c)
+                                           tar $ x :- y
+tar (a :- Atom 3 :- b)               = tar (a :- b) >>= wut
+tar (a :- Atom 4 :- b)               = tar (a :- b) >>= lus
+tar (a :- Atom 5 :- b)               = tar (a :- b) >>= tis
+
+tar (a :- Atom 6 :- b :- c :- d)     = tar (a :- Atom 2 :- (Atom 0 :- Atom 1) :-
+                                            Atom 2 :- (Atom 1 :- c :- d) :-
+                                            (Atom 1 :- Atom 0) :- Atom 2 :-
+                                            (Atom 1 :- Atom 2 :- Atom 3) :-
+                                            (Atom 1 :- Atom 0) :- Atom 4 :-
+                                            Atom 4 :- b)
+tar (a :- Atom 7 :- b :- c)          = tar (a :- Atom 2 :- b :- Atom 1 :- c)
+tar (a :- Atom 8 :- b :- c)          = tar (a :- Atom 7 :-
+                                            ((Atom 7 :- (Atom 0 :- Atom 1) :- b) :-
+                                             Atom 0 :- Atom 1) :- c)
+tar (a :- Atom 9 :- b :- c)          = tar (a :- Atom 7 :- c :- Atom 2 :-
+                                            (Atom 0 :- Atom 1) :- Atom 0 :- b)
+tar (a :- Atom 10 :- (b :- c) :- d)  = tar (a :- Atom 8 :- c :- Atom 7 :-
+                                            (Atom 0 :- Atom 3) :- d)
+tar (a :- Atom 10 :- b :- c)         = tar (a :- c)
+
+tar a                                = Left "*a"
+```

--- a/docs/community-projects/nock-implementations/hoon.md
+++ b/docs/community-projects/nock-implementations/hoon.md
@@ -1,0 +1,54 @@
+---
+navhome: /docs/
+title: Hoon
+sort: 11
+---
+
+# Hoon 
+
+```
+|=  {sub/* fol/*}
+^-  *
+?<  ?=(@ fol)
+?:  ?=(^ -.fol)
+  [$(fol -.fol) $(fol +.fol)]
+?+    fol 
+  !!
+    {$0 b/@}
+  ?<  =(0 b.fol)
+  ?:  =(1 b.fol)  sub
+  ?<  ?=(@ sub)
+  =+  [now=(cap b.fol) lat=(mas b.fol)]
+  $(b.fol lat, sub ?:(=(2 now) -.sub +.sub))
+::
+    {$1 b/*}
+  b.fol
+::
+    {$2 b/{^ *}}
+  =+  ben=$(fol b.fol)
+  $(sub -.ben, fol +.ben)
+::
+    {$3 b/*}
+  =+  ben=$(fol b.fol)
+  .?(ben)
+::
+    {$4 b/*}
+  =+  ben=$(fol b.fol)
+  ?>  ?=(@ ben)
+  +(ben)
+::
+    {$5 b/*}
+  =+  ben=$(fol b.fol)
+  ?>  ?=(^ ben)
+  =(-.ben +.ben)
+::
+    {$6 b/* c/* d/*}
+  $(fol =>(fol [2 [0 1] 2 [1 c d] [1 0] 2 [1 2 3] [1 0] 4 4 b]))
+::
+    {$7 b/* c/*}         $(fol =>(fol [2 b 1 c]))
+    {$8 b/* c/*}         $(fol =>(fol [7 [[0 1] b] c]))
+    {$9 b/* c/*}         $(fol =>(fol [7 c 0 b]))
+    {$10 @ c/*}          $(fol c.fol)
+    {$10 {b/* c/*} d/*}  =+($(fol c.fol) $(fol d.fol))
+==
+```

--- a/docs/community-projects/nock-implementations/javascript.md
+++ b/docs/community-projects/nock-implementations/javascript.md
@@ -1,0 +1,365 @@
+---
+navhome: /docs/
+title: Javascript
+sort: 9
+next: true
+---
+
+# Javascript
+
+From [Joe Bryan](https://github.com/joemfb/nock.js/blob/master/nock.js):
+
+```js
+(function (self, factory) {
+  'use strict'
+
+  if (typeof define === 'function' && define.amd) {
+    define([], factory)
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    module.exports = factory()
+  } else {
+    self.nock = factory()
+  }
+}(this, function () {
+  'use strict'
+
+  /**
+   * Nock is a combinator interpreter on nouns. A noun is an atom or a cell.
+   * An atom is an unsigned integer of any size; a cell is an ordered pair of nouns.
+   *
+   * @see http://urbit.org/docs/nock/definition/
+   * @see http://media.urbit.org/whitepaper.pdf
+   */
+
+  var useMacros = false
+
+  /*
+   *  code conventions:
+   *
+   *    `n` is a noun,
+   *    `s` is a subject noun,
+   *    `f` is a formula (or cell of formulas)
+   */
+
+  /*  operators  */
+
+  /**
+   * wut (?): test for atom (1) or cell (0)
+   *
+   *   ?[a b]           0
+   *   ?a               1
+   */
+  function wut (n) {
+    return typeof n === 'number' ? 1 : 0
+  }
+
+  /**
+   * lus (+): increment an atom
+   *
+   *   +[a b]           +[a b]
+   *   +a               1 + a
+   */
+  function lus (n) {
+    if (wut(n) === 0) throw new Error('lus cell')
+    return 1 + n
+  }
+
+  /**
+   * tis (=): test equality
+   *
+   *   =[a a]           0
+   *   =[a b]           1
+   *   =a               =a
+   */
+  function tis (n) {
+    if (wut(n) === 1) throw new Error('tis atom')
+    return deepEqual(n[0], n[1]) ? 0 : 1
+  }
+
+  /**
+   * fas (/): resolve a tree address
+   *
+   *   /[1 a]           a
+   *   /[2 a b]         a
+   *   /[3 a b]         b
+   *   /[(a + a) b]     /[2 /[a b]]
+   *   /[(a + a + 1) b] /[3 /[a b]]
+   *   /a               /a
+   */
+  function fas (addr, n) {
+    if (n === undefined) throw new Error('invalid fas noun')
+    if (addr === 0) throw new Error('invalid fas addr: 0')
+
+    if (addr === 1) return n
+    if (addr === 2) return n[0]
+    if (addr === 3) return n[1]
+
+    return fas(2 + (addr % 2), fas((addr / 2) | 0, n))
+  }
+
+  /*  formulas  */
+
+  /**
+   * slot (0): resolve a tree address
+   *
+   *   *[a 0 b]         /[b a]
+   */
+  function slot (s, f) {
+    var p = fas(f, s)
+
+    if (p === undefined) throw new Error('invalid fas addr: ' + f)
+
+    return p
+  }
+
+  /**
+   * constant (1): return the formula regardless of subject
+   *
+   *   *[a 1 b]  b
+   */
+  function constant (s, f) {
+    return f
+  }
+
+  /**
+   * evaluate (2): evaluate the product of second formula against the product of the first
+   *
+   *   *[a 2 b c]  *[*[a b] *[a c]]
+   */
+  function evaluate (s, f) {
+    return nock(nock(s, f[0]), nock(s, f[1]))
+  }
+
+  /**
+   * cell (3): test if the product is a cell
+   *
+   *   *[a 3 b]         ?*[a b]
+   */
+  function cell (s, f) {
+    return wut(nock(s, f))
+  }
+
+  /**
+   *  incr (4): increment the product
+   *
+   *   *[a 4 b]         +*[a b]
+   */
+  function incr (s, f) {
+    return lus(nock(s, f))
+  }
+
+  /**
+   * eq (5): test for equality between nouns in the product
+   *
+   *   *[a 5 b]         =*[a b]
+   */
+  function eq (s, f) {
+    return tis(nock(s, f))
+  }
+
+  /*  macro-formulas  */
+
+  /**
+   * ife (6): if/then/else
+   *
+   *   *[a 6 b c d]      *[a 2 [0 1] 2 [1 c d] [1 0] 2 [1 2 3] [1 0] 4 4 b]
+   */
+  function macroIfe (s, f) {
+    return nock(s, [2, [[0, 1], [2, [[1, [f[1][0], f[1][1]]], [[1, 0], [2, [[1, [2, 3]], [[1, 0], [4, [4, f[0]]]]]]]]]]])
+  }
+
+  function ife (s, f) {
+    var cond = nock(s, f[0])
+
+    if (cond === 0) return nock(s, f[1][0])
+    if (cond === 1) return nock(s, f[1][1])
+
+    throw new Error('invalid ife conditional')
+  }
+
+  /**
+   * compose (7): evaluate formulas composed left-to-right
+   *
+   *   *[a 7 b c]  *[a 2 b 1 c]
+   */
+  function macroCompose (s, f) {
+    return nock(s, [2, [f[0], [1, f[1]]]])
+  }
+
+  function compose (s, f) {
+    // alternate form:
+    // return nock(nock(s, f[0]), constant(s, f[1]))
+    return nock(nock(s, f[0]), f[1])
+  }
+
+  /**
+   * extend (8): evaluate the second formula against [product of first, subject]
+   *
+   *   *[a 8 b c]  *[a 7 [[7 [0 1] b] 0 1] c]
+   */
+  function macroExtend (s, f) {
+    return nock(s, [7, [[[7, [[0, 1], f[0]]], [0, 1]], f[1]]])
+  }
+
+  function extend (s, f) {
+    // alternate form:
+    // return nock([compose(s, [[0, 1], f[0]]), s], f[1])
+    return nock([nock(s, f[0]), s], f[1])
+  }
+
+  /**
+   * invoke (9): construct a core and evaluate one of it's arms against it
+   *
+   *   *[a 9 b c]  *[a 7 c 2 [0 1] 0 b]
+   */
+  function macroInvoke (s, f) {
+    return nock(s, [7, [f[1], [2, [[0, 1], [0, f[0]]]]]])
+  }
+
+  function invoke (s, f) {
+    var prod = nock(s, f[1])
+    return nock(prod, slot(prod, f[0]))
+  }
+
+  /**
+   * hint (10): skip first formula, evaluate second
+   *
+   *   *[a 10 [b c] d]  *[a 8 c 7 [0 3] d]
+   *   *[a 10 b c]      *[a c]
+   */
+  function macroHint (s, f) {
+    if (wut(f[0]) === 0) return nock(s, [8, [f[0][1], [7, [[0, 3], f[1]]]]])
+    return nock(s, f[1])
+  }
+
+  function hint (s, f) {
+    if (wut(f[0]) === 0) {
+      if (wut(f[0][1]) === 1) throw new Error('invalid hint')
+      nock(s, f[0][1])
+    }
+    return nock(s, f[1])
+  }
+
+  /*  indexed formula functions  */
+  var macroFormulas = [slot, constant, evaluate, cell, incr, eq, macroIfe, macroCompose, macroExtend, macroInvoke, macroHint]
+  var formulas = [slot, constant, evaluate, cell, incr, eq, ife, compose, extend, invoke, hint]
+
+  /**
+   * nock (*)
+   *
+   * the nock function
+   *
+   *   *[a [b c] d]     [*[a b c] *[a d]]
+   *   *a               *a
+   */
+  function nock (s, f) {
+    if (wut(f[0]) === 0) return [nock(s, f[0]), nock(s, f[1])]
+
+    var idx = f[0]
+
+    if (idx > 10) throw new Error('invalid formula: ' + idx)
+
+    if (useMacros) return macroFormulas[idx](s, f[1])
+
+    return formulas[idx](s, f[1])
+  }
+
+  /* construct a JS noun (group an array into pairs, associating right) */
+  function assoc (x) {
+    if (!x.length) return x
+
+    if (x.length === 1) return assoc(x[0])
+
+    return [assoc(x[0]), assoc(x.slice(1))]
+  }
+
+  /* deep equality for arrays or primitives */
+  function deepEqual (a, b) {
+    if (a === b) return true
+
+    if (!(Array.isArray(a) && Array.isArray(b))) return false
+    if (a.length !== b.length) return false
+
+    for (var i = 0; i < a.length; i++) {
+      if (!deepEqual(a[i], b[i])) return false
+    }
+
+    return true
+  }
+
+  /* parse a hoon-serialized nock formula and construct a JS noun */
+  function parseNoun (x) {
+    if (Array.isArray(x)) return assoc(x)
+
+    if (typeof x === 'string') {
+      var str = x.replace(/[\."']/g, '').split(' ').join(',')
+      return assoc(JSON.parse(str))
+    }
+
+    return x
+  }
+
+  function nockInterface () {
+    var args = [].slice.call(arguments)
+    var subject, formula, noun
+
+    if (args.length === 1) {
+      formula = parseNoun(args[0])
+    } else if (args.length === 2) {
+      subject = parseNoun(args[0])
+      formula = parseNoun(args[1])
+    } else {
+      noun = assoc(args)
+      subject = noun[0]
+      formula = noun[1]
+    }
+
+    if (!formula) throw new Error('formula required')
+
+    if (!subject) {
+      // !=(~)
+      subject = [1, 0]
+    }
+
+    return nock(subject, formula)
+  }
+
+  return {
+    nock: nockInterface,
+    _nock: nock,
+    useMacros: function (arg) {
+      useMacros = arg === undefined || arg
+      return this
+    },
+    util: {
+      assoc: assoc,
+      parseNoun: parseNoun,
+      deepEqual: deepEqual
+    },
+    operators: {
+      wut: wut,
+      lus: lus,
+      tis: tis,
+      fas: fas
+    },
+    formulas: {
+      slot: slot,
+      constant: constant,
+      evaluate: evaluate,
+      cell: cell,
+      incr: incr,
+      eq: eq,
+      macroIfe: macroIfe,
+      ife: ife,
+      macroCompose: macroCompose,
+      compose: compose,
+      macroExtend: macroExtend,
+      extend: extend,
+      macroInvoke: macroInvoke,
+      invoke: invoke,
+      macroHint: macroHint,
+      hint: hint
+    }
+  }
+}))
+```

--- a/docs/community-projects/nock-implementations/python.md
+++ b/docs/community-projects/nock-implementations/python.md
@@ -1,0 +1,95 @@
+---
+navhome: /docs/
+title: Python
+sort: 1
+next: true
+---
+
+# Python 
+
+From [James Tauber](https://github.com/jtauber/pynock/blob/master/nock.py):
+
+```
+#!/usr/bin/env python3
+
+# []
+def l(*lst):
+    if len(lst) == 1:
+        return(lst[0], 0)
+    if len(lst) == 2:
+        return lst
+    else:
+        return (lst[0], l(*lst[1:]))
+
+# *
+def nock(noun):
+    return tar(noun)
+
+# ?
+def wut(noun):
+    if isinstance(noun, int):
+        return 1
+    else:
+        return 0
+
+
+# +
+def lus(noun):
+    if isinstance(noun, int):
+        return 1 + noun
+    else:
+        return noun
+
+
+# =
+def tis(noun):
+    if noun[0] == noun[1]:
+        return 0
+    else:
+        return 1
+
+
+# /
+def slot(noun):
+    if noun[0] == 1:
+        return noun[1]
+    elif noun[0] == 2:
+        return noun[1][0]
+    elif noun[0] == 3:
+        return noun[1][1]
+    elif noun[0] % 2 == 0:
+        return slot((2, slot((noun[0] // 2, noun[1]))))
+    elif noun[0] % 2 == 1:
+        return slot((3, slot(((noun[0] - 1) // 2, noun[1]))))
+
+
+def tar(noun):
+    if isinstance(noun[1][0], int):
+        if noun[1][0] == 0:
+            return slot((noun[1][1], noun[0]))
+        elif noun[1][0] == 1:
+            return noun[1][1]
+        elif noun[1][0] == 2:
+            return nock((nock((noun[0], noun[1][1][0])), nock((noun[0], noun[1][1][1]))))
+        elif noun[1][0] == 3:
+            return wut(nock((noun[0], noun[1][1])))
+        elif noun[1][0] == 4:
+            return lus(nock((noun[0], noun[1][1])))
+        elif noun[1][0] == 5:
+            return tis(nock((noun[0], noun[1][1])))
+        elif noun[1][0] == 6:
+            return nock(l(noun[0], 2, (0, 1), 2, l(1, noun[1][1][1][0], noun[1][1][1][1]), (1, 0), 2, l(1, 2, 3), (1, 0), 4, 4, noun[1][1][0]))
+        elif noun[1][0] == 7:
+            return nock(l(noun[0], 2, noun[1][1][0], 1, noun[1][1][1]))
+        elif noun[1][0] == 8:
+            return nock(l(noun[0], 7, l(l(7, (0, 1), noun[1][1][0]), 0, 1), noun[1][1][1]))
+        elif noun[1][0] == 9:
+            return nock(l(noun[0], 7, noun[1][1][1], l(2, (0, 1), (0, noun[1][1][0]))))
+        elif noun[1][0] == 10:
+            if isinstance(noun[1][1][0], int):
+                return nock((noun[0], noun[1][1][1]))
+            else:
+                return nock(l(noun[0], 8, noun[1][1][0][1], 7, (0, 3), noun[1][1][1][0]))
+    else:
+        return (nock((noun[0], noun[1][0])), nock((noun[0], noun[1][1])))
+```

--- a/docs/community-projects/nock-implementations/ruby.md
+++ b/docs/community-projects/nock-implementations/ruby.md
@@ -1,0 +1,139 @@
+---
+navhome: /docs/
+title: Ruby
+sort: 2
+next: true
+---
+
+# Ruby
+
+From [T.J. Corcoran](https://github.com/TJamesCorcoran/nock/blob/master/nock.rb):
+
+```
+def str_to_tree(str)
+  arr = []
+  str.scan(/\+|\=|\?|\/|\*|\[|\]|\d+/).each do |token|
+  end
+end
+
+def max_depth(arr)
+  ret = arr.is_a?(Array) ?  [max_depth(arr[0]), max_depth(arr[1])].max + 1 : 1
+  ret 
+end
+
+def pp(arr)
+  depth = max_depth(arr)
+  space = 128
+  1.up_to(8) do |depth|
+    space = space / 2
+    min = 2 ** (depth - 1) 
+    max = (2 ** depth) - 1
+    min.upto(max) { |axis| 
+  end
+
+end
+
+def norm(arr)
+  return arr unless arr.is_a?(Array)
+  while arr.size > 2
+    size = arr.size
+    arr[size - 2] = [ arr[size - 2], arr.pop ]
+  end
+  arr = arr.map { |x| norm(x)   } 
+end
+
+def wut(arr)
+  arr.is_a?(Array) ? YES : NO
+end
+
+def lus(atom)
+  raise "not an atom" unless atom.is_a?(Fixnum)
+  atom + 1
+end
+
+def tis(arr)
+  raise "not pair" unless arr.is_a?(Array) && arr.size == 2
+  ( arr[0] == arr[1] ) ? YES : NO
+end
+
+def slot(axis, arr, allow_error = true)
+  raise "axis on atom" unless arr.is_a?(Array)
+  return arr if axis == 1
+  return arr[0] if axis == 2
+  return arr[1] if axis == 3
+  return slot(2, slot(axis/2, arr))   if (axis %2) == 0
+  return slot(3, slot(axis/2, arr))
+end
+
+
+def nock(arr)
+  raise "error: nocking an atom" unless arr.is_a?(Array)
+
+  oper = slot(4, arr)
+  a    = slot(2, arr)
+  b    = slot(5, arr)
+
+  if oper.is_a?(Array)
+    return  [ nock( [ a, [b, c]]), nock( [a, d]) ] 
+  end
+
+
+  case oper
+    when 0 then
+    slot(b,a )
+
+    when 1 then 
+    b
+    
+    when 2 then       
+    b_prime = slot(2, b)
+    c       = slot(3,b)
+    nock( [ nock([a, b_primce]), nock([a, c]) ])
+            
+    when 3 then 
+    wut(nock([a, b]))
+
+    when 4 then 
+    lus(nock([a, b]))
+
+    when 5 then 
+    tis(nock([a, b]))
+
+    when 6 then
+    b_prime = slot(2, b)
+    c = slot(6,b)
+    d = slot(7,b)
+    nock( norm([a, 2, [0, 1], 2, [1, c, d], [1, 0], 2, [1, 2, 3], [1, 0], 4, 4, b]) )
+      
+    when 7 then
+    b_prime = slot(2, b)
+    c = slot(3,b)
+    nock( norm ([a, 2, b_prime, 1, c]))
+
+    when 8 then
+    b_prime = slot(2, b)
+    c = slot(3,b)
+    nock( norm ([a, 7, [[7, [0, 1], b_prime], 0, 1], c]))
+
+    when 9 then
+    b_prime = slot(2, b)
+    c = slot(3,b)
+    nock( norm ([a, 7, c, 2, [0, 1], 0, b_prime]))
+
+    when 10 then
+    if wut(slot(2,b)) == TRUE
+      b_prime = slot(4, b)
+      c       = slot(5, b)
+      d       = slot(3, b)
+      c = slot(3,b)
+      nock( norm ([a, 8, c, 7, [0, 3], d]))
+    else
+      b_prime = slot(2, b)
+      c       = slot(3, b)
+      nock( norm ([a, 10, [b, c]]))
+    end
+    else
+      raise "error: unknown opcode #{oper.inspect}" 
+    end
+end
+```

--- a/docs/community-projects/nock-implementations/scala.md
+++ b/docs/community-projects/nock-implementations/scala.md
@@ -1,0 +1,86 @@
+---
+navhome: /docs/
+title: Scala
+sort: 4
+next: true
+---
+
+# Scala 
+
+From [Steve Randy Waldman](https://github.com/swaldman/nnnock/blob/master/src/main/scala/com/mchange/sc/v1/nnnock/package.scala):
+
+```
+package object nnnock {
+
+  sealed trait Noun;
+  case class Atom( value : Int ) extends Noun;
+  case class Cell( head : Noun, tail : Noun ) extends Noun;
+  implicit def toAtom( value : Int ) : Atom = Atom( value );
+  implicit def toInt( atom : Atom ) : Int = atom.value;
+
+  def nock( a : Noun ) : Noun = *(a)
+
+  object Cell {
+    private def apply( nl : List[Noun] ) : Cell = {
+      nl match {
+	case a :: b :: Nil => Cell(a, b);
+	case a :: b :: c :: Nil => Cell(a, Cell(b, c));
+	case a :: b :: c :: tail => Cell(a, this.apply( b :: c :: tail ) ); 
+      }
+    }
+    def apply(a : Noun, b : Noun, tail : Noun*) : Cell = apply( a :: b :: tail.toList );
+  }
+
+  def ?( noun : Noun ) : Noun = noun match {
+    case _ : Cell => 0;
+    case _ : Atom => 1;
+  }
+
+  @tailrec def plus( noun : Noun ) : Noun = noun match {
+    case a : Atom => 1 + a;
+    case c : Cell => plus( c ); //intentional endless spin
+  }
+
+  def heq( noun : Noun ) : Atom = noun match {
+    case Cell( a : Atom, b : Atom ) => if ( a == b ) 0 else 1;
+    case Cell( a : Cell, b : Atom ) => 1;
+    case Cell( a : Atom, b : Cell ) => 1;
+    case Cell( a : Cell, b : Cell ) => if ((heq( Cell( a.head, b.head ) ) | heq( Cell( a.tail, b.tail ) )) == 0) 0 else 1;
+    case a : Atom => heq( a ); //intentional endless spin
+  }
+
+  def /( noun : Noun ) : Noun = noun match {
+    case Cell(Atom(1), a) => a;
+    case Cell(Atom(2), Cell(a, b)) => a;
+    case Cell(Atom(3), Cell(a, b)) => b;
+    case Cell(Atom(value), b ) => {
+      val a = value / 2;
+      val num = if ( value % a == 0 ) 2 else 3;
+      /(Cell(num, /(Cell(a, b))));
+    }
+    case a => /( a ); //intentional endless spin
+  } 
+
+  def *( noun : Noun ) : Noun = noun match {
+    case Cell( a, Cell(Cell(b, c), d) ) => Cell( *(Cell(a,b,c)), *(Cell(a,d)) );
+    case Cell( a, Cell(Atom(value), tail) ) => {
+      (value, tail) match {
+	case (0, b) => /( Cell(b, a) );
+	case (1, b) => b;
+	case (2, Cell(b, c)) => *( Cell( *( Cell(a,b) ), *( Cell(a,c) ) ) );
+	case (3, b) => ?( *( Cell(a,b) ) );
+	case (4, b) => plus( *( Cell(a,b) ) );
+	case (5, b) => heq( *( Cell(a,b) ) );
+	case (6, Cell(b, Cell(c, d))) => *( Cell(a,2,Cell(0,1),2,Cell(1,c,d),Cell(1,0),2,Cell(1,2,3),Cell(1,0),4,4,b) ); //wtf?
+	case (7, Cell(b, c)) => *( Cell(a,2,b,1,c) );
+	case (8, Cell(b, c)) => *( Cell(a,7,Cell(Cell(7,Cell(0,1),b),0,1),c) ); //wtf2
+	case (9, Cell(b, c)) => *( Cell(a,7,c,2,Cell(0,1),0,b) );
+	case (10, Cell(Cell(b,c),d)) => *( Cell(a,8,c,7,Cell(0,3),d) );
+	case (10, Cell(b, c)) => *( Cell(a,c) );
+	case _ => *( noun ); //intentional endless spin
+      }
+    }
+    case a => *( a ); //intentional endless spin
+  }
+}
+```

--- a/docs/community-projects/nock-implementations/scheme.md
+++ b/docs/community-projects/nock-implementations/scheme.md
@@ -1,0 +1,128 @@
+---
+navhome: /docs/
+title: Scheme
+sort: 8
+next: true
+---
+
+# Scheme 
+
+From [Kohányi Róbert](https://github.com/kohanyirobert/snock/blob/master/snock.ss):
+
+```
+(import (rnrs (6)))
+
+(define (i a) a)
+
+(define (n a r)
+  (cond
+    ((list? a)
+     (let ((l (length a)))
+       (cond
+         ((equal? l 0) (raise 1))
+         ((equal? l 1) (r (car a)))
+         (else
+           (let ((t (cond
+                      ((equal? l 2) (cadr a))
+                      (else (cdr a)))))
+             (n (car a)
+                (lambda (p) (n t
+                               (lambda (q) (r (cons p q)))))))))))
+    ((fixnum? a) (r a))
+    (else (raise 2))))
+
+(define (wut a)
+  (cond
+    ((fixnum? a) 1)
+    (else 0)))
+
+(define (lus a)
+  (cond
+    ((equal? (wut a) 0) (raise 3))
+    (else (+ 1 a))))
+
+(define (tis a)
+  (cond
+    ((equal? (wut a) 1) (raise 4))
+    ((equal? (car a) (cdr a)) 0)
+    (else 1)))
+
+(define (fas a r)
+  (cond
+    ((equal? (wut a) 1) (raise 5))
+    (else
+      (let ((h (car a))
+          (t (cdr a)))
+      (cond
+        ((not (fixnum? h)) (raise 6))
+        ((equal? h 0) (raise 7))
+        ((equal? h 1) (r t))
+        ((fixnum? t) (raise 8))
+        ((equal? h 2) (r (car t)))
+        ((equal? h 3) (r (cdr t)))
+        (else
+            (fas (cons (div h 2) t)
+                 (lambda (p) (fas (cons (+ 2 (mod h 2)) p)
+                                  (lambda (q) (r q)))))))))))
+
+(define (tar a r)
+  (cond
+    ((equal? (wut a) 1) (raise 9))
+    (else
+      (let ((s (car a))
+            (f (cdr a)))
+        (cond
+          ((equal? (wut f) 1) (raise 10))
+          (else
+            (let ((o (car f))
+                  (v (cdr f)))
+              (cond
+                ((equal? (wut o) 0) (tar (cons s o)
+                                         (lambda (p) (tar (cons s v)
+                                                          (lambda (q) (r (cons p q)))))))
+                ((equal? o 0) (r (fas (cons v s) i)))
+                ((equal? o 1) (r v))
+                ((equal? o 3) (tar (cons s v)
+                                   (lambda (p) (r (wut p)))))
+                ((equal? o 4) (tar (cons s v)
+                                   (lambda (p) (r (lus p)))))
+                ((equal? o 5) (tar (cons s v)
+                                   (lambda (p) (r (tis p)))))
+                ((equal? (wut v) 1) (raise 11))
+                (else
+                  (let ((x (car v))
+                        (y (cdr v)))
+                    (cond
+                      ((equal? o 2) (tar (cons s x)
+                                         (lambda (p) (tar (cons s y)
+                                                          (lambda (q) (tar (cons p q)
+                                                                           (lambda (u) (r u))))))))
+                      ((equal? o 7) (tar (n (list (list s) 2 (list x) 1 (list y)) i)
+                                         (lambda (p) (r p))))
+                      ((equal? o 8) (tar (n (list (list s) 7 (list (list 7 (list 0 1) (list x)) 0 1) (list y)) i)
+                                         (lambda (p) (r p))))
+                      ((equal? o 9) (tar (n (list (list s) 7 (list y) 2 (list 0 1) 0 (list x)) i)
+                                         (lambda (p) (r p))))
+                      ((equal? o 10) (cond
+                                       ((equal? (wut x) 1) (tar (cons s y)
+                                                                (lambda (p) (r p))))
+                                       (else (tar (n (list (list s) 8 (list (cdr x)) 7 (list 0 3) (list y)) i)
+                                                  (lambda (p) (r p))))))
+                      ((equal? (wut y) 1) (raise 12))
+                      ((equal? o 6) (tar (n (list
+                                              (list s)
+                                              2
+                                              (list 0 1)
+                                              2
+                                              (list 1 (list (car y)) (list (cdr y)))
+                                              (list 1 0)
+                                              2
+                                              (list 1 2 3)
+                                              (list 1 0)
+                                              4
+                                              4
+                                              (list x))
+                                            i)
+                                         (lambda (p) (r p))))
+                      (else (raise 13)))))))))))))
+```

--- a/docs/community-projects/nock-implementations/swift.md
+++ b/docs/community-projects/nock-implementations/swift.md
@@ -1,0 +1,366 @@
+---
+navhome: /docs/
+title: Swift
+sort: 10
+next: true
+---
+
+# Swift
+
+```swift
+import Foundation
+//  1   ::  A noun is an atom or a cell.
+//  2   ::  An atom is a natural number.
+//  3   ::  A cell is an ordered pair of nouns.
+//  4
+//  5   ::  nock(a)             *a
+//  6   ::  [a b c]             [a [b c]]
+//  7
+//  8   ::  ?[a b]              0
+//  9   ::  ?a                  1
+// 10   ::  +[a b]              +[a b]
+// 11   ::  +a                  1 + a
+// 12   ::  =[a a]              0
+// 13   ::  =[a b]              1
+// 14   ::  =a                  =a
+// 15
+// 16   ::  /[1 a]              a
+// 17   ::  /[2 a b]            a
+// 18   ::  /[3 a b]            b
+// 19   ::  /[(a + a) b]        /[2 /[a b]]
+// 20   ::  /[(a + a + 1) b]    /[3 /[a b]]
+// 21   ::  /a                  /a
+// 22
+// 23   ::  *[a [b c] d]        [*[a b c] *[a d]]
+// 24
+// 25   ::  *[a 0 b]            /[b a]
+// 26   ::  *[a 1 b]            b
+// 27   ::  *[a 2 b c]          *[*[a b] *[a c]]
+// 28   ::  *[a 3 b]            ?*[a b]
+// 29   ::  *[a 4 b]            +*[a b]
+// 30   ::  *[a 5 b]            =*[a b]
+// 31
+// 32   ::  *[a 6 b c d]        *[a 2 [0 1] 2 [1 c d] [1 0] 2 [1 2 3] [1 0] 4 4 b]
+// 33   ::  *[a 7 b c]          *[a 2 b 1 c]
+// 34   ::  *[a 8 b c]          *[a 7 [[7 [0 1] b] 0 1] c]
+// 35   ::  *[a 9 b c]          *[a 7 c 2 [0 1] 0 b]
+// 36   ::  *[a 10 [b c] d]     *[a 8 c 7 [0 3] d]
+// 37   ::  *[a 10 b c]         *[a c]
+// 38
+// 39   ::  *a                  *a
+
+//  1   ::  A noun is an atom or a cell.
+public indirect enum Noun: IntegerLiteralConvertible, ArrayLiteralConvertible, Equatable, Hashable, CustomStringConvertible
+{
+    //  2   ::  An atom is a natural number.
+    public typealias ATOM = UIntMax
+    
+    case Atom(ATOM)
+    //  3   ::  A cell is an ordered pair of nouns.
+    case Cell(Noun, Noun)
+    case Invalid
+    
+    public static var YES: Noun { return .Atom(0) }
+    public static var NO: Noun  { return .Atom(1) }
+    
+    public init(_ noun: Noun) { self = noun }
+    
+    //  6   ::  [a b c]          [a [b c]]
+    public init(_ nouns: [Noun]) {
+        self = .Invalid
+        if nouns.count > 0 {
+            var reverse = nouns.reverse().generate()
+            self = reverse.next()!
+            while let n = reverse.next() {
+                self = .Cell(n, self)
+            }
+        }
+    }
+    
+    // protocol IntegerLiteralConvertible
+    public typealias IntegerLiteralType = ATOM
+    public init(integerLiteral value: IntegerLiteralType) {
+        self = .Atom(value)
+    }
+    
+    // protocol ArrayLiteralConvertible
+    public typealias Element = Noun
+    public init(arrayLiteral elements: Element...) {
+        self = Noun(elements)
+    }
+    
+    // Array subscript
+    public subscript(axis: ATOM) -> Noun {
+        return fas(.Cell(.Atom(axis), self))
+    }
+    
+    // protocol Hashable
+    public var hashValue: Int {
+        //return self.description.hashValue
+        switch self {
+        case let .Atom(a):
+            return a.hashValue
+        case let .Cell(a, b):
+            return (5381 + 31 &* a.hashValue) &+ b.hashValue
+        default:
+            abort()
+        }
+    }
+
+    // protocol CustomStringConvertible
+    public var description: String {
+        return describe()
+    }
+    
+    private func describe(depth: Int = 0) -> String {
+        var sub = ""
+        let next = depth+1
+        switch self {
+        case .Invalid:
+            return "[%INVALID%]"
+        case let .Atom(atom):
+            return "\(atom)"
+        case let .Cell(.Cell(a, b), c):
+            sub =  "[\(a.describe(next)) \(b.describe(next))] \(c.describe(next))"
+        case let .Cell(a, b):
+            sub = "\(a.describe(next)) \(b.describe(next))"
+        }
+        return depth == 0 ? "[\(sub)]" : sub
+    }
+}
+
+// protocol Equatable
+public func == (left: Noun, right: Noun) -> Bool
+{
+    switch (left, right) {
+    case let (.Atom(lhs), .Atom(rhs)):          return lhs == rhs
+    case let (.Cell(lp, lq), .Cell(rp, rq)):    return lp == rp && lq == rq
+    case (.Invalid, .Invalid):                  return true
+    default:                                    return false
+    }
+}
+
+public func wut(noun: Noun) -> Noun
+{
+    switch noun {
+        //  8   ::  ?[a b]           0
+    case .Cell:
+        return Noun.YES
+    case .Atom:
+        //  9   ::  ?a               1
+        return Noun.NO
+    default:
+        //return wut(noun)
+        abort()
+    }
+}
+
+public func lus(noun: Noun) -> Noun
+{
+    if case let .Atom(a) = noun {
+        // 11   ::  +a               1 + a
+        return .Atom(1+a)
+    }
+    // 10   ::  +[a b]           +[a b]
+    //return lus(noun)
+    abort()
+}
+
+public func tis(noun: Noun) -> Noun
+{
+    if case let .Cell(a, b) = noun {
+        // 12   ::  =[a a]           0
+        // 13   ::  =[a b]           1
+        return (a == b) ? Noun.YES : Noun.NO
+    }
+    // 14   ::  =a               =a
+    //return tis(noun)
+    abort()
+}
+
+public func fas(noun: Noun) -> Noun
+{
+    switch noun {
+        // 16   ::  /[1 a]           a
+    case let .Cell(1, a):
+        return a
+        // 17   ::  /[2 a b]         a
+    case let .Cell(2, .Cell(a, _)):
+        return a
+        // 18   ::  /[3 a b]         b
+    case let .Cell(3, .Cell(_, b)):
+        return b
+        // 19   ::  /[(a + a) b]        /[2 /[a b]]
+        // 20   ::  /[(a + a + 1) b]    /[3 /[a b]]
+    case let .Cell(.Atom(axis), tree):
+        let inner = Noun.Atom(axis / 2)
+        let outer = Noun.Atom(2 + (axis % 2))
+        return fas(.Cell(outer, fas(.Cell(inner, tree))))
+    default:
+        // 21   ::  /a                  /a
+        //return fas(noun)
+        abort()
+    }
+}
+
+public func tar(noun: Noun) -> Noun
+{
+    switch noun {
+    case let .Cell(a, formula):
+        switch formula {
+            // 23   ::  *[a [b c] d]     [*[a b c] *[a d]]
+        case let .Cell(.Cell(b, c), d):
+            return .Cell(tar([a, b, c]), tar([a, d]))
+            
+            // 25   ::  *[a 0 b]         /[b a]
+        case let .Cell(0, b):
+            return fas([b, a])
+            
+            // 26   ::  *[a 1 b]         b
+        case let .Cell(1, b):
+            return b
+            
+            // 27   ::  *[a 2 b c]       *[*[a b] *[a c]]
+        case let .Cell(2, .Cell(b, c)):
+            return tar([tar([a, b]), tar([a, c])])
+            
+            // 28   ::  *[a 3 b]         ?*[a b]
+        case let .Cell(3, b):
+            return wut(tar([a, b]))
+            
+            // 29   ::  *[a 4 b]         +*[a b]
+        case let .Cell(4, b):
+            return lus(tar([a, b]))
+            
+            // 30   ::  *[a 5 b]         =*[a b]
+        case let .Cell(5, b):
+            return tis(tar([a, b]))
+            
+            // 32   ::  *[a 6 b c d]     *[a 2 [0 1] 2 [1 c d] [1 0] 2 [1 2 3] [1 0] 4 4 b]
+        case let .Cell(6, .Cell(b, .Cell(c, d))):
+            return tar([a, 2, [0, 1], 2, [1, c, d], [1, 0], 2, [1, 2, 3], [1, 0], 4, 4, b])
+            
+            // 33   ::  *[a 7 b c]       *[a 2 b 1 c]
+        case let .Cell(7, .Cell(b, c)):
+            return tar([a, 2, b, 1, c])
+            
+            // 34   ::  *[a 8 b c]       *[a 7 [[7 [0 1] b] 0 1] c]
+        case let .Cell(8, .Cell(b, c)):
+            return tar([a, 7, [[7, [0, 1], b], 0, 1], c])
+            
+            // 35   ::  *[a 9 b c]       *[a 7 c 2 [0 1] 0 b]
+        case let .Cell(9, .Cell(b, c)):
+            return tar([a, 7, c, 2, [0, 1], 0, b])
+            
+            // 36   ::  *[a 10 [b c] d]  *[a 8 c 7 [0 3] d]
+        case let .Cell(10, .Cell(.Cell(_, c), d)):
+            return tar([a, 8, c, 7, [0, 3], d])
+            
+            // 37   ::  *[a 10 b c]      *[a c]
+        case let .Cell(10, .Cell(_, c)):
+            return tar([a, c]);
+            
+        default:
+            //return tar(noun)
+            abort()
+        }
+    default:
+        //return tar(noun)
+        abort()
+    }
+}
+
+
+public var nock_functions = Dictionary<Noun, Noun -> Noun>()
+
+public func dao(formula: Noun) -> Noun->Noun
+{
+    if let cached = nock_functions[formula] {
+        return cached
+    }
+    
+    let compiler = { () -> Noun -> Noun in
+        switch formula {
+        case let .Cell(.Cell(b, c), d):     // Distribution
+            let (p, q) = (dao(.Cell(b, c)), dao(d))
+            return { a in .Cell(p(a), q(a)) }
+        
+        case let .Cell(0, b):               // Axis
+            return { a in fas(.Cell(b, a)) }
+        
+        case let .Cell(1, b):               // Just
+            return { _ in b }
+        
+        case let .Cell(2, .Cell(b, c)):     // Fire
+            let (f, g) = (dao(b), dao(c))
+            return { a in dao(g(a))(f(a)) }
+        
+        case let .Cell(3, b):               // Depth
+            let f = dao(b)
+            return { a in wut(f(a)) }
+        
+        case let .Cell(4, b):               // Bump
+            let f = dao(b)
+            return { a in lus(f(a)) }
+        
+        case let .Cell(5, b):               // Same
+            let f = dao(b)
+            return { a in tis(f(a)) }
+        
+        case let .Cell(6, .Cell(b, .Cell(c, d))): // If
+            let (p, q, r) = (dao(b), dao(c), dao(d))
+            return { a in
+                switch p(a) {
+                case Noun.self.YES:
+                    return q(a)
+                case Noun.self.NO:
+                    return r(a)
+                default:
+                    return tar(.Cell(a, formula))
+                }
+            }
+        
+        case let .Cell(7, .Cell(b, c)):     // Compose
+            let (f, g) = (dao(b), dao(c))
+            return { a in g(f(a)) }
+        
+        case let .Cell(8, .Cell(b, c)):     // Push
+            let (f, g) = (dao(b), dao(c))
+            return { a in g(.Cell(f(a), a)) }
+        
+        case let .Cell(9, .Cell(b, c)):     // Call
+            let f = dao(c)
+            return { a in
+                let core = f(a)
+                let arm = dao(fas(.Cell(b, core)))
+                return arm(core)
+            }
+        
+        case let .Cell(10, .Cell(.Cell(_, c), d)): // Hint
+            let ignore = dao(c)
+            let f = dao(d)
+            return { a in ignore(a); return f(a) }
+        
+        case let .Cell(10, .Cell(_, c)):    // Hint
+            let f = dao(c)
+            return { a in f(a) }
+        
+        default:
+            return { a in tar(.Cell(a, formula)) }
+        }
+    }
+    
+    let r = compiler()
+    nock_functions[formula] = r
+    return r
+}
+
+public func nock(n: Noun) -> Noun
+{
+    if case let .Cell(a, b) = n {
+        let f = dao(b)
+        return f(a)
+    }
+    return nock(n)
+}
+```

--- a/docs/community-projects/string-processing.md
+++ b/docs/community-projects/string-processing.md
@@ -1,0 +1,17 @@
+---
+navhome: /docs/
+sort: 3
+title: A Hoon string processing library
+next: true
+---
+
+
+# A Hoon string processing library
+
+<div>
+
+<h5><a href="https://github.com/Fang-/urbit-string">A Hoon string processing library</a>
+<br />
+<code>~palfun-foslup</code></h5>
+
+</div>

--- a/docs/community-projects/talkbot.md
+++ b/docs/community-projects/talkbot.md
@@ -1,0 +1,17 @@
+---
+navhome: /docs/
+sort: 2
+title: ~talkbot: the one and only
+next: true
+---
+
+
+# ~talkbot: the one and only
+
+<div>
+
+<h5><a href="https://github.com/Fang-/talkbot">~talkbot, the one and only</a>
+<br />
+<code>~palfun-foslup</code></h5>
+
+</div>

--- a/docs/community-projects/yint.md
+++ b/docs/community-projects/yint.md
@@ -1,0 +1,17 @@
+---
+navhome: /docs/
+sort: 1
+title: Yint: A Tiny MUD
+next: true
+---
+
+
+# Yint: A TinyMUD Compatible MUD Server
+
+<div>
+
+<h5><a href="https://github.com/ponnys-podfer/yint">Yint: A TinyMUD Compatible MUD server</a>
+<br />
+<code>~ponnys-podfer</code></h5>
+
+</div>

--- a/docs/hoon/advanced.md
+++ b/docs/hoon/advanced.md
@@ -1,6 +1,6 @@
 ---
 navhome: /docs/
-sort: 17
+sort: 16
 next: true
 title: Advanced types
 ---

--- a/docs/hoon/demo.md
+++ b/docs/hoon/demo.md
@@ -1,6 +1,6 @@
 ---
 navhome: /docs/
-sort: 10
+sort: 11
 next: true
 title: Demo
 ---

--- a/docs/hoon/examples.md
+++ b/docs/hoon/examples.md
@@ -1,6 +1,6 @@
 ---
 navhome: /docs/
-sort: 18
+sort: 17
 title: Examples
 next: true
 ---

--- a/docs/hoon/exercises.md
+++ b/docs/hoon/exercises.md
@@ -1,6 +1,6 @@
 ---
 navhome: /docs/
-sort: 11
+sort: 18
 title: Exercises
 ---
 

--- a/docs/hoon/irregular.md
+++ b/docs/hoon/irregular.md
@@ -1,6 +1,6 @@
 ---
 navhome: /docs/
-sort: 21
+sort: 22
 title: Irregular forms
 comments: true
 ---

--- a/docs/hoon/mission.md
+++ b/docs/hoon/mission.md
@@ -1,6 +1,6 @@
 ---
 navhome: /docs/
-sort: 12
+sort: 10
 next: true
 title: Mission
 ---

--- a/docs/hoon/reference.md
+++ b/docs/hoon/reference.md
@@ -1,6 +1,6 @@
 ---
 navhome: /docs/
-sort: 19
+sort: 21
 title: Twig reference
 ---
 

--- a/docs/hoon/syntax.md
+++ b/docs/hoon/syntax.md
@@ -1,6 +1,6 @@
 ---
 navhome: /docs/
-sort: 14
+sort: 12
 next: true
 title: Syntax
 ---

--- a/docs/hoon/troubleshooting.md
+++ b/docs/hoon/troubleshooting.md
@@ -1,6 +1,6 @@
 ---
 navhome: /docs/
-sort: 12
+sort: 19
 title: Troubleshooting
 next: true
 ---

--- a/docs/hoon/twig.md
+++ b/docs/hoon/twig.md
@@ -1,6 +1,6 @@
 ---
 navhome: /docs/
-sort: 16
+sort: 14
 next: true
 title: Expressions
 ---

--- a/docs/nock.md
+++ b/docs/nock.md
@@ -8,6 +8,4 @@ title: Nock
 
 Nock is our nano-VM.  If you're into combinators or want to understand the foundation of Urbit, dive in.
 
-Building a Nock interpreter is a fun exercise, as you can see in the [implementations](nock/implementations)
-
 <list/>

--- a/docs/nock/implementations.md
+++ b/docs/nock/implementations.md
@@ -1,9 +1,214 @@
 ---
 navhome: /docs/
-sort: 4
-title: Implementations
+title: Implementation
+sort: 6
+next: true
 ---
 
-# Implementations
+# C implementation
 
-<list src="."></list>
+The actual production Nock interpreter.  Note gotos for tail-call elimination,
+and manual reference counting.  More about the C environment can be found
+in the [runtime system documentation](../../../runtime).
+
+```
+/* nock(): produce .*(bus fol).  Do not virtualize.
+*/
+static u3_noun
+nock(u3_noun bus, u3_noun fol)
+{
+  u3_noun hib, gal;
+
+  while ( 1 ) {
+    hib = u3h(fol);
+    gal = u3t(fol);
+
+    if ( c3y == u3r_du(hib) ) {
+      u3_noun poz, riv;
+
+      poz = nock(u3k(bus), u3k(hib));
+      riv = nock(bus, u3k(gal));
+
+      u3a_lose(fol);
+      return u3i_cell(poz, riv);
+    }
+    else switch ( hib ) {
+      default: return u3m_bail(c3__exit);
+
+      case 0: {
+        if ( c3n == u3r_ud(gal) ) {
+          return u3m_bail(c3__exit);
+        }
+        else {
+          u3_noun pro = u3k(u3at(gal, bus));
+
+          u3a_lose(bus); u3a_lose(fol);
+          return pro;
+        }
+      }
+      c3_assert(!"not reached");
+
+      case 1: {
+        u3_noun pro = u3k(gal);
+
+        u3a_lose(bus); u3a_lose(fol);
+        return pro;
+      }
+      c3_assert(!"not reached");
+
+      case 2: {
+        u3_noun nex = nock(u3k(bus), u3k(u3t(gal)));
+        u3_noun seb = nock(bus, u3k(u3h(gal)));
+
+        u3a_lose(fol);
+        bus = seb;
+        fol = nex;
+        continue;
+      }
+      c3_assert(!"not reached");
+
+      case 3: {
+        u3_noun gof, pro;
+
+        gof = nock(bus, u3k(gal));
+        pro = u3r_du(gof);
+
+        u3a_lose(gof); u3a_lose(fol);
+        return pro;
+      }
+      c3_assert(!"not reached");
+
+      case 4: {
+        u3_noun gof, pro;
+
+        gof = nock(bus, u3k(gal));
+        pro = u3i_vint(gof);
+
+        u3a_lose(fol);
+        return pro;
+      }
+      c3_assert(!"not reached");
+
+      case 5: {
+        u3_noun wim = nock(bus, u3k(gal));
+        u3_noun pro = u3r_sing(u3h(wim), u3t(wim));
+
+        u3a_lose(wim); u3a_lose(fol);
+        return pro;
+      }
+      c3_assert(!"not reached");
+
+      case 6: {
+        u3_noun b_gal, c_gal, d_gal;
+
+        u3x_trel(gal, &b_gal, &c_gal, &d_gal);
+        {
+          u3_noun tys = nock(u3k(bus), u3k(b_gal));
+          u3_noun nex;
+
+          if ( 0 == tys ) {
+            nex = u3k(c_gal);
+          } else if ( 1 == tys ) {
+            nex = u3k(d_gal);
+          } else return u3m_bail(c3__exit);
+
+          u3a_lose(fol);
+          fol = nex;
+          continue;
+        }
+      }
+      c3_assert(!"not reached");
+
+      case 7: {
+        u3_noun b_gal, c_gal;
+
+        u3x_cell(gal, &b_gal, &c_gal);
+        {
+          u3_noun bod = nock(bus, u3k(b_gal));
+          u3_noun nex = u3k(c_gal);
+
+          u3a_lose(fol);
+          bus = bod;
+          fol = nex;
+          continue;
+        }
+      }
+      c3_assert(!"not reached");
+
+      case 8: {
+        u3_noun b_gal, c_gal;
+
+        u3x_cell(gal, &b_gal, &c_gal);
+        {
+          u3_noun heb = nock(u3k(bus), u3k(b_gal));
+          u3_noun bod = u3nc(heb, bus);
+          u3_noun nex = u3k(c_gal);
+
+          u3a_lose(fol);
+          bus = bod;
+          fol = nex;
+          continue;
+        }
+      }
+      c3_assert(!"not reached");
+
+      case 9: {
+        u3_noun b_gal, c_gal;
+
+        u3x_cell(gal, &b_gal, &c_gal);
+        {
+          u3_noun seb = nock(bus, u3k(c_gal));
+
+          if ( c3n == u3r_ud(b_gal) ) {
+            return u3m_bail(c3__exit);
+          }
+          else {
+            u3_noun nex = u3k(u3at(b_gal, seb));
+
+            u3a_lose(fol);
+            bus = seb;
+            fol = nex;
+            continue;
+          }
+        }
+      }
+      c3_assert(!"not reached");
+
+      case 10: {
+        u3_noun p_gal, q_gal;
+
+        u3x_cell(gal, &p_gal, &q_gal);
+        {
+          u3_noun zep, hod, nex;
+
+          if ( c3y == u3r_du(p_gal) ) {
+            u3_noun b_gal = u3h(p_gal);
+            u3_noun c_gal = u3t(p_gal);
+            u3_noun d_gal = q_gal;
+
+            zep = u3k(b_gal);
+            hod = nock(u3k(bus), u3k(c_gal));
+            nex = u3k(d_gal);
+          }
+          else {
+            u3_noun b_gal = p_gal;
+            u3_noun c_gal = q_gal;
+
+            zep = u3k(b_gal);
+            hod = u3_nul;
+            nex = u3k(c_gal);
+          }
+
+          u3a_lose(zep);
+          u3a_lose(hod);
+
+          return nock(bus, nex);
+        }
+      }
+      c3_assert(!"not reached");
+    }
+  }
+}
+```
+
+Building a Nock interpreter in another language is a fun exercise. Check out our community Nock implementations [here](../../community-projects/nock-implementations)!


### PR DESCRIPTION
Changes:
* Urbyte urls back to docs/byte (to not break existing links)
* Community projects section added — includes Elliot’s MUD, Fang’s
~talkbot and string processing library, and our community Nock
implementations (more below)
* Community docs section moved from previous ‘Learn’ section to own kid
of /docs/
* Both community sections placed at bottom of grid, after Arvo Hoon Nock sections
* Only production C Nock interpreter in Nock section; rest moved to
community projects section, linked to in production interpreter doc
* Opening /docs/ paragraph column width changed to col-md-10
* Better Hoon docs sort order