### PR TITLE
Update Ubuntu reqs

### DIFF
--- a/docs/using/install.md
+++ b/docs/using/install.md
@@ -74,9 +74,12 @@ Which can usually be installed with the following one-liners:
     # Mac OS X [Macports]
     $ sudo port install gmp libsigsegv openssl autoconf automake cmake
 
-    # Ubuntu or Debian
+    # Debian (Incomplete, missing libuv1)
     $ sudo apt-get install libgmp3-dev libsigsegv-dev openssl libssl-dev libncurses5-dev make exuberant-ctags automake autoconf libtool g++ ragel cmake re2c libcurl4-gnutls-dev
 
+    # Ubuntu
+    $ sudo apt-get install libgmp3-dev libsigsegv-dev openssl libssl-dev libncurses5-dev make exuberant-ctags automake autoconf libtool g++ ragel cmake re2c libcurl4-gnutls-dev python libuv1-dev
+    
     # Fedora
     $ sudo dnf install gcc gcc-c++ gmp-devel openssl-devel openssl ncurses-devel libsigsegv-devel ctags automake autoconf libtool ragel cmake re2c libcurl-devel
 


### PR DESCRIPTION
Debian doesn't provide libuv1, but Ubuntu does.  So I separated Debian and Ubuntu and added 'python libuv1-dev' which does result in a good build on Ubuntu.  The Debian is incomplete though, I don't know how to get libuv1 easily onto Debian.