### PR TITLE
Highlight what "cast syntax" is

### DIFF
--- a/docs/byte/1.md
+++ b/docs/byte/1.md
@@ -76,8 +76,8 @@ Let's type in some aura examples:
 ```
 
 So decimal is aura `@ud`, hexadecimal is `@ux`.  The cast
-syntax&mdash;`` `@ud` ``&mdash;lets us change the type of an atom, converting hex
-`0x42` to a decimal `66`.
+syntax&mdash;`` `@ud` ``&mdash;lets us change the type of an 
+atom, converting hex `0x42` to a decimal `66`.
 
 An aura is soft type.   The programmer can always insist on how
 to interpret an atom.  Hoon doesn't have "dependent types"; it

--- a/docs/byte/1.md
+++ b/docs/byte/1.md
@@ -75,8 +75,8 @@ Let's type in some aura examples:
 
 ```
 
-So decimal is aura `@ud`, hexadecimal is `@ux`.  Note the cast
-syntax, which lets us change the type of an atom, converting hex
+So decimal is aura `@ud`, hexadecimal is `@ux`.  The cast
+syntax&mdash;`` `@ud` ``&mdash;lets us change the type of an atom, converting hex
 `0x42` to a decimal `66`.
 
 An aura is soft type.   The programmer can always insist on how


### PR DESCRIPTION
We don't define casting before this point in Urbytes, so it would be helpful to emphasize the part of the example being referred to by "cast syntax".