### PR TITLE
Removed broken `? ~~Ürbit` example

### DIFF
--- a/docs/byte/1.md
+++ b/docs/byte/1.md
@@ -136,10 +136,6 @@ slightly clunkier syntax in exchange for much simpler semantics.
   @ux
 0x7469.6272.9cc3
 
-> ? ~~Ürbit
-  @t
-'Ürbit'
-
 > ? ~.urbit
   @ta
 ~.urbit


### PR DESCRIPTION
This example is broken (issue #145).

We still have people trying this out in :dojo and becoming confused when it doesn't work.  Someone was struggling with this today and brought it up in urbit-meta.  We should delete it for now.  Broken examples are frustrating.  When the problem in #145 is corrected, then we can (and should) add it back in.