### PR TITLE
Adds an Index page for the Standard Library. Fixes #98.

### DIFF
--- a/docs/hoon/library/1a.md
+++ b/docs/hoon/library/1a.md
@@ -4,7 +4,7 @@ navhome: /docs/
 
 
 # 1a: basic arithmetic
-### `++add`
+### <a name="add">`++add`</a>
 
 Add
 
@@ -43,7 +43,7 @@ Examples
     1.337
 
 ***
-### `++dec`
+### <a name="dec">`++dec`</a>
 
 Decrement
 
@@ -84,7 +84,7 @@ Examples
 
 
 ***
-### `++div`
+### <a name="div">`++div`</a>
 
 Divide
 
@@ -129,7 +129,7 @@ Examples
 
 
 ***
-### `++gte`
+### <a name="gte">`++gte`</a>
 
 Greater-than/equal
 
@@ -170,7 +170,7 @@ Examples
 
 
 ***
-### `++gth`
+### <a name="gth">`++gth`</a>
 
 Greater-than
 
@@ -210,7 +210,7 @@ Examples
 
 
 ***
-### `++lte`
+### <a name="lte">`++lte`</a>
 
 Less-than/equal
 
@@ -253,7 +253,7 @@ Examples
 
 
 ***
-### `++lth`
+### <a name="lth">`++lth`</a>
 
 Less-than
 
@@ -299,7 +299,7 @@ Examples
 
 
 ***
-### `++max`
+### <a name="max">`++max`</a>
 
 Maximum
 
@@ -340,7 +340,7 @@ Examples
 
 
 ***
-### `++min`
+### <a name="min">`++min`</a>
 
 Minimum
 
@@ -367,7 +367,7 @@ Source
       ^-  @
       ?:  (lth a b)  a
       b
-        
+
 Examples
 --------
 
@@ -381,7 +381,7 @@ Examples
 
 
 ***
-### `++mod`
+### <a name="mod">`++mod`</a>
 
 Modulus
 
@@ -408,7 +408,7 @@ Source
       ^-  @
       ?<  =(0 b)
       (sub a (mul b (div a b)))
-        
+
 
 Examples
 --------
@@ -421,7 +421,7 @@ Examples
 
 
 ***
-### `++mul`
+### <a name="mul">`++mul`</a>
 
 Multiply
 
@@ -450,19 +450,19 @@ Source
       |-
       ?:  =(0 a)  c
       $(a (dec a), c (add b c))
-        
+
 Examples
 --------
 
     > (mul 3 4)
-     12 
-    > (mul 0 1) 
+     12
+    > (mul 0 1)
     0
 
 
 
 ***
-### `++sub`
+### <a name="sub">`++sub`</a>
 
 Subtract
 

--- a/docs/hoon/library/1b.md
+++ b/docs/hoon/library/1b.md
@@ -4,7 +4,7 @@ navhome: /docs/
 
 
 # 1b: tree addressing
-### `++cap`
+### <a name="cap">`++cap`</a>
 
 Tree head
 
@@ -50,7 +50,7 @@ Examples
 
 
 ***
-### `++mas`
+### <a name="mas">`++mas`</a>
 
 Axis within head/tail?
 
@@ -100,7 +100,7 @@ Examples
 
 
 ***
-### `++peg`
+### <a name="peg">`++peg`</peg>
 
 Axis within axis
 

--- a/docs/hoon/library/1c.md
+++ b/docs/hoon/library/1c.md
@@ -5,7 +5,7 @@ navhome: /docs/
 
 # 1c: molds and mold builders
 
-### `++bloq`
+### <a name="bloq">`++bloq`</a>
 
 Blocksize
 
@@ -27,7 +27,7 @@ Examples
 
 ***
 
-### `++each`
+### <a name="each">`++each`</a>
 
 Mold of fork between two
 
@@ -49,7 +49,7 @@ Examples
     [%.y p='']
 
 ***
-### `++gate`
+### <a name="gate">`++gate`</a>
 
 Function
 
@@ -78,7 +78,7 @@ See also: `++lift`, `++cork`
 
 
 ***
-### `++list`
+### <a name="list">`++list`</a>
 
 List
 
@@ -108,7 +108,7 @@ See also: `++turn`, `++snag`
 
 
 ***
-### `++lone`
+### <a name="lone">`++lone`</a>
 
 `++lone` puts face of `p` on something.
 
@@ -120,7 +120,7 @@ Source
     ++  lone  |*(a/$-(* *) p/a)                             ::  just one thing
 
 ***
-### `++pair`
+### <a name="pair">`++pair`</a>
 
 Mold of pair of types
 
@@ -143,7 +143,7 @@ Examples
 
 
 ***
-### `++pole`
+### <a name="pole">`++pole`</a>
 
 Faceless list
 
@@ -166,7 +166,7 @@ Examples
 
 
 ***
-### `++qual`
+### <a name="qual">`++qual`</a>
 
 Mold of 4 type tuple
 
@@ -187,7 +187,7 @@ Examples
 
 
 ***
-### `++quid`
+### <a name="quid">`++quid`</a>
 
 For use with `=^` `:sip`.
 
@@ -207,7 +207,7 @@ Examples
 
 
 ***
-### `++quip`
+### <a name="quip">`++quip`</a>
 
 For use with `=^` `:sip`.
 

--- a/docs/hoon/library/index.md
+++ b/docs/hoon/library/index.md
@@ -1,0 +1,92 @@
+---
+navhome: /docs/
+sort: 1
+title: Index
+---
+
+# A
+
+[add](../1a/#add) :: *Add.* Produces the sum of `a` and `b`.
+
+# B
+
+[bloq](../1c/#bloq) :: *Blocksize.* Atom representing a blocksize, by convention
+expressed as a power of 2.
+
+# C
+
+[cap](../1b/#cap) :: *Tree head.* Tests whether an `a` is in the head or tail of
+a noun. Produces the cube `%2` if it is within the head, or the cube `%3` if it
+is within the tail.
+
+# D
+
+[dec](../1a/#dec) :: *Decrement.* Decrements `a` by `1`.
+
+[div](../1a/#div) :: *Divide.* Computes `a` divided by `b`.
+
+# E
+
+[each](../1c/#each) :: *Mold of fork between two.* mold generator: produces a
+discriminated fork between two types.
+
+# G
+
+[gate](../1c/#gate) :: *Function.* A core with one arm, `$`--the empty
+name--which transforms a sample noun into a product noun. If used dryly as a
+type, the subject must have a sample type of `*`.
+
+[gte](../1a/#gte) :: *Greater-than/equal.* Tests whether `a` is greater than a
+number `b`.
+
+[gth](../1a/#gth) :: *Greater-than.* Tests whether `a` is greater than `b`.
+
+# L
+
+[list](../1c/#list) :: *List.* mold generator. `++list` generates a mold of a
+null-termanated list of a homogenous type.
+
+[lone](../1c/#lone) :: *Put face on.* `++lone` puts face of `p` on something.
+
+[lte](../1a/#lte) :: *Less-than/equal.* Tests whether `a` is less than or equal
+to `b`.
+
+[lth](../1a/#lth) :: *Less-than.* Tests whether `a` is less than `b`.
+
+# M
+
+[mas](../1b/#mas) :: *Axis within head/tail?* Computes the axis of `a` within
+either the head or tail of a noun (depends whether `a` lies within the the head
+  or tail).
+
+[max](../1a/#max) :: *Maximum.* Computes the greater of `a` and `b`.
+
+[min](../1a/#min) :: *Minimum.* Computes the lesser of `a` and `b`.
+
+[mod](../1a/#mod) :: *Modulus.* Computes the remainder of dividing `a` by `b`.
+
+[mul](../1a/#mul) :: *Multiply.* Multiplies `a` by `b`.
+
+# P
+
+[pair](../1c/#pair) :: *Mold of pair of types.* mold generator. Produces a tuple
+of two of the types passed in.
+
+[peg](../1b/#peg) :: *Axis within axis.* Computes the axis of `b` within axis `a`.
+
+[pole](../1c/#pole) :: *Faceless list.* A `++list` without the faces `i` and `t`.
+
+# Q
+
+[qual](../1c/#qual) :: *Mold of 4 type tuple.* A `++qual` is a tuple of four of
+the types passed in.
+
+[quid](../1c/#quid) :: *For use with `=^` `:sip`.* Mold generator. Produces a
+tuple of `a` and the mold of `b`.
+
+[quip](../1c/#quip) :: *For use with `=^` `:sip`.* Mold generator. Produces a
+tuple of a list of `a` and the mold of `b`.
+
+# S
+
+[sub](../1a/#sub) :: *Subtract.* Subtracts `b` from `a`.


### PR DESCRIPTION
This is a **Proposal** and is not ready for merge. I wanted to get this out there, however, before I put in more work to make sure I am going down the right path.

This is a big "itch" of mine because when you read examples, for example in this excellent post: https://urbit.org/fora/posts/~2017.7.20..09.13.38..a812~/, you see gates like cork, crip, and trip and it is difficult to find them in the current 1a, 1b, &c. structure of the standard library docs.

This is unfortunately hampered by the fact that *[tree](https://github.com/urbit/tree)* doesn't properly follow anchor links when sending to another page. (They do work intra-page). This is an existing bug that is already affecting the docs and I am going to try to take a stab at fixing that as well. But, for now, for this patch you'll just have to imagine it works. :wink: At least it takes you to the right section.

Comments on the formatting and presentation are welcomed.