### PR TITLE
|sync examples had two on one line.

### DIFF
--- a/docs/using/filesystem.md
+++ b/docs/using/filesystem.md
@@ -143,7 +143,9 @@ that issued a star).
 
 **Examples:**
 
-    |sync %home-local ~dozbud %home |sync %home ~doznec
+    |sync %home-local ~dozbud %home
+
+    |sync %home ~doznec
 
 ### `|unsync desk plot [plot-desk]`
 


### PR DESCRIPTION
This patch got added to another pr I sent earlier.  Here it is by itself.