### PR TITLE
Arvo network message doc: Boot a comet, not a moon

### DIFF
--- a/docs/arvo/network.md
+++ b/docs/arvo/network.md
@@ -174,10 +174,10 @@ Run it with these commands:
     >=
 
 Replace `~sampel-sipnym` with another urbit. The easiest thing to do is
-to start a moon, a sub-identity of your urbit. If you don't know how to
-start a moon, see [the user admin section](/docs/using/admin/). Don't
-forget to start the `%examples-pong` app on that urbit, too. You should
-see, on the foreign urbit, this output:
+to start a comet, a free and disposable Urbit identity. If you don't know
+how to start a comet, see [the user setup section](/docs/using/setup/).
+Don't forget to start the `%examples-pong` app on that urbit, too. You 
+should see, on the foreign urbit, this output:
 
     [%receiving 'howdy']
 


### PR DESCRIPTION
A number of developers new to Urbit have been reading these docs and
running these examples, only to realize that booting a moon ships their
planets for unknown reasons. This is a simple doc fix that can push
people to comets in the meantime. And this is probably easier to do
than starting a moon anyways.

But maybe all of these docs should point people towards doing these on
fake ships? In an ideal Urbit world, dumb examples never sink your
planet, but unfortunately this can be the case now, and perhaps we
should make that explicit to early developer adopters.