### PR TITLE
Add information about turning timestamps on/off in talk

### DIFF
--- a/docs/using/messaging.md
+++ b/docs/using/messaging.md
@@ -289,3 +289,9 @@ All nicknames must be 14 characters or less, lowercase. Nicknames are
 strictly local - like the names on entries in a phonebook. Sometimes in
 a post you want to mention someone you know by a nickname. Just type
 `~plato`, and `:talk` will replace it with `~your-urbit`.
+
+### Timestamps
+
+`;set showtime` - Show the timestamp for each message
+
+`;unset showtime` - Stop showing the timestamp for each message


### PR DESCRIPTION
In a discussion in Talk last Friday, I learned for the first time that talk has the ability to turn timestamps on and off using the ;set command. As this was previously undocumented, I decided to add a section to the help doc that discusses talk.