### PR TITLE
Small Tweaks to Docs

### DIFF
--- a/docs/arvo/basic.md
+++ b/docs/arvo/basic.md
@@ -283,26 +283,26 @@ Lookup each of these expressions (and all others!) in the [Twig Expressions](../
 
 1.  There are two syntaxes for writing Hoon: tallform and wideform.
 
-In tallform, expressions are formed with either two spaces or a line
-break separating both a rune from its children and each of its children
-from one another. We use tallform when writing multiline expressions.
+    In tallform, expressions are formed with either two spaces or a line
+    break separating both a rune from its children and each of its children
+    from one another. We use tallform when writing multiline expressions.
 
-For more concise expressions, we use wideform, which is always a single
-line. Wideform can be used inside tallform expressions, but not vice
-versa.
+    For more concise expressions, we use wideform, which is always a single
+    line. Wideform can be used inside tallform expressions, but not vice
+    versa.
 
-Wideform expressions are formed with a rune followed by `()` containing
-its children, all of which are separated by a single space. For example,
-to make a cell of two elements:
+    Wideform expressions are formed with a rune followed by `()` containing
+    its children, all of which are separated by a single space. For example,
+    to make a cell of two elements:
 
       :-(a b)
 
-We've already seen wideform in action, for example with
-`=((mod b 3) 0)`. In this case, `=` is actually an irregular form of
-`.=`, which tests its two children for equality.
+    We've already seen wideform in action, for example with
+    `=((mod b 3) 0)`. In this case, `=` is actually an irregular form of
+    `.=`, which tests its two children for equality.
 
-Surrounding a function with `()` is an irregular wide form syntax for
-calling a function with *N* arguments. More on this later.
+    Surrounding a function with `()` is an irregular wide form syntax for
+    calling a function with *N* arguments. More on this later.
 
 2.  For a set of multiple arguments following `|=` ('[bartis](../../hoon/twig/bar-core/tis-gate/)'), use `{` 'kel' and `}` 'ker.' For example: `{a/@u b/@u}`.
 

--- a/docs/arvo/basic.md
+++ b/docs/arvo/basic.md
@@ -293,9 +293,7 @@ Lookup each of these expressions (and all others!) in the [Twig Expressions](../
 
     Wideform expressions are formed with a rune followed by `()` containing
     its children, all of which are separated by a single space. For example,
-    to make a cell of two elements:
-
-    `:-(a b)`
+    to make a cell of two elements, use `:-(a b)`.
 
     We've already seen wideform in action, for example with
     `=((mod b 3) 0)`. In this case, `=` is actually an irregular form of

--- a/docs/arvo/basic.md
+++ b/docs/arvo/basic.md
@@ -295,7 +295,7 @@ Lookup each of these expressions (and all others!) in the [Twig Expressions](../
     its children, all of which are separated by a single space. For example,
     to make a cell of two elements:
 
-      :-(a b)
+    `:-(a b)`
 
     We've already seen wideform in action, for example with
     `=((mod b 3) 0)`. In this case, `=` is actually an irregular form of

--- a/docs/arvo/basic.md
+++ b/docs/arvo/basic.md
@@ -304,12 +304,14 @@ We've already seen wideform in action, for example with
 Surrounding a function with `()` is an irregular wide form syntax for
 calling a function with *N* arguments. More on this later.
 
-2.  `:-` makes a cell of values. The irregular wide form of this is
+2.  For a set of multiple arguments following `|=` ('[bartis](../../hoon/twig/bar-core/tis-gate/)'), use `{` 'kel' and `}` 'ker.' For example: `{a/@u b/@u}`.
+
+3.  `:-` makes a cell of values. The irregular wide form of this is
     `[a b]`, with two expressions separated by a single space. While the
     regular form of this rune takes a fixed number of children (two),
     its irregular wide form can accept *N* expressions: `[a1..an]`
 
-3.  Cords are one datatype for text in Hoon. They're just a big atom
+4.  Cords are one datatype for text in Hoon. They're just a big atom
     formed from adjacent unicode bytes -- a "c string". To produce a
     cord, enclose text within single quotes. To set the type of an
     argument to a cord, use `@t`.

--- a/docs/arvo/basic.md
+++ b/docs/arvo/basic.md
@@ -307,7 +307,7 @@ Lookup each of these expressions (and all others!) in the [Twig Expressions](../
 3.  `:-` makes a cell of values. The irregular wide form of this is
     `[a b]`, with two expressions separated by a single space. While the
     regular form of this rune takes a fixed number of children (two),
-    its irregular wide form can accept *N* expressions: `[a1..an]`
+    its irregular wide form can accept *N* expressions: `[a1..an]`.
 
 4.  Cords are one datatype for text in Hoon. They're just a big atom
     formed from adjacent unicode bytes -- a "c string". To produce a

--- a/docs/arvo/basic.md
+++ b/docs/arvo/basic.md
@@ -304,12 +304,12 @@ We've already seen wideform in action, for example with
 Surrounding a function with `()` is an irregular wide form syntax for
 calling a function with *N* arguments. More on this later.
 
-1.  `:-` makes a cell of values. The irregular wide form of this is
+2.  `:-` makes a cell of values. The irregular wide form of this is
     `[a b]`, with two expressions separated by a single space. While the
     regular form of this rune takes a fixed number of children (two),
     its irregular wide form can accept *N* expressions: `[a1..an]`
 
-2.  Cords are one datatype for text in Hoon. They're just a big atom
+3.  Cords are one datatype for text in Hoon. They're just a big atom
     formed from adjacent unicode bytes -- a "c string". To produce a
     cord, enclose text within single quotes. To set the type of an
     argument to a cord, use `@t`.

--- a/docs/arvo/subject.md
+++ b/docs/arvo/subject.md
@@ -82,7 +82,7 @@ accessible.
 **Exercises**:
 
 -   Pass `++sum` its arguments (`2.000` and `3.000`) from the
-    commandline.
+    command line.
 
 -   Comment out all of the arms of the `|%`. Now add another arm and
     call it `++add`, have it accept two arguments and procduce 42


### PR DESCRIPTION
I made a few small typographical fixes to the Arvo tutorial. I also added an extra hint to the **Basic Hoon** page that I thought should have been there when first working through the tutorial myself.