### PR TITLE
fixing an incorrect expansion of ;;

### DIFF
--- a/docs/hoon/twig/sem-make/sem-fry.md
+++ b/docs/hoon/twig/sem-make/sem-fry.md
@@ -11,13 +11,13 @@ sort: 1
 
 ```
 :pin  :name(a (p q))
-:sure  =(a (p a))
+:sure  =(`*`a `*`q)
 a
 ```
 
 ```
 =+  a=(p q)
-?>  =(a (p a))
+?>  =(`*`a `*`q)
 a
 ```
 


### PR DESCRIPTION
The old expansion of ;; was definitely wrong.  I adjusted it so it now matches the relevant code in ++open of hoon.hoon:

https://github.com/urbit/arvo/blob/eee8697782c04e6cbb33a1df682c5fcfa6ccb91d/sys/hoon.hoon#L6724