### PR TITLE
Adjusting Description of dot-tar

### DIFF
--- a/docs/hoon/twig/dot-nock/tar-nock.md
+++ b/docs/hoon/twig/dot-nock/tar-nock.md
@@ -5,7 +5,7 @@ sort: 1
 
 # `:nock  .*  "dottar"`
 
-`{$nock p/seed q/seed}`: evaluate with Nock `2`.
+`{$nock p/seed q/seed}`: Nock evaluation.
 
 ## Produces
 
@@ -16,6 +16,10 @@ Nock of formula `q` and subject `p`, with span `%noun`.
 Regular: *2-fixed*.
 
 ## Discussion
+
+The rune `.*` evaluates twigs `p` and `q` against the 
+Hoon subject, and then evaluates in Nock the latter 
+product against the former.
 
 Note that `:nock` can be used to bypass the type system,
 though its product contains no type information.  It's


### PR DESCRIPTION
There is a sense in which `.*` is like Nock 2, but I think that's misleading.  `p` and `q` are evaluated against the Hoon subject using Hoon rules, and then the latter product is evaluated against the former using Nock rules.  This isn't really Nock 2, which is, of course, entirely in Nock.  The current description confused me when I was first learning Nock.

This is a nitpick, but I think we can, and should, be a little more clear here.