### PR TITLE
docs for ford runes

### DIFF
--- a/docs/arvo/internals/ford/commentary.md
+++ b/docs/arvo/internals/ford/commentary.md
@@ -198,9 +198,9 @@ retrieve it from.
               ==                                            ::
 
 This is how we represent the static resources hook files can load. The
-discussion of their use from a user's perspective is documented
-elsewhere (link), so we will here only give a description of the data
-structure itself.
+discussion of their use from a user's perspective is documented in the [runes
+documentation](https://urbit.org/docs/arvo/internals/runes), so we will here
+only give a description of the data structure itself.
 
 A `%ape` horn is simply a twig that gets evaluated and placed in the
 subject.

--- a/docs/arvo/internals/ford/runes.md
+++ b/docs/arvo/internals/ford/runes.md
@@ -6,6 +6,35 @@ One of the most common ways to use ford is through ford's runes, all of which be
 
 Another common use case is assembling and rendering markdown templates into a single HTML file, to be sent as an HTTP response in urbit's web server `%eyre`. It's important to keep in mind that %ford is quite flexible and generic, and is used in other parts of urbit -- such as the dojo -- that would not traditionally fall under the auspices of a build system.
 
+### `/+` import from lib/
+
+The `/+` rune accepts a filename as an argument. It interprets that filename
+as a hoon source file within the `lib` directory. This is how we import a shared
+library in urbit.
+
+Example:
+```
+/+  time-to-id
+::
+(time-to-id now)
+```
+produces: `"c.314d"` (or something similar depending on when you run it)
+
+### `/-` import from sur/
+
+The `/-` rune accepts a filename as an argument. It interprets that filename as
+a hoon source file within the `sur` directory. The `sur` directory contains
+shared structures that can be used by other parts of urbit. This is somewhat
+similar to including a header file in C.
+
+Example:
+```
+/-  talk
+::
+*serial:talk
+```
+produces: `0v0`
+
 ### `/~` twig by hand
 
 `/~  <twig>` produces a horn that evaluates a twig and places the product
@@ -22,9 +51,9 @@ produces:
 ### `//` include a file by relative path
 
 `// <rel-path>` parses `rel-path` as a hoon twig, and then adds the resulting
-twig to the subject. It's similar to `#include` in C. Note that the result type
-of this rune is not a horn, but just a hoon twig, so its result can't be used
-as an argument to other runes that expect a horn.
+twig to the subject. Note that the result type of this rune is not a horn, but
+just a hoon twig, so its result can't be used as an argument to other runes
+that expect a horn.
 
 Example:
 ```
@@ -223,32 +252,3 @@ produces two `<script>` tags. The first has its contents set to the contents
 of the JavaScript file we loaded from clay. The second is an auto-update
 script that polls the server to check whether the dependency hash has changed.
 This pattern is used in urbit's `tree` web publishing system.
-
-### `/+` import from lib/
-
-The `/+` rune accepts a filename as an argument. It interprets that filename
-as a hoon source file within the `lib` directory. This is how we import a shared
-library in urbit.
-
-Example:
-```
-/+  time-to-id
-::
-(time-to-id now)
-```
-produces: `"c.314d"` (or something similar depending on when you run it)
-
-### `/-` import from sur/
-
-The `/-` rune accepts a filename as an argument. It interprets that filename as
-a hoon source file within the `sur` directory. The `sur` directory contains
-shared structures that can be used by other parts of urbit. This is somewhat
-similar to including a header file in C.
-
-Example:
-```
-/-  talk
-::
-*serial:talk
-```
-produces: `0v0`

--- a/docs/arvo/internals/ford/runes.md
+++ b/docs/arvo/internals/ford/runes.md
@@ -187,7 +187,9 @@ need to be enclosed in `/`'s: `/&  html  /elem/`
 
 ### `/_` run a horn on each file in the current directory
 
-`/_` takes a horn as an argument. It produces a new horn representing the
+`/_` can be used in two ways: filtered and unfiltered.
+
+Unfiltered `/_` takes a horn as an argument. It produces a new horn representing the
 result of mapping the supplied horn over the list of files in the current
 directory. The keys in the resulting map are the basenames of the files in the
 directory, and each value is the result of running that horn on the contents of
@@ -205,6 +207,21 @@ filename without the prefix), and each value is the result of running the
 contents of the file through the `%hoon` mark, which validates that it's valid
 hoon code and returns it unmodified. So, the resulting map associates basenames
 with file contents.
+
+Filtered `/_` takes an aura and a horn, and filters the list of files in the
+current directory by whether their filenames can be parsed to an atom of that
+aura. It then produces a map where each key is the filename after parsing into
+that atom type, and each value is the result of running the horn on the
+contents of that file.
+
+Example:
+```
+/=  timed-posts  /_  @da  /md/
+`(map @da @t)`timed-posts
+```
+produces a map from dates to cords. This product will only contain files whose
+names are parsable into `@da` dates. The values are the file contents converted
+to a cord of markdown-formatted text.
 
 ### `/;` operate on
 

--- a/docs/arvo/internals/ford/runes.md
+++ b/docs/arvo/internals/ford/runes.md
@@ -124,6 +124,40 @@ produces:
 This result includes the MIME type ('text/html'), the content length in bytes,
 and the HTML itself.
 
+### `/&` pass through a series of marks
+
+`/&` passes a horn through multiple marks, right-to-left. It has both a
+wide-form and a tall-form syntax. Wide-form:
+
+```
+/=  some-text  /:  /%/text-file  /&mime&/txt/
+::
+some-text
+```
+produces: `[[%text %plain ~] p=17 q='Hi I\'m some text\0a']`
+
+This example shows two of the ways marks are used. The first way is what
+happens with the `/txt/` mark: we use it to find a file in clay with that
+extension, without performing any conversions.  Since this file is stored with
+the `%txt` mark in `%clay`, its type is a `wain`: a list of cords, where each
+cord is a single line. Once we've read the file, the `%mime` mark converts the
+`wain` to a triple that includes the MIME type ("text/plain"), the content
+length in bytes, and the content itself as a cord.
+
+```
+/=  page  /&html&elem&/~[;div.foo;]
+::
+page
+```
+produces: `'<html><head></head><body><div class="foo"></div></body></html>'`
+
+This runs the sail expression `;div.foo;` through the `%elem` mark, then
+through the `%html` mark.  The `/~` rune produces an item of mark `noun`.  The
+`%elem` mark converts the mark of the expression from `noun` to `elem` by
+checking that the type fits in `manx` (a hoon/sail type indicating an XML
+element). The `%html` mark recognizes the `%elem` and converts it to an HTML
+string with enclosing `<html>`, `<head>`, and `<body>` tags.
+
 ### `/_` run a horn on each file in the current directory
 
 `/_` takes a horn as an argument. It produces a new horn representing the

--- a/docs/arvo/internals/ford/runes.md
+++ b/docs/arvo/internals/ford/runes.md
@@ -259,7 +259,7 @@ produces the number of bytes in the file "/%/path/to/hoon/file."
 
 `/,` is a switch statement, which picks a branch to evaluate based on
 whether the current path matches the path in the switch statement. 
-Takes a sequence of pairs of (path, horn) terminated by a `==`.
+Takes a sequence of pairs of (path, horn) terminated by a `==`. No wide-form.
 
 Example:
 ```
@@ -278,7 +278,7 @@ produces: `'evaluate-me'`
 
 ### `/.` list
 
-Produce a null-terminated list from a sequence of horns, terminated by a `==`.
+Produce a null-terminated list from a sequence of horns, terminated by a `==`. No wide-form.
 
 Example:
 ```
@@ -319,6 +319,8 @@ produces: `1`
 
 Without the cast, we wouldn't be able to access the 'i' face of the list.
 
+Wide-form `/^` uses `^` as a delimiter: `/^(list @)^/~[1 2 3 ~]`
+
 ### `/#` insert dephash
 
 `/#` takes a horn and produces a cell of the dependency
@@ -337,6 +339,8 @@ of the JavaScript file we loaded from clay. The second is an auto-update
 script that polls the server to check whether the dependency hash has changed.
 This pattern is used in urbit's `tree` web publishing system.
 
+Wide-form `/#` does not need a delimiter:
+`/=  inline  /^  {dep/@uvH txt/@t}  /#/:/%/my-script:/js/`
 
 ### `/$` process extra arguments
 
@@ -358,3 +362,5 @@ Example:
 ```
 produces: [%who '~zod' %where /ford/pages/web %case 60]
 
+Wide-form `/$` takes its arguments inside brackets, like `/~`:
+`/=gas=/$[fuel]`

--- a/docs/arvo/internals/ford/runes.md
+++ b/docs/arvo/internals/ford/runes.md
@@ -200,3 +200,32 @@ i.liz
 produces: `1`
 
 Without the cast, we wouldn't be able to access the 'i' face of the list.
+
+### `/+` import from lib/
+
+The `/+` rune accepts a filename as an argument. It interprets that filename
+as a hoon source file within the `lib` directory. This is how we import a shared
+library in urbit.
+
+Example:
+```
+/+  time-to-id
+::
+(time-to-id now)
+```
+produces: `"c.314d"` (or something similar depending on when you run it)
+
+### `/-` import from sur/
+
+The `/-` rune accepts a filename as an argument. It interprets that filename as
+a hoon source file within the `sur` directory. The `sur` directory contains
+shared structures that can be used by other parts of urbit. This is somewhat
+similar to including a header file in C.
+
+Example:
+```
+/-  talk
+::
+*serial:talk
+```
+produces: `0v0`

--- a/docs/arvo/internals/ford/runes.md
+++ b/docs/arvo/internals/ford/runes.md
@@ -30,7 +30,7 @@ Example:
 ```
 //  %/file-to-include
 ::
-(frobnicate:file-to-include |)
+(frobnicate:file-to-include %.n)
 
 ::  contents of file-to-include.hoon
 |%
@@ -45,9 +45,7 @@ _Note: `%` means current directory, which in a hoon file will resolve to the
 "directory" containing that file. Also, %clay doesn't have first-class
 directories the way unix filesystems do. Whereas in unix, a directory is a
 special kind of file, in %clay it's just a path prefix, and there is no file
-stored at that path. The meaning of `%` is also contextual: some ford runes can
-also modify the value of `%` inside their arguments (see the docs for `/_` for
-an example)._
+stored at that path._
 
 ### `/=` wrap a face around an included horn
 
@@ -63,21 +61,33 @@ produces: `[0 1]`
 
 ### `/_` run a horn on each file in the current directory
 
-`/_` takes a horn as an argument. It produces a new horn
-representing the result of mapping the supplied horn over
-the list of files in the current directory.
+`/_` takes a horn as an argument. It produces a new horn representing the
+result of mapping the supplied horn over the list of files in the current
+directory. The keys in the resulting map are the basenames of the files in the
+directory, and each value is the result of running that horn on the contents of
+the file.
 
 Example:
 ```
-/=  kids  /_  /~  %
-`(map term path)`kids
+/=  kids  /_  /hoon/
+`(map term cord)`kids
 ```
 
-produces a value of type `(map term path)`, where each key is the basename (the
-filename without the prefix), and each value is the prefix: the path of the
-"directory" containing that file.
+produces a value of type `(map term cord)`, where each key is the basename (the
+filename without the prefix), and each value is the result of running the
+contents of the file through the `%hoon` mark, which validates that it's valid
+hoon code and returns it unmodified. So, the resulting map associates basenames
+with file contents. For more information on marks, see the docs for the
+`/<mark>/` syntax.
 
-_Note that `%` is contextual: it takes on different values based on the
-"current directory", which can be set by `/_` and other ford runes. For each
-file in the directory through which `/_` is iterating, `%` becomes the path of
-that file during that iteration._
+### `/:` evaluate at path
+
+`/:` takes a path and a horn, and evaluates the horn with the current path set to the supplied path.
+
+Example:
+```
+/=  hoo-source  /:  /path/to/hoon-file  /hoon/
+`@t`hoo-source
+```
+
+produces the text of the hoon file at "/path/to/hoon-file/hoon".

--- a/docs/arvo/internals/ford/runes.md
+++ b/docs/arvo/internals/ford/runes.md
@@ -206,6 +206,24 @@ produces: `1`
 
 Without the cast, we wouldn't be able to access the 'i' face of the list.
 
+### `/#` insert dephash
+
+`/#` takes a horn and produces a cell of the dependency
+hash of the result of the horn, and the result itself.
+
+Example:
+```
+/=  inline  /^  {dep/@uvH txt/@t}  /#  /:  /%/my-script  /js/
+::
+;=  ;script: (trip txt.inline)                          ::  set script contents
+    ;script@"/~/on/{<dep.inline>}.js";                  ::  set script src
+==
+```
+produces two `<script>` tags. The first has its contents set to the contents
+of the JavaScript file we loaded from clay. The second is an auto-update
+script that polls the server to check whether the dependency hash has changed.
+This pattern is used in urbit's `tree` web publishing system.
+
 ### `/+` import from lib/
 
 The `/+` rune accepts a filename as an argument. It interprets that filename

--- a/docs/arvo/internals/ford/runes.md
+++ b/docs/arvo/internals/ford/runes.md
@@ -48,6 +48,19 @@ Example:
 produces:
 `[0 1]`
 
+In wide-form, `/~` always takes a tuple (which may be a degenerate tuple of one element), and produces it.
+
+Example:
+```
+/~[%something]
+```
+produces: `%something`
+
+```
+/~[%a %b]
+```
+produces: `[%a %b]`
+
 ### `//` include a file by relative path
 
 `// <rel-path>` parses `rel-path` as a hoon twig, and then adds the resulting

--- a/docs/arvo/internals/ford/runes.md
+++ b/docs/arvo/internals/ford/runes.md
@@ -185,7 +185,7 @@ just a mark: `/&c&b&/:path:/mark/`
 Tall-form `/&` takes only two arguments: a mark and a horn. The mark does not
 need to be enclosed in `/`'s: `/&  html  /elem/`
 
-### `/_` run a horn on each file in the current directory
+### `/_` unfiltered: run a horn on each file in the current directory
 
 `/_` can be used in two ways: filtered and unfiltered.
 
@@ -208,6 +208,10 @@ contents of the file through the `%hoon` mark, which validates that it's valid
 hoon code and returns it unmodified. So, the resulting map associates basenames
 with file contents.
 
+Wide-form unfiltered `/_` doesn't need a delimiter: `/=  kids  /_/hoon/`
+
+### `/_` filtered: run a horn on each file in the directory matching an aura
+
 Filtered `/_` takes an aura and a horn, and filters the list of files in the
 current directory by whether their filenames can be parsed to an atom of that
 aura. It then produces a map where each key is the filename after parsing into
@@ -222,6 +226,8 @@ Example:
 produces a map from dates to cords. This product will only contain files whose
 names are parsable into `@da` dates. The values are the file contents converted
 to a cord of markdown-formatted text.
+
+Wide-form filtered `/_` uses `_` as a delimiter: `/=  timed-posts  /_@da_/md/`
 
 ### `/;` operate on
 

--- a/docs/arvo/internals/ford/runes.md
+++ b/docs/arvo/internals/ford/runes.md
@@ -402,3 +402,17 @@ produces: [%who '~zod' %where /ford/pages/web %case 60]
 
 Wide-form `/$` takes its arguments inside brackets, like `/~`:
 `/=gas=/$[fuel]`
+
+### `/%` propagate extra arguments into renderers
+
+`/%` will forward extra arguments (usually from `%eyre`) on to any enclosed `/renderer/`'s. Without this,
+renderers that use `/$` to read the extra arguments will crash.
+
+Example:
+```
+/=  dat  /%  /tree-json/
+::
+dat
+```
+produces the results of running `ren/tree-json` on the current path. This renderer needs the query string,
+which is one of the extra arguments passed in from `%eyre`.

--- a/docs/arvo/internals/ford/runes.md
+++ b/docs/arvo/internals/ford/runes.md
@@ -136,11 +136,11 @@ Here's a slightly more complex example with runes that use the filesystem:
 ```
 /=  file-length
     /;  |=(a/@t (lent (crip a)))
-    /:  /path/to/hoon/file  /hoon/
+    /:  /%/path/to/hoon/file  /hoon/
 ::
 file-length
 ```
-produces the number of bytes in the file "/path/to/hoon/file."
+produces the number of bytes in the file "/%/path/to/hoon/file."
 
 ### `/,` switch by path
 
@@ -151,11 +151,11 @@ Takes a sequence of pairs of (path, horn) terminated by a `==`.
 Example:
 ```
 /=  just-right
-    /:  /right-path                                     ::  set path to /right-path 
+    /:  /===/right-path                                 ::  set path to /%/right-path
     /,
       /wrong-path  /~  ~
       /another-wrong-path  /~  ~
-      /right-path  /~  %evaluate-me                     ::  only evaluate this horn 
+      /right-path  /~  %evaluate-me                     ::  only evaluate this horn
     ==
 ::
 `@t`just-right

--- a/docs/arvo/internals/ford/runes.md
+++ b/docs/arvo/internals/ford/runes.md
@@ -55,9 +55,44 @@ that horn, and wraps a face around it.
 Example:
 ```
 /=  foo  /~  [a=0 b=1]
+::
 [a.foo b.foo]
 ```
 produces: `[0 1]`
+
+### `/:` evaluate at path, and `/<mark>/` render mark at current path
+
+`/:` takes a path and a horn, and evaluates the horn with the current path set to the supplied path.
+`/mar/` renders the mark 'mar' at the current path.
+
+Example:
+```
+/=  hoo-source  /:  /path/to/hoon-file  /hoon/
+::
+`@t`hoo-source
+```
+
+produces the text of the hoon file at "/path/to/hoon-file/hoon".
+
+`/hoon/` renders the current path using the `%hoon` mark, which in this case
+passes the contents through unchanged.  In general, rendering a file with a
+mark will potentially run the contents through a series of conversion
+operations. For details on marks, see the
+[marks docs](https://urbit.org/docs/arvo/marks).
+
+Here's an example that includes a mark conversion:
+```
+/=  page  /:  /path/to/html/file  /mime/
+::
+page
+
+::  contents of /path/to/html/file:
+<html><head><title>My Fascinating Blog</title></head></html>
+```
+produces: `[[%text %html ~] 37 '<html><body><div></div></body></html>']`
+
+This result includes the MIME type ('text/html'), the content length in bytes,
+and the HTML itself.
 
 ### `/_` run a horn on each file in the current directory
 
@@ -70,6 +105,7 @@ the file.
 Example:
 ```
 /=  kids  /_  /hoon/
+::
 `(map term cord)`kids
 ```
 
@@ -77,31 +113,30 @@ produces a value of type `(map term cord)`, where each key is the basename (the
 filename without the prefix), and each value is the result of running the
 contents of the file through the `%hoon` mark, which validates that it's valid
 hoon code and returns it unmodified. So, the resulting map associates basenames
-with file contents. For more information on marks, see the docs for the
-`/<mark>/` syntax.
-
-### `/:` evaluate at path
-
-`/:` takes a path and a horn, and evaluates the horn with the current path set to the supplied path.
-
-Example:
-```
-/=  hoo-source  /:  /path/to/hoon-file  /hoon/
-`@t`hoo-source
-```
-
-produces the text of the hoon file at "/path/to/hoon-file/hoon".
+with file contents.
 
 ### `/;` operate on
 
 `/;` takes a twig and a horn. The twig should evaluate to a gate, which is then slammed
-with the result of the horn.
+with the result of the horn as its sample.
 
 Example:
-
 ```
-/=  goo  /;  |=({a/@ b/@} +(b))  /~  [a=0 b=1]
+/=  goo
+    /;  |=({a/@ b/@} +(b))
+    /~  [a=0 b=1]
+::
 goo
 ```
+
+Here's a slightly more complex example with runes that use the filesystem:
+```
+/=  file-length
+    /;  |=(a/@t (lent (crip a)))
+    /:  /path/to/hoon/file  /hoon/
+::
+file-length
+```
+produces the number of bytes in the file "/path/to/hoon/file."
 
 produces: `2`

--- a/docs/arvo/internals/ford/runes.md
+++ b/docs/arvo/internals/ford/runes.md
@@ -185,6 +185,31 @@ just a mark: `/&c&b&/:path:/mark/`
 Tall-form `/&` takes only two arguments: a mark and a horn. The mark does not
 need to be enclosed in `/`'s: `/&  html  /elem/`
 
+### `/|` short-circuiting 'or'
+
+`/|` takes a series of horns and produces the first one (left-to-right) that
+succeeds. If none succeed, it produces stack traces from all of its arguments.
+
+Example:
+```
+/=  res  /:  /%/path/to/file
+/|
+  /!elem/
+  /elem/
+==
+::
+res
+```
+tries to parse the file at `/%/path/to/file` as a hoon expression and evaluate
+it (`/!elem/`), and then if that fails, tries to convert the file to an HTML
+element directly (`/elem/`). This is used in urbit's `tree` publishing system
+to enable a user to place either a hoon file or a static file in a directory,
+and have them both result in webpages, with preference given to treating the
+file as hoon to be evaluated.
+
+Wide-form `/|` encloses its arguments in parentheses, with a single space as a delimiter:
+`/|(/!elem/ /elem/)`
+
 ### `/_` unfiltered: run a horn on each file in the current directory
 
 `/_` can be used in two ways: filtered and unfiltered.

--- a/docs/arvo/internals/ford/runes.md
+++ b/docs/arvo/internals/ford/runes.md
@@ -252,3 +252,25 @@ produces two `<script>` tags. The first has its contents set to the contents
 of the JavaScript file we loaded from clay. The second is an auto-update
 script that polls the server to check whether the dependency hash has changed.
 This pattern is used in urbit's `tree` web publishing system.
+
+
+### `/$` process extra arguments
+
+`/$` will slam a gate on whatever extra arguments have been supplied to this build.
+At the moment, only HTTP requests forwarded by `%eyre` contain any extra arguments,
+and using this rune outside of that context will cause an error. Requests from `%eyre`
+contain an argument representing the query string, which can be parsed using the
+standard library gate `++fuel`.
+
+Example:
+```
+/=  gas  /$  fuel
+::
+:*
+  %who    {<(~(get ju aut.ced.gas) 0)>}
+  %where  {(spud s.bem.gas)}
+  %case   {(scow %ud p.r.bem.gas)}
+==
+```
+produces: [%who '~zod' %where /ford/pages/web %case 60]
+

--- a/docs/arvo/internals/ford/runes.md
+++ b/docs/arvo/internals/ford/runes.md
@@ -4,7 +4,7 @@
 
 One of the most common ways to use ford is through ford's runes, all of which begin with `/` ("fas"). A ford rune runs a step of a ford build and places the result in the subject. There are various kinds of build steps, some of which take other build steps as parameters. The most common pattern is to have a sequence of ford runes at the top of a hoon source file that import the results of evaluating other hoon files. This is how we "import a library" in urbit: we add the result of compiling another hoon file into the current subject, possibly renaming it by wrapping a face around it.
 
-Another common use case is assembling and rendering markdown templates into a single HTML file, to be sent as an HTTP response in urbit's web server `%eyre`. It's important to keep in mind that %ford is quite flexible and generic, and is used in other parts of urbit -- such as the dojo -- that would not traditionally fall under the auspices of a build system.
+Another common use case is assembling and rendering markdown templates into a single HTML file, to be sent as an HTTP response in urbit's web server `%eyre`. It's important to keep in mind that %ford is quite flexible and generic, and is used in other parts of urbit -- such as the dojo -- that would not traditionally fall under the purview of a build system.
 
 ### `/+` import from lib/
 

--- a/docs/arvo/internals/ford/runes.md
+++ b/docs/arvo/internals/ford/runes.md
@@ -144,7 +144,8 @@ produces the number of bytes in the file "/path/to/hoon/file."
 ### `/,` switch by path
 
 `/,` is a switch statement, which picks a branch to evaluate based on
-whether the current path matches the path in the switch statement.
+whether the current path matches the path in the switch statement. 
+Takes a sequence of pairs of (path, horn) terminated by a `==`.
 
 Example:
 ```
@@ -155,7 +156,29 @@ Example:
       /another-wrong-path  /~  ~
       /right-path  /~  %evaluate-me                     ::  only evaluate this horn 
     ==
+::
 `@t`just-right
 ```
 
 produces: `'evaluate-me'`
+
+### `/.` list
+
+Produce a null-terminated list from a sequence of horns, terminated by a `==`.
+
+Example:
+```
+/=  vanes
+    /.
+      /~  %ames
+      /~  %behn
+      /~  %clay
+      /~  %dill
+      /~  %eyre
+      /~  %ford
+      /~  %gall
+    ==
+::
+vanes
+```
+produces: `[%ames %behn %clay %dill %eyre %ford %gall ~]`.

--- a/docs/arvo/internals/ford/runes.md
+++ b/docs/arvo/internals/ford/runes.md
@@ -94,7 +94,8 @@ produces the text of the hoon file at "/path/to/hoon-file/hoon".
 
 ### `/;` operate on
 
-`/;` takes a twig and a horn, and applies the twig to the result of the horn.
+`/;` takes a twig and a horn. The twig should evaluate to a gate, which is then slammed
+with the result of the horn.
 
 Example:
 

--- a/docs/arvo/internals/ford/runes.md
+++ b/docs/arvo/internals/ford/runes.md
@@ -416,3 +416,5 @@ dat
 ```
 produces the results of running `ren/tree-json` on the current path. This renderer needs the query string,
 which is one of the extra arguments passed in from `%eyre`.
+
+Wide-form `/%` has no delimiter: `/%/tree-json/`

--- a/docs/arvo/internals/ford/runes.md
+++ b/docs/arvo/internals/ford/runes.md
@@ -158,6 +158,8 @@ checking that the type fits in `manx` (a hoon/sail type indicating an XML
 element). The `%html` mark recognizes the `%elem` and converts it to an HTML
 string with enclosing `<html>`, `<head>`, and `<body>` tags.
 
+It's possible to use wide-form `/&` with more than two marks, by using `&` as a delimiter between marks and adding a `/` before the last mark, like: `/&d&c&b&/a/`.
+
 ### `/_` run a horn on each file in the current directory
 
 `/_` takes a horn as an argument. It produces a new horn representing the

--- a/docs/arvo/internals/ford/runes.md
+++ b/docs/arvo/internals/ford/runes.md
@@ -37,8 +37,10 @@ produces: `0v0`
 
 ### `/~` twig by hand
 
-`/~  <twig>` produces a horn that evaluates a twig and places the product
-in the subject. Arbitrary hoon can be in the twig.
+`/~  <twig>` produces a "horn" that evaluates a twig and places the product in
+the subject. Arbitrary hoon can be in the twig. A
+[horn](https://urbit.org/docs/arvo/internals/ford/commentary/#-horn) is a data
+structure representing a `%ford` static resource.
 
 Example:
 ```

--- a/docs/arvo/internals/ford/runes.md
+++ b/docs/arvo/internals/ford/runes.md
@@ -127,7 +127,9 @@ and the HTML itself.
 ### `/&` pass through a series of marks
 
 `/&` passes a horn through multiple marks, right-to-left. It has both a
-wide-form and a tall-form syntax. Wide-form:
+wide-form and a tall-form syntax. In wide-form, it takes a series of mark
+arguments followed by a horn. In tall-form, it takes a single mark followed by
+a horn.
 
 ```
 /=  some-text  /:  /%/text-file  /&mime&/txt/
@@ -158,7 +160,13 @@ checking that the type fits in `manx` (a hoon/sail type indicating an XML
 element). The `%html` mark recognizes the `%elem` and converts it to an HTML
 string with enclosing `<html>`, `<head>`, and `<body>` tags.
 
-It's possible to use wide-form `/&` with more than two marks, by using `&` as a delimiter between marks and adding a `/` before the last mark, like: `/&d&c&b&/a/`.
+It's possible to use wide-form `/&` with more than two marks, by using `&` as a
+delimiter between marks and adding a `/` before the last mark, like:
+`/&d&c&b&/a/`. The last argument here can actually be any arbitrary horn, not
+just a mark: `/&c&b&/:path:/mark/`
+
+Tall-form `/&` takes only two arguments: a mark and a horn. The mark does not
+need to be enclosed in `/`'s: `/&  html  /elem/`
 
 ### `/_` run a horn on each file in the current directory
 

--- a/docs/arvo/internals/ford/runes.md
+++ b/docs/arvo/internals/ford/runes.md
@@ -184,6 +184,11 @@ vanes
 ```
 produces: `[%ames %behn %clay %dill %eyre %ford %gall ~]`.
 
+### `/*` heterogeneous map
+
+_DEPRECATED_
+TODO: remove
+
 ### `/^` cast
 
 `/^` takes a mold and a horn, and casts the result of the horn to the mold.

--- a/docs/arvo/internals/ford/runes.md
+++ b/docs/arvo/internals/ford/runes.md
@@ -1,0 +1,83 @@
+# `%ford` user manual
+
+## ford runes
+
+One of the most common ways to use ford is through ford's runes, all of which begin with `/` ("fas"). A ford rune runs a step of a ford build and places the result in the subject. There are various kinds of build steps, some of which take other build steps as parameters. The most common pattern is to have a sequence of ford runes at the top of a hoon source file that import the results of evaluating other hoon files. This is how we "import a library" in urbit: we add the result of compiling another hoon file into the current subject, possibly renaming it by wrapping a face around it.
+
+Another common use case is assembling and rendering markdown templates into a single HTML file, to be sent as an HTTP response in urbit's web server `%eyre`. It's important to keep in mind that %ford is quite flexible and generic, and is used in other parts of urbit -- such as the dojo -- that would not traditionally fall under the auspices of a build system.
+
+### `/~` twig by hand
+
+`/~  <twig>` produces a horn that evaluates a twig and places the product
+in the subject. Arbitrary hoon can be in the twig.
+
+Example:
+```
+/~  [a=0 b=1]
+[a b]
+```
+produces:
+`[0 1]`
+
+### `//` include a file by relative path
+
+`// <rel-path>` parses `rel-path` as a hoon twig, and then adds the resulting
+twig to the subject. It's similar to `#include` in C. Note that the result type
+of this rune is not a horn, but just a hoon twig, so its result can't be used
+as an argument to other runes that expect a horn.
+
+Example:
+```
+//  %/file-to-include
+::
+(frobnicate:file-to-include |)
+
+::  contents of file-to-include.hoon
+|%
+++  frobnicate
+  |=  a/?  ^+  a
+  !a
+--
+```
+produces: `%.y`
+
+_Note: `%` means current directory, which in a hoon file will resolve to the
+"directory" containing that file. Also, %clay doesn't have first-class
+directories the way unix filesystems do. Whereas in unix, a directory is a
+special kind of file, in %clay it's just a path prefix, and there is no file
+stored at that path. The meaning of `%` is also contextual: some ford runes can
+also modify the value of `%` inside their arguments (see the docs for `/_` for
+an example)._
+
+### `/=` wrap a face around an included horn
+
+`/=` runs a horn (usually produced by another ford rune), takes the result of
+that horn, and wraps a face around it.
+
+Example:
+```
+/=  foo  /~  [a=0 b=1]
+[a.foo b.foo]
+```
+produces: `[0 1]`
+
+### `/_` run a horn on each file in the current directory
+
+`/_` takes a horn as an argument. It produces a new horn
+representing the result of mapping the supplied horn over
+the list of files in the current directory.
+
+Example:
+```
+/=  kids  /_  /~  %
+`(map term path)`kids
+```
+
+produces a value of type `(map term path)`, where each key is the basename (the
+filename without the prefix), and each value is the prefix: the path of the
+"directory" containing that file.
+
+_Note that `%` is contextual: it takes on different values based on the
+"current directory", which can be set by `/_` and other ford runes. For each
+file in the directory through which `/_` is iterating, `%` becomes the path of
+that file during that iteration._

--- a/docs/arvo/internals/ford/runes.md
+++ b/docs/arvo/internals/ford/runes.md
@@ -141,6 +141,19 @@ and the HTML itself.
 
 In wide-form, `/:` uses `:` as a delimiter: `/=page=/:/path/to/html/file:/mime/`
 
+### `/!mark/` evaluate as hoon, then pass through mark
+
+Example:
+```
+/=  mime  /:  /%/some-hoon-file  /!mime/
+::
+mime
+
+:: contents of /%/some-hoon-file:
+%produces-a-cord
+```
+produces: `[[%text %plain ~] 15 'produces-a-cord']`
+
 ### `/&` pass through a series of marks
 
 `/&` passes a horn through multiple marks, right-to-left. It has both a

--- a/docs/arvo/internals/ford/runes.md
+++ b/docs/arvo/internals/ford/runes.md
@@ -182,3 +182,20 @@ Example:
 vanes
 ```
 produces: `[%ames %behn %clay %dill %eyre %ford %gall ~]`.
+
+### `/^` cast
+
+`/^` takes a mold and a horn, and casts the result of the horn to the mold.
+
+Example:
+```
+/=  liz  /^  (list @)                                   ::  cast to real list
+         /~  ~[1 2 3]                                   ::  no 'i' or 't' faces
+::
+?<  ?=($~ liz)                                          ::  prevent find-fork
+i.liz
+```
+
+produces: `1`
+
+Without the cast, we wouldn't be able to access the 'i' face of the list.

--- a/docs/arvo/internals/ford/runes.md
+++ b/docs/arvo/internals/ford/runes.md
@@ -91,3 +91,16 @@ Example:
 ```
 
 produces the text of the hoon file at "/path/to/hoon-file/hoon".
+
+### `/;` operate on
+
+`/;` takes a twig and a horn, and applies the twig to the result of the horn.
+
+Example:
+
+```
+/=  goo  /;  |=({a/@ b/@} +(b))  /~  [a=0 b=1]
+goo
+```
+
+produces: `2`

--- a/docs/arvo/internals/ford/runes.md
+++ b/docs/arvo/internals/ford/runes.md
@@ -66,7 +66,7 @@ produces: `[%a %b]`
 `// <rel-path>` parses `rel-path` as a hoon twig, and then adds the resulting
 twig to the subject. Note that the result type of this rune is not a horn, but
 just a hoon twig, so its result can't be used as an argument to other runes
-that expect a horn.
+that expect a horn. There is no wide-form for this rune.
 
 Example:
 ```
@@ -102,6 +102,8 @@ Example:
 ```
 produces: `[0 1]`
 
+In wide-form, `/=` uses `=` as a delimiter: `/=foo=/~[a=0 b=1]`
+
 ### `/:` evaluate at path, and `/<mark>/` render mark at current path
 
 `/:` takes a path and a horn, and evaluates the horn with the current path set to the supplied path.
@@ -136,6 +138,8 @@ produces:
 
 This result includes the MIME type ('text/html'), the content length in bytes,
 and the HTML itself.
+
+In wide-form, `/:` uses `:` as a delimiter: `/=page=/:/path/to/html/file:/mime/`
 
 ### `/&` pass through a series of marks
 

--- a/docs/arvo/internals/ford/runes.md
+++ b/docs/arvo/internals/ford/runes.md
@@ -129,6 +129,8 @@ Example:
 goo
 ```
 
+produces: `2`
+
 Here's a slightly more complex example with runes that use the filesystem:
 ```
 /=  file-length
@@ -139,4 +141,21 @@ file-length
 ```
 produces the number of bytes in the file "/path/to/hoon/file."
 
-produces: `2`
+### `/,` switch by path
+
+`/,` is a switch statement, which picks a branch to evaluate based on
+whether the current path matches the path in the switch statement.
+
+Example:
+```
+/=  just-right
+    /:  /right-path                                     ::  set path to /right-path 
+    /,
+      /wrong-path  /~  ~
+      /another-wrong-path  /~  ~
+      /right-path  /~  %evaluate-me                     ::  only evaluate this horn 
+    ==
+`@t`just-right
+```
+
+produces: `'evaluate-me'`

--- a/docs/arvo/internals/ford/runes.md
+++ b/docs/arvo/internals/ford/runes.md
@@ -89,7 +89,8 @@ page
 ::  contents of /path/to/html/file:
 <html><head><title>My Fascinating Blog</title></head></html>
 ```
-produces: `[[%text %html ~] 37 '<html><body><div></div></body></html>']`
+produces:
+`[[%text %html ~] 60 '<html><head><title>My Fascinating Blog</title></head></html>']`
 
 This result includes the MIME type ('text/html'), the content length in bytes,
 and the HTML itself.


### PR DESCRIPTION
Here's the rendered markdown of the new file:
https://github.com/urbit/docs/blob/ford-docs/docs/arvo/internals/ford/runes.md

This should show up as a link on the main ford docs page, under arvo internals.