### PR TITLE
Fixes #180, Broken examples on the Hoon Map Library Page

### DIFF
--- a/docs/hoon/library/2i.md
+++ b/docs/hoon/library/2i.md
@@ -18,8 +18,8 @@ pairs. The contained arms inherit it's sample map, `a`.
 
 `a` is a map.
 
-    > ~(. by (mo (limo [%a 1] [%b 2] ~)))
-    <19.irb [nlr([p={%a %b} q=@ud]) <414.rvm 101.jzo 1.ypj %164>]>
+    > ~(. by (my [%a 1] [%b 2] ~))
+    <22.znh {a/nlr({p/?($a $b) q/@ud}) <409.ofg 110.xht 1.ztu $151>}>
 
 ------------------------------------------------------------------------
 
@@ -44,10 +44,10 @@ Computes the logical AND on the results of slamming every element in map
 
 `b` is a wet gate.
 
-    > =b (mo `(list {@t *})`[['a' 1] ['b' [2 3]] ~])
+    > =b (my [['a' 1] ['b' [2 3]] ~])
     > (~(all by b) |=(a/* ?@(a & |)))
     %.n
-    > =a (mo `(list {@t @u})`[['a' 1] ['b' 2] ['c' 3] ['d' 4] ['e' 5] ~])
+    > =a (my [['a' 1] ['b' 2] ['c' 3] ['d' 4] ['e' 5] ~])
     > (~(all by a) |=(a/@ (lte a 6)))
     %.y
     > (~(all by a) |=(a/@ (lte a 4)))
@@ -74,11 +74,11 @@ gate `b`. Produces a loobean.
 
 `b` is a wet gate.
 
-    > =b (mo `(list {@t *})`[['a' 1] ['b' [2 3]] ~])
-    > (~(all by b) |=(a/* ?@(a & |)))
+    > =b (my [['a' 1] ['b' [2 3]] ~])
+    > (~(any by b) |=(a/* ?@(a & |)))
     %.y
-    > =a (mo `(list {@t @u})`[['a' 1] ['b' 2] ['c' 3] ['d' 4] ['e' 5] ~])
-    > (~(any by a) |=(a=@ (lte a 4)))
+    > =a (my [['a' 1] ['b' 2] ['c' 3] ['d' 4] ['e' 5] ~])
+    > (~(any by a) |=(a/@ (lte a 4)))
     %.y
 
 ------------------------------------------------------------------------
@@ -111,9 +111,9 @@ Produces map `a` with the element located at key `b` removed.
 
 `b` is a key as a noun.
 
-        > =b (mo `(list {@t *})`[['a' 1] ['b' [2 3]] ~])
-        > (~(del by b) `a`)
-        {[p=`b` q=[2 3]]}
+        > =b (my [['a' 1] ['b' [2 3]] ~])
+        > (~(del by b) 'a')
+        {[p='b' q=[2 3]]}
 
 ------------------------------------------------------------------------
 
@@ -139,8 +139,8 @@ Produce the axis of key `b` within map `a`.
 
 `b` is a key as a noun.
 
-        > =b (mo `(list {@t *})`[['a' 1] ['b' [2 3]] ~])  
-        > (~(dig by b) `b`)
+        > =b (my [['a' 1] ['b' [2 3]] ~])  
+        > (~(dig by b) 'b')
         [~ 2]
 
 ------------------------------------------------------------------------
@@ -165,10 +165,10 @@ Insert a list of key-value pairs `b` into map `a`.
 
 `b` is a list of cells of key-value nouns `p` and `q`.
 
-    > =a (mo `(list {@t *})`[[`a` 1] [`b` 2] ~])
-    > =b `(list {@t *})`[[`c` 3] [`d` 4] ~]
+    > =a (my [['a' 1] ['b' 2] ~])
+    > =b [['c' 3] ['d' 4] ~]
     > (~(gas by a) b)
-    {[p=`d` q=4] [p=`a` q=1] [p=`c` q=3] [p=`b` q=2]}
+    {[p='d' q=4] [p='a' q=1] [p='c' q=3] [p='b' q=2]}
 
 ------------------------------------------------------------------------
 
@@ -194,8 +194,8 @@ Produce the unit value of the value located at key `b` within map `a`.
 
 `b` is a key as a noun
 
-        > =b (mo `(list {@t *})`[['a' 1] ['b' [2 3]] ~])  
-        > (~(get by b) `b`)
+        > =b (my [['a' 1] ['b' [2 3]] ~])  
+        > (~(get by b) 'b')
         [~ [2 3]]
 
 ------------------------------------------------------------------------
@@ -215,7 +215,7 @@ does not exist.
 
 `b` is a key.
 
-        > =m (mo `(list {@t *})`[['a' 1] ['b' 2] ~])
+        > =m (my [['a' 1] ['b' 2] ~])
         > m
         {[p='a' q=1] [p='b' q=2]}
         > (~(get by m) 'a')
@@ -244,10 +244,10 @@ loobean.
 
 `b` is a key as a noun.
 
-        > =b (mo `(list {@t *})`[['a' 1] ['b' [2 3]] ~])  
-        > (~(has by b) `b`)
+        > =b (my [['a' 1] ['b' [2 3]] ~])  
+        > (~(has by b) 'b')
         %.y
-        > (~(has by b) `c`)
+        > (~(has by b) 'c')
         %.n
 
 ------------------------------------------------------------------------
@@ -285,27 +285,27 @@ different values, the element from map `b` is used.
 
 `b` is a map.
 
-        > =n (mo `(list {@t *})`[['a' 1] ['c' 3] ~])
+        > =n (my [['a' 1] ['c' 3] ~])
         > n
         {[p='a' q=1] [p='c' q=3]}
         > m
         {[p='a' q=1] [p='b' q=2]}
         > (~(int by m) n)
         {[p='a' q=1]}
-        ~ravpel-holber/try=> =p (mo `(list {@t *})`[['a' 2] ['b' 2] ~])
+        > =p (my [['a' 2] ['b' 2] ~])
         > p
         {[p='a' q=2] [p='b' q=2]}
         > (~(int by p) n)
-        {[p='a' q=2]}
-        > =q (mo `(list {@t *})`[['a' 2] ['c' 2] ~])
+        {[p='a' q=1]}
+        > =q (my [['a' 2] ['c' 2] ~])
         > q
-        {[p='a' q=2] [p='b' q=2]}
+        {[p='a' q=2] [p='c' q=2]}
         > (~(int by p) q)
-        {[p='a' q=2] [p='b' q=2]}
-        > =o (mo `(list {@t *})`[['c' 3] ['d' 4] ~])
+        {[p='a' q=2]}
+        > =o (my [['c' 3] ['d' 4] ~])
         > (~(int by m) o)
         {}
-       
+
 
 ------------------------------------------------------------------------
 
@@ -471,6 +471,7 @@ Produces the list of all elements in map `a` that is prepended to list
 
 `b` is a list.
 
+    > m
     {[p='a' q=1] [p='b' q=2]}
     > `*`m
     [[98 2] [[97 1] 0 0] 0]
@@ -521,9 +522,9 @@ shares a key with `a`, the tuple from `b` is preserved.
     > (~(uni by m) ~)
     {[p='a' q=1] [p='b' q=2]}
     > n
-    {[p='a' q=1] [p='c' q=9]}
+    {[p='a' q=1] [p='c' q=3]}
     > (~(uni by o) n)
-    {[p='d' q=4] [p='a' q=1] [p='c' q=9]}
+    {[p='d' q=4] [p='a' q=1] [p='c' q=3]}
 
 ------------------------------------------------------------------------
 
@@ -547,10 +548,13 @@ produces a noun (the new value).
 
     > m
     {[p='a' q=1] [p='b' q=2]}
+
     > (~(urn by m) |=(a=[p=* q=*] q.a))
     {[p='a' q=1] [p='b' q=2]}
+
     > (~(urn by m) |=(a=[p=* q=*] 7))
     {[p='a' q=7] [p='b' q=7]}
+
     > (~(urn by m) |=(a=[p=* q=*] p.a))
     {[p='a' q=97] [p='b' q=98]}
 

--- a/docs/hoon/library/2i.md
+++ b/docs/hoon/library/2i.md
@@ -549,13 +549,13 @@ produces a noun (the new value).
     > m
     {[p='a' q=1] [p='b' q=2]}
 
-    > (~(urn by m) |=(a=[p=* q=*] q.a))
+    > (~(urn by m) |=(a/(pair * *) q.a))
     {[p='a' q=1] [p='b' q=2]}
 
-    > (~(urn by m) |=(a=[p=* q=*] 7))
+    > (~(urn by m) |=(a/(pair * *) 7))
     {[p='a' q=7] [p='b' q=7]}
 
-    > (~(urn by m) |=(a=[p=* q=*] p.a))
+    > (~(urn by m) |=(a/(pair * *) p.a))
     {[p='a' q=97] [p='b' q=98]}
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
Update examples to use modern hoon. (mo is no longer supported. Use (my which is currently considered the proper way to do this.

Corrects a couple other small syntax errors which were preventing some of the examples from running correctly. (e.g. incorrect back tics instead of single quotes and using a / instead of = on line 81)

The **urn:by** examples still don't work for me and I don't know enough to figure out why. Here's what I get when I run them:

```
> m
{[p='a' q=1] [p='b' q=2]}
> (~(urn by m) |=(a=[p=* q=*] q.a))
/~zod/home/~2017.6.14..18.23.05..c35f/arvo/ford:<[1.211 24].[1.211 52]>
-find.$
ford: build failed ~[/g/~zod/use/dojo/~zod/inn/hand /g/~zod/use/hood/~zod/out/dojo/drum/phat/~zod/dojo /d //term/1]
> (~(urn by m) |=(a=[p=* q=*] 7))
/~zod/home/~2017.6.14..18.23.05..c35f/arvo/ford:<[1.211 24].[1.211 52]>
-find.$
ford: build failed ~[/g/~zod/use/dojo/~zod/inn/hand /g/~zod/use/hood/~zod/out/dojo/drum/phat/~zod/dojo /d //term/1]
> (~(urn by m) |=(a=[p=* q=*] p.a))
/~zod/home/~2017.6.14..18.23.05..c35f/arvo/ford:<[1.211 24].[1.211 52]>
-find.$
ford: build failed ~[/g/~zod/use/dojo/~zod/inn/hand /g/~zod/use/hood/~zod/out/dojo/drum/phat/~zod/dojo /d //term/1]

```