### PR TITLE
Partial Rewrite of Hoon Syntax doc

### DIFF
--- a/docs/hoon/syntax.md
+++ b/docs/hoon/syntax.md
@@ -72,13 +72,22 @@ higher-order programming; write-only Hoon can certainly be
 # Design
 
 Hoon expressions are called 
-*[twigs](https://urbit.org/docs/about/glossary#twig)*. The name 
-of a twig is its 
-*[stem](https://urbit.org/docs/about/glossary#stem)*.  Because 
-each twig stem has its own structure, each has its own parser
-rule. We'll describe these grammars as we go through the stems.
+*[twigs](https://urbit.org/docs/about/glossary#twig)*, and at the 
+beginning of each twig is a 
+*[rune](https://urbit.org/docs/about/glossary#rune)*.  Each rune 
+type has a name, called a 
+*[stem](https://urbit.org/docs/about/glossary#stem)*.  Finally, 
+each stem has its own structure, e.g.:
 
-But Hoon has a general syntax design with common principles and
+> :-
+>   (add 12 13)
+> (sub 10 7)
+
+This twig uses the rune `:-` (stem: `cons`) to produce an ordered 
+pair: `[25 3]`.  There are two subexpressions following the `:-`, 
+corresponding to the two parts of the `cons` structure.  
+
+Hoon has a general syntax design with common principles and
 regularities.  We'll cover those here.
 
 ## Glyphs and characters
@@ -139,48 +148,19 @@ principles at all.  All irregular forms are flat.
 
 Some twigs have *only* irregular forms.
 
-## Keywords versus runes
+## Runes
 
-A regular form starts with a 
-*[sigil](https://urbit.org/docs/about/glossary#sigil)*, which is 
-either a *keyword* or a 
-*[rune](https://urbit.org/docs/about/glossary#rune)*&mdash;at 
-the programmer's choice.
-
-A *keyword* is `:` and then the stem label&mdash;e.g., `:cons`.
+As mentioned earlier, a regular form starts with a 
+*[rune](https://urbit.org/docs/about/glossary#rune).
 
 A *rune* is a pair of ASCII punctuation marks (a digraph)&mdash;e.g.,
 `:-`.  The first glyph in the rune indicates the category&mdash;e.g.,
 `:` runes make cells.  Runes can be pronounced by their glyphs or
-by their stem -- for `:-`, you can say either "colhep" or "cons".
-
-Keywords may be less challenging for early learners.  Rune style
-is less cluttered and distracting for experienced programmers;
-the system codebase is all in rune style.   Beginners can start
-with keywords and move to runes; start with runes and stick
-with runes; or start with keywords and stick with keywords.
-
-Here's the FizzBuzz demo code, in idiomatic rune syntax.  Compare
-with the [original](../demo).
-
-```
-  |=  end/atom
-  =/  count  1
-  |-  ^-  (list tape)
-  ?:  =(end count)  ~
-  :_  $(count (add 1 count))
-  ?:  =(0 (mod count 15))
-    "FizzBuzz"
-  ?:  =(0 (mod count 5))
-    "Fizz"
-  ?:  =(0 (mod count 3))
-    "Buzz"
-  (pave !>(count))
-```
+by their stem&mdash;for `:-`, you can say either "colhep" or "cons".
 
 ## Tall regular form
 
-Tall regular form starts with the sigil, followed by a `gap`
+Tall regular form starts with the rune, followed by a `gap`
 (any whitespace except `ace`). After this is a 
 *[bulb](https://urbit.org/docs/about/glossary#bulb)*&mdash;the 
 contents of the twig&mdash;whose own twigs are separated by 
@@ -188,7 +168,7 @@ contents of the twig&mdash;whose own twigs are separated by
 
 There are four body subtypes: *fixed*, *running*, *jogging*, and
 *battery*.  Stems with a *fixed* number of subexpressions
-self-terminate.  For instance, `:if` has three subexpressions and
+self-terminate.  For instance, `?:` has three subexpressions and
 is self-terminating.  Otherwise the twig is terminated by a
 `gap`, then either `==` (*running* or *jogging*, most twigs) or
 `--` (*battery*).
@@ -312,7 +292,7 @@ conventional example:
 
 ## Flat regular form
 
-Flat regular form starts with the sigil, followed by `pal`
+Flat regular form starts with the rune, followed by `pal`
 (`(`, left parenthesis), followed by a bulb whose subexpressions
 are separated by `ace` (one space), followed by `par` (`)`, right
 parenthesis).

--- a/docs/hoon/syntax.md
+++ b/docs/hoon/syntax.md
@@ -99,7 +99,7 @@ Code is often vocalized or subvocalized. "pal" is easier to say,
 aloud or silently, than "left paren".
 
 Note that the list includes two separate whitespace forms: `ace`
-for a single space, `gap` for 2+, comment, and newline.  In Hoon,
+for a single space; `gap` is either 2+ spaces or a newline.  In Hoon,
 the only significance in whitespace is the difference between
 `ace` and `gap`. Comments start with `::` and run to the end of 
 the line.
@@ -122,8 +122,7 @@ Each rune is followed by one or more subexpressions. The number and
 kind of subexpressions depend on the rune.
 
 ```
-:-
-  25
+:-  25
 3
 ```
 
@@ -163,8 +162,7 @@ Some runes also have *irregular forms*, which follow no
 principles at all.  All irregular forms are flat.
 
 ```
-.=
-  22
+.=  22
 23
 ```
 

--- a/docs/hoon/syntax.md
+++ b/docs/hoon/syntax.md
@@ -79,9 +79,11 @@ type has a name, called a
 *[stem](https://urbit.org/docs/about/glossary#stem)*.  Finally, 
 each stem has its own structure, e.g.:
 
-> :-
->   (add 12 13)
-> (sub 10 7)
+```
+  :-
+    (add 12 13)
+  (sub 10 7)
+```
 
 This twig uses the rune `:-` (stem: `cons`) to produce an ordered 
 pair: `[25 3]`.  There are two subexpressions following the `:-`, 

--- a/docs/hoon/syntax.md
+++ b/docs/hoon/syntax.md
@@ -47,10 +47,10 @@ shaped more or less like procedural programs.
 
 ## Feature/label confusion
 
-*Feature/label confusion* (FLC) is any syntax which makes it hard 
-for the eye to tell whether a token on the screen is a feature of 
-the language, or a label in the program.  For example, in Lisp a
-special form has the same syntax as a function call.
+*Feature/label confusion* (FLC) is the result of any syntax that
+makes it hard for the eye to tell whether a token on the screen is 
+a feature of the language, or a label in the program.  For example, 
+in Lisp a special form has the same syntax as a function call.
 
 The worst-case result of FLC is "DSL cancer."  Every source file
 is effectively written in its own domain-specific language.  To
@@ -101,8 +101,8 @@ aloud or silently, than "left paren".
 Note that the list includes two separate whitespace forms: `ace`
 for a single space; `gap` is either 2+ spaces or a newline.  In Hoon,
 the only significance in whitespace is the difference between
-`ace` and `gap`. Comments start with `::` and run to the end of 
-the line.
+`ace` and `gap`. Comments also count as `gap` whitespace&mdash;they 
+start with `::` and run to the end of the line.
 
 An 80-column right margin is strongly encouraged.  Really 
 well-groomed Hoon uses a 55-column code margin and puts a standard 
@@ -119,7 +119,7 @@ pairs). We pronounce runes using their glyph names&mdash;for `:-`,
 we say "colhep".
 
 Each rune is followed by one or more subexpressions. The number and 
-kind of subexpressions depend on the rune.
+kind of subexpressions depend on the rune used.
 
 ```
 :-  25
@@ -134,7 +134,7 @@ and the second of which becomes the *tail* (i.e., the right).
 Hoon expressions are sometimes called 
 [twigs](https://urbit.org/docs/about/glossary#twig). You'll find that 
 Hoon code has a tree-like structure, so you can think of the various 
-expressions as twigs of this tree.  The subexpressions following the 
+expressions as twigs of the tree.  The subexpressions following the 
 rune are sometimes called the *children* of that twig.
 
 ## Tall and flat forms
@@ -176,15 +176,15 @@ Some twigs have *only* irregular forms.
 
 ## Tall regular form
 
-Tall regular form starts with the rune, followed by a `gap`.
-(Remember, a `gap` is any whitespace other than `ace`.). After 
+Tall regular forms start with a rune followed by a `gap`.
+(Remember, a `gap` is any whitespace other than `ace`.) After 
 that are the number and types of subexpressions appropriate for 
-that rune.  Each subexpression is separated from the others by a 
-`gap`.
+that rune.  Each subexpression is separated from its neighboring 
+subexpressions by a `gap`.
 
 Let's call everything in the twig after the initial rune the twig 
 *body*. There are four body subtypes: *fixed*, *running*, *jogging*, 
-and [battery](https://urbit.org/docs/about/glossary#battery). 
+and *[battery](https://urbit.org/docs/about/glossary#battery)*. 
 
 Runes with a *fixed* number of subexpressions self-terminate. For 
 instance, the `:-` and `.=` runes each have two subexpressions 
@@ -194,12 +194,13 @@ a `gap`, then either `==` (*running* or *jogging*, most twigs) or
 
 The *running* body has a list of *children* (i.e., subexpressions). 
 The *jogging* body has a list of child pairs, where the members of 
-each pair is separated by a `gap`.  The *battery* body is
+each pair are separated by a `gap`.  The *battery* body is
 a list of symbol-child pairs, separated by a gap, prefixed by `++`
 and then a gap.
 
-This definition is enough to write Hoon that will parse.  But the 
-proper shape of the whitespace gaps requires an informal convention.
+This definition is enough to write Hoon that will parse.  But 
+writing code with optimal whitespace management requires some 
+additional informal conventions.
 
 Whitespace design in Hoon is an art, not a science.  It involves
 both tall/flat mode switches and well-shaped gaps.  (Hoon layout
@@ -334,7 +335,7 @@ There is no flat regular form for *battery* bodies.  Be tall.
 
 Hoon does not enforce any rule on symbols, except that capitals
 are not allowed (use kebab-case).  However, a lot of system code
-is written in using "lapidary" conventions that need explanation.
+is written using "lapidary" conventions that need explanation.
 
 Naming things is one of the hard problems in CS.  Dodging this
 problem is one of the reasons mathematicians use Greek letters,

--- a/docs/hoon/syntax.md
+++ b/docs/hoon/syntax.md
@@ -164,9 +164,9 @@ for `:-`, you say "colhep".
 
 Tall regular form starts with the rune, followed by a `gap`
 (any whitespace except `ace`). After this is a 
-*[bulb](https://urbit.org/docs/about/glossary#bulb)*&mdash;the 
-contents of the twig&mdash;whose own twigs are separated by 
-`gap`.
+*[bulb](https://urbit.org/docs/about/glossary#bulb)*&mdash;which 
+defines the types of content the twig can have&mdash;whose own twigs 
+are separated by `gap`.
 
 There are four body subtypes: *fixed*, *running*, *jogging*, and
 *battery*.  Stems with a *fixed* number of subexpressions

--- a/docs/hoon/syntax.md
+++ b/docs/hoon/syntax.md
@@ -153,7 +153,7 @@ Some twigs have *only* irregular forms.
 ## Runes
 
 As mentioned earlier, a regular form starts with a 
-*[rune](https://urbit.org/docs/about/glossary#rune).
+[rune](https://urbit.org/docs/about/glossary#rune).
 
 A *rune* is a pair of ASCII punctuation marks (a digraph)&mdash;e.g.,
 `:-`.  The first glyph in the rune indicates the category&mdash;e.g.,

--- a/docs/hoon/syntax.md
+++ b/docs/hoon/syntax.md
@@ -110,7 +110,7 @@ line comment at column 57.
 
 ## Expressions and Runes
 
-Each regular Hoon expression begins with a  
+Each regular Hoon expression begins with a 
 [rune](https://urbit.org/docs/about/glossary#rune). A rune is a pair 
 of ASCII punctuation marks (a digraph)&mdash;e.g., `:-`.  The first 
 glyph in the rune indicates the category&mdash;e.g., `:` runes make 
@@ -177,10 +177,10 @@ Some twigs have *only* irregular forms.
 ## Tall regular form
 
 Tall regular form starts with the rune, followed by a `gap`.
-(Remember, a `gap` is any whitespace except `ace`, including 
-either comments or line breaks.). After that are the number and 
-types of subexpressions appropriate for that rune.  Each 
-subexpression is separated from the others by a `gap`.
+(Remember, a `gap` is any whitespace other than `ace`.). After 
+that are the number and types of subexpressions appropriate for 
+that rune.  Each subexpression is separated from the others by a 
+`gap`.
 
 Let's call everything in the twig after the initial rune the twig 
 *body*. There are four body subtypes: *fixed*, *running*, *jogging*, 

--- a/docs/hoon/syntax.md
+++ b/docs/hoon/syntax.md
@@ -186,9 +186,10 @@ subexpression is separated from the others by a `gap`.
 
 Let's call everything in the twig after the initial rune the twig 
 *body*. There are four body subtypes: *fixed*, *running*, *jogging*, 
-and *[battery](https://urbit.org/docs/about/glossary#battery)*.  
-Runes with a *fixed* number of subexpressions self-terminate.  
-For instance, the `:-` and `.=` runes each have two subexpressions 
+and *[battery](https://urbit.org/docs/about/glossary#battery)*. 
+
+Runes with a *fixed* number of subexpressions self-terminate. For 
+instance, the `:-` and `.=` runes each have two subexpressions 
 and are self-terminating.  Otherwise the twig is terminated by both
 a `gap`, then either `==` (*running* or *jogging*, most twigs) or
 `--` (*battery*).

--- a/docs/hoon/syntax.md
+++ b/docs/hoon/syntax.md
@@ -7,22 +7,19 @@ title: Syntax
 
 # Hoon syntax
 
-Hoon's semantics are simple, but unusual.  Hoon's syntax is
-complex, and unusual.  Sorry.
+Hoon's syntax is unusual, and to beginners it can look a lot more 
+complex than it really is. However, we believe that anyone who 
+learns Hoon syntax will find that it has a number of advantages.
 
 # Motivation
 
-An excuse: the normal human brain doesn't have hardware support
-for math, but it does have hardware support for syntax.  Learning
-math is harder than it looks.  Learning syntax is easier.
-
-An explanation: the Hoon syntax is trying to solve three serious
+Hoon syntax is trying to solve three serious
 problems in functional syntax design.  These are *terminator
 piles*, *indentation creep*, and *feature/label confusion*.
 
 ## Terminator piles
 
-*Terminator piles* are like Lisp's stacks of right parentheses.
+*Terminator piles* are like Lisp's stacks of right parentheses. 
 Significant whitespace solves this problem and creates others.
 
 Hoon has no terminator piles.  Except for a 1-space / more-space
@@ -32,8 +29,9 @@ distinction, it has no significant whitespace.
 
 *Indentation creep* is a problem caused by indentation conventions
 where the indentation point is a function of expression tree
-depth.  It's true that short functions are better than long ones,
-but long ones sometimes need to be written.
+depth. This problem is especially irritating when working with 
+long functions.  It's true that short functions are better, but 
+long ones sometimes need to be written.
 
 A procedural block has a backbone of statements which flows
 straight down.  Most expressions are flat and of limited depth.
@@ -49,53 +47,37 @@ shaped more or less like procedural programs.
 
 ## Feature/label confusion
 
-*Feature/label confusion* is any syntax which makes it hard for
-the eye to tell whether a token on the screen is a feature of the
-language, or a label in the program.  For example, in Lisp a
+*Feature/label confusion* (FLC) is any syntax which makes it hard 
+for the eye to tell whether a token on the screen is a feature of 
+the language, or a label in the program.  For example, in Lisp a
 special form has the same syntax as a function call.
 
 The worst-case result of FLC is "DSL cancer."  Every source file
 is effectively written in its own domain-specific language.  To
 read a new file is to learn a new language&mdash;"write-only code."
 
-A fixed reserved-word set, especially with syntax highlighting,
-and especially with orthogonal grammar (in C, you don't write
-`for(a b c)`), may not be too bad.  User-level macros, operator
-overloading, even excessive use of higher-order programming,
-can all lead quickly to the tragedy of write-only code.
+User-level macros, operator overloading, even excessive use of 
+higher-order programming, can all lead quickly to the tragedy of 
+write-only code.
 
-Hoon has very weak FLC in keyword style, none in rune style.
-It has no user-level macros or overloading.  It does support
-higher-order programming; write-only Hoon can certainly be
+Hoon has no FLC, user-level macros, or overloading. It does 
+support higher-order programming; write-only Hoon can certainly be
 (and has been) written.  But good Hoon style is to avoid it.
 
 # Design
-
-Hoon expressions are called 
-*[twigs](https://urbit.org/docs/about/glossary#twig)*, and at the 
-beginning of each twig is a 
-*[rune](https://urbit.org/docs/about/glossary#rune)*.  Each rune 
-type has a name, called a 
-*[stem](https://urbit.org/docs/about/glossary#stem)*.  Finally, 
-each stem has its own structure, e.g.:
-
-```
-  :-
-    (add 12 13)
-  (sub 10 7)
-```
-
-This twig uses the rune `:-` (stem: `%clhp`) to produce an ordered 
-pair: `[25 3]`.  There are two subexpressions following the `:-`, 
-corresponding to the two parts of the `%clhp` structure.  
 
 Hoon has a general syntax design with common principles and
 regularities.  We'll cover those here.
 
 ## Glyphs and characters
 
-Hoon is a heavy punctuation user.  To aid pronunciation,
-we've mapped each punctuation glyph to a syllable:
+Hoon source uses ASCII text. Hoon does not accept non-ASCII 
+text in source files, except UTF-8 in quoted strings. Hard
+tab characters are illegal.
+
+Hoon is a heavy punctuation user.  Reading off code aloud 
+using the proper names of ASCII symbols is tedious, so we've 
+mapped each punctuation glyph to a syllable:
 
 ```
 ace [1 space]   gal <               pal (
@@ -112,28 +94,60 @@ fas /           pat @               wut ?
 zap !
 ```
 
-You don't need to memorize these glyph names, but it helps.  Code
-is often vocalized or subvocalized.   "pal" is easier to say,
-aloud or silently, then "left paren."
+You don't need to memorize these glyph names, but it might help. 
+Code is often vocalized or subvocalized. "pal" is easier to say,
+aloud or silently, than "left paren".
 
 Note that the list includes two separate whitespace forms: `ace`
-for a single space, `gap` for 2+, comment or newline.  In Hoon,
+for a single space, `gap` for 2+, comment, and newline.  In Hoon,
 the only significance in whitespace is the difference between
-`ace` and `gap`.
+`ace` and `gap`. Comments start with `::` and run to the end of 
+the line.
 
-Comments start with `::` and run to the end of the line.  Hard
-tab characters are illegal, and an 80-column right margin is
-strongly encouraged.  Really well-groomed Hoon uses a 55-column
-code margin and puts a standard line comment at column 57.
+An 80-column right margin is strongly encouraged.  Really 
+well-groomed Hoon uses a 55-column code margin and puts a standard 
+line comment at column 57.
 
-Hoon does not accept non-ASCII text in source files, except UTF-8
-in quoted strings.
+## Expressions and Runes
+
+Each regular Hoon expression begins with a  
+[rune](https://urbit.org/docs/about/glossary#rune). A rune is a pair 
+of ASCII punctuation marks (a digraph)&mdash;e.g., `:-`.  The first 
+glyph in the rune indicates the category&mdash;e.g., `:` runes make 
+[cells](https://urbit.org/docs/about/glossary#cell) (i.e., ordered 
+pairs). We pronounce runes using their glyph names&mdash;for `:-`, 
+we say "colhep".
+
+Each rune is followed by one or more subexpressions. The number and 
+kind of subexpressions depend on the rune.
+
+```
+:-
+  25
+3
+```
+
+This twig uses `:-` to produce a cell: `[25 3]`. There are always two 
+subexpressions following the `:-` in syntactically correct Hoon code, 
+the first of which, when evaluated, becomes the *head* (i.e., the left) 
+and the second of which becomes the *tail* (i.e., the right).
+
+Hoon expressions are sometimes called 
+[twigs](https://urbit.org/docs/about/glossary#twig). You'll find that 
+Hoon code has a tree-like structure, so you can think of the various 
+expressions as twigs of this tree.  The subexpressions following the 
+rune are sometimes called the *children* of that twig.
 
 ## Tall and flat forms
 
 There are two kinds of Hoon expression syntax: *tall* and *flat*.
-Most stems have both tall and flat forms.  Tall twigs can contain
-flat twigs, but not vice versa.
+Most runes can be used in both tall and flat twigs. Tall twigs can 
+contain flat twigs, but not vice versa.
+
+The `:-` expression in the last subsection was in tall form.  Here's 
+the flat equivalent:
+
+`:-(25 3)`
 
 Visually, a tall twig looks like a "statement" and a flat twig
 like an "expression," preserving the attractive visual shape of
@@ -141,47 +155,52 @@ procedural code without the nasty side effects.
 
 ## Regular and irregular forms
 
-Most stems have *regular forms*, which share a common design.
-There is a regular flat form and a regular tall form; most stems
-implement both.  All tall forms are regular.
+Most runes have *regular forms*, which share a common design.
+There is a regular flat form and a regular tall form; most runes
+have both kinds of implementation.  All tall forms are regular.
 
-Some twigs also have *irregular forms*, which follow no
+Some runes also have *irregular forms*, which follow no
 principles at all.  All irregular forms are flat.
+
+```
+.=
+  22
+23
+```
+
+The `.=` rune tests for equality the two subexpressions that 
+follow, and returns a boolean. Above is the tall, regular form of 
+`.=`.  Below is the irregular form:
+
+`=(22 23)`
 
 Some twigs have *only* irregular forms.
 
-## Runes
-
-As mentioned earlier, a regular form starts with a 
-[rune](https://urbit.org/docs/about/glossary#rune).
-
-A *rune* is a pair of ASCII punctuation marks (a digraph)&mdash;e.g.,
-`:-`.  The first glyph in the rune indicates the category&mdash;e.g.,
-`:` runes make cells.  Runes can be pronounced by their glyphs&mdash;
-for `:-`, you say "colhep".
-
 ## Tall regular form
 
-Tall regular form starts with the rune, followed by a `gap`
-(any whitespace except `ace`). After this is a 
-*[bulb](https://urbit.org/docs/about/glossary#bulb)*&mdash;which 
-defines the types of content the twig can have&mdash;whose own twigs 
-are separated by `gap`.
+Tall regular form starts with the rune, followed by a `gap`.
+(Remember, a `gap` is any whitespace except `ace`, including 
+either comments or line breaks.). After that are the number and 
+types of subexpressions appropriate for that rune.  Each 
+subexpression is separated from the others by a `gap`.
 
-There are four body subtypes: *fixed*, *running*, *jogging*, and
-*battery*.  Stems with a *fixed* number of subexpressions
-self-terminate.  For instance, `?:` has three subexpressions and
-is self-terminating.  Otherwise the twig is terminated by a
-`gap`, then either `==` (*running* or *jogging*, most twigs) or
+Let's call everything in the twig after the initial rune the twig 
+*body*. There are four body subtypes: *fixed*, *running*, *jogging*, 
+and *[battery](https://urbit.org/docs/about/glossary#battery)*.  
+Runes with a *fixed* number of subexpressions self-terminate.  
+For instance, the `:-` and `.=` runes each have two subexpressions 
+and are self-terminating.  Otherwise the twig is terminated by both
+a `gap`, then either `==` (*running* or *jogging*, most twigs) or
 `--` (*battery*).
 
-The *running* body is a list of twigs.  The *jogging* body is a
-list of twig pairs, separated by a `gap`.  The *battery* body is
-a list of symbol-twig pairs, separated by a gap, prefixed by `++`
+The *running* body has a list of *children* (i.e., subexpressions). 
+The *jogging* body has a list of child pairs, where the members of 
+each pair is separated by a `gap`.  The *battery* body is
+a list of symbol-child pairs, separated by a gap, prefixed by `++`
 and then a gap.
 
-This definition is enough to parse.  But the proper shape of the
-whitespace gaps demands an informal convention.
+This definition is enough to write Hoon that will parse.  But the 
+proper shape of the whitespace gaps rquiress an informal convention.
 
 Whitespace design in Hoon is an art, not a science.  It involves
 both tall/flat mode switches and well-shaped gaps.  (Hoon layout
@@ -190,15 +209,15 @@ But it would at least take machine learning, not a rule engine.)
 
 There are only two real *rules* in Hoon whitespace design: don't
 go past 80 characters, and don't use (completely) blank lines.
-Otherwise, if it looks good and is easy to read, it's good.  But
-the best way to learn the art is to do everything by convention
+Otherwise, if it looks good and is easy to read, it's good.  The 
+best way to learn the art is to do everything by convention
 until you know what you're doing.  Here are the conventions:
 
 ### Conventions: *fixed*
 
-Bulbs with *fixed* fanout use "backstep" indentation, which slopes
-backward and to the right by two spaces per line.  The first
-child is two spaces after the end of the sigil.
+Twig bodies with *fixed* fanout use "backstep" indentation, which 
+slopes backward and to the right by two spaces per line.  The first
+twig child is two spaces after the end of the rune.
 
 Some *1-fixed*, *2-fixed*, *3-fixed* and *4-fixed* examples:
 
@@ -219,15 +238,14 @@ r
 s
 ```
 
-The hope of backstep indentation is that the heaviest twigs are
-at the bottom, keeping code flow vertical rather than diagonal.
-
+In optimal usage of backstep indentation, the most complicated twigs 
+are at the bottom, keeping code flow vertical rather than diagonal.
 
 ### Conventions: *running*
 
-A *running* bulb (a simple child list) puts the first child two
-spaces after the end of the sigil, and the following children
-straight down:
+A *running* twig body (a simple child list) puts the first child two
+spaces after the end of the rune, and the following children straight 
+down:
 
 A *running* example:
 
@@ -242,10 +260,11 @@ A *running* example:
 
 ### Conventions: *jogging*
 
-A *jogging* bulb (a list of child pairs) is like a running bulb,
-but backsteps the head of the pair above the tail.  Most jogging
-twigs start with a *fixed* sequence; the first jogging pair is
-below and two steps backward from the last fixed child.
+A *jogging* twig body (a list of child pairs) is like a running 
+body, but with a pair of children on each line, separated by 
+two spaces. Most jogging bodies start with a *fixed* sequence; 
+the first jogging pair is below and two steps backward from the 
+last fixed child.
 
 There are two jogging conventions: *flat* (pair on one line) and
 *tall* (pair split across lines).
@@ -275,7 +294,7 @@ A *tall jogging* example (preceded by *1-fixed* `p`):
 
 ### Conventions: *battery*
 
-A *battery* bulb is a list of symbol-twig pairs, for the
+A *battery* body has a list of symbol-child pairs, for the
 *[battery](https://urbit.org/docs/about/glossary#battery)*
 of a 
 *[core](https://urbit.org/docs/about/glossary#core)*.  A 
@@ -294,24 +313,20 @@ conventional example:
 
 ## Flat regular form
 
-Flat regular form starts with the rune, followed by `pal`
-(`(`, left parenthesis), followed by a bulb whose subexpressions
-are separated by `ace` (one space), followed by `par` (`)`, right
+Flat regular form starts with the rune, followed by `pal`, `(` 
+(left parenthesis), followed by a body whose subexpressions
+are separated by `ace` (one space), followed by `par`, `)` (right
 parenthesis).
 
 A twig in flat form, `:if`, `?:`, `{$if p/twig q/twig r/twig}`:
 
-```
-:if(p q r)
-
-?:(p q r)
-```
+`?:(p q r)`
 
 The only exception is *jogging* bodies, in which subexpression
 pairs are separated by commas:
 
 ```
-:make(foo bar 42, baz 55, moo 17)
+foo(bar 42, baz 55, moo 17)
 ```
 
 There is no flat regular form for *battery* bodies.  Be tall.
@@ -340,11 +355,11 @@ appropriate.
 
 In the *ultralapidary* naming style, labels are single letters,
 starting in order of construction from `a`, or within a tuple
-mold `p`.  Hoon uses single-letter names for the same reason
-Algol style languages pass arguments by order, rather than
-keyword.  Naming items by order makes sense when there are no
-more than three or four; five is stretching it; six is outright
-ridiculous.
+[mold](https://urbit.org/docs/about/glossary#mold) `p`.  Hoon 
+uses single-letter names for the same reason Algol style 
+languages pass arguments by order, rather than keyword.  Naming 
+items by order makes sense when there are no more than three or 
+four; five is stretching it; six is outright ridiculous.
 
 For example, when defining `add`, we want to name the operands
 `a` and `b`.  It's silly to call them `foo` and `bar`, let alone

--- a/docs/hoon/syntax.md
+++ b/docs/hoon/syntax.md
@@ -85,7 +85,7 @@ each stem has its own structure, e.g.:
   (sub 10 7)
 ```
 
-This twig uses the rune `:-` (stem: `cons`) to produce an ordered 
+This twig uses the rune `:-` (stem: "cons") to produce an ordered 
 pair: `[25 3]`.  There are two subexpressions following the `:-`, 
 corresponding to the two parts of the `cons` structure.  
 

--- a/docs/hoon/syntax.md
+++ b/docs/hoon/syntax.md
@@ -56,7 +56,7 @@ special form has the same syntax as a function call.
 
 The worst-case result of FLC is "DSL cancer."  Every source file
 is effectively written in its own domain-specific language.  To
-read a new file is to learn a new language -- "write-only code."
+read a new file is to learn a new language&mdash;"write-only code."
 
 A fixed reserved-word set, especially with syntax highlighting,
 and especially with orthogonal grammar (in C, you don't write
@@ -71,15 +71,19 @@ higher-order programming; write-only Hoon can certainly be
 
 # Design
 
-Because each twig stem has its own bulb, each has its own parser
-rule.  We'll describe these grammars as we go through the stems.
+Hoon expressions are called 
+*[twigs](https://urbit.org/docs/about/glossary#twig)*. The name 
+of a twig is its 
+*[stem](https://urbit.org/docs/about/glossary#stem)*.  Because 
+each twig stem has its own structure, each has its own parser
+rule. We'll describe these grammars as we go through the stems.
 
 But Hoon has a general syntax design with common principles and
 regularities.  We'll cover those here.
 
 ## Glyphs and characters
 
-Hoon is a heavy punctuation user.  To make ASCII great again,
+Hoon is a heavy punctuation user.  To aid pronunciation,
 we've mapped each punctuation glyph to a syllable:
 
 ```
@@ -133,17 +137,20 @@ implement both.  All tall forms are regular.
 Some twigs also have *irregular forms*, which follow no
 principles at all.  All irregular forms are flat.
 
-Some twigs (simple leafy ones) have *only* irregular forms.
+Some twigs have *only* irregular forms.
 
 ## Keywords versus runes
 
-A regular form starts with a *sigil*, which is either a
-*keyword* or a *rune* -- at the programmer's choice.
+A regular form starts with a 
+*[sigil](https://urbit.org/docs/about/glossary#sigil)*, which is 
+either a *keyword* or a 
+*[rune](https://urbit.org/docs/about/glossary#rune)*&mdash;at 
+the programmer's choice.
 
-A *keyword* is `:` and then the stem label - e.g., `:cons`.
+A *keyword* is `:` and then the stem label&mdash;e.g., `:cons`.
 
-A *rune* is a pair of ASCII punctuation marks (a digraph) - e.g.,
-`:-`.  The first glyph in the rune indicates the category - e.g.,
+A *rune* is a pair of ASCII punctuation marks (a digraph)&mdash;e.g.,
+`:-`.  The first glyph in the rune indicates the category&mdash;e.g.,
 `:` runes make cells.  Runes can be pronounced by their glyphs or
 by their stem -- for `:-`, you can say either "colhep" or "cons".
 
@@ -174,8 +181,10 @@ with the [original](../demo).
 ## Tall regular form
 
 Tall regular form starts with the sigil, followed by a `gap`
-(any whitespace except `ace`), followed by a bulb whose twigs are
-separated by `gap`.
+(any whitespace except `ace`). After this is a 
+*[bulb](https://urbit.org/docs/about/glossary#bulb)*&mdash;the 
+contents of the twig&mdash;whose own twigs are separated by 
+`gap`.
 
 There are four body subtypes: *fixed*, *running*, *jogging*, and
 *battery*.  Stems with a *fixed* number of subexpressions
@@ -284,8 +293,11 @@ A *tall jogging* example (preceded by *1-fixed* `p`):
 
 ### Conventions: *battery*
 
-A *battery* bulb is a list of symbol-twig pairs, for the battery
-of a core.  A conventional example:
+A *battery* bulb is a list of symbol-twig pairs, for the
+*[battery](https://urbit.org/docs/about/glossary#battery)*
+of a 
+*[core](https://urbit.org/docs/about/glossary#core)*.  A 
+conventional example:
 
 ```
 |%

--- a/docs/hoon/syntax.md
+++ b/docs/hoon/syntax.md
@@ -186,7 +186,7 @@ subexpression is separated from the others by a `gap`.
 
 Let's call everything in the twig after the initial rune the twig 
 *body*. There are four body subtypes: *fixed*, *running*, *jogging*, 
-and *[battery](https://urbit.org/docs/about/glossary#battery)*. 
+and [battery](https://urbit.org/docs/about/glossary#battery). 
 
 Runes with a *fixed* number of subexpressions self-terminate. For 
 instance, the `:-` and `.=` runes each have two subexpressions 
@@ -296,9 +296,9 @@ A *tall jogging* example (preceded by *1-fixed* `p`):
 ### Conventions: *battery*
 
 A *battery* body has a list of symbol-child pairs, for the
-*[battery](https://urbit.org/docs/about/glossary#battery)*
+[battery](https://urbit.org/docs/about/glossary#battery)
 of a 
-*[core](https://urbit.org/docs/about/glossary#core)*.  A 
+[core](https://urbit.org/docs/about/glossary#core).  A 
 conventional example:
 
 ```

--- a/docs/hoon/syntax.md
+++ b/docs/hoon/syntax.md
@@ -85,9 +85,9 @@ each stem has its own structure, e.g.:
   (sub 10 7)
 ```
 
-This twig uses the rune `:-` (stem: "cons") to produce an ordered 
+This twig uses the rune `:-` (stem: `%clhp`) to produce an ordered 
 pair: `[25 3]`.  There are two subexpressions following the `:-`, 
-corresponding to the two parts of the `cons` structure.  
+corresponding to the two parts of the `%clhp` structure.  
 
 Hoon has a general syntax design with common principles and
 regularities.  We'll cover those here.
@@ -157,8 +157,8 @@ As mentioned earlier, a regular form starts with a
 
 A *rune* is a pair of ASCII punctuation marks (a digraph)&mdash;e.g.,
 `:-`.  The first glyph in the rune indicates the category&mdash;e.g.,
-`:` runes make cells.  Runes can be pronounced by their glyphs or
-by their stem&mdash;for `:-`, you can say either "colhep" or "cons".
+`:` runes make cells.  Runes can be pronounced by their glyphs&mdash;
+for `:-`, you say "colhep".
 
 ## Tall regular form
 

--- a/docs/hoon/syntax.md
+++ b/docs/hoon/syntax.md
@@ -201,7 +201,7 @@ a list of symbol-child pairs, separated by a gap, prefixed by `++`
 and then a gap.
 
 This definition is enough to write Hoon that will parse.  But the 
-proper shape of the whitespace gaps rquiress an informal convention.
+proper shape of the whitespace gaps requires an informal convention.
 
 Whitespace design in Hoon is an art, not a science.  It involves
 both tall/flat mode switches and well-shaped gaps.  (Hoon layout


### PR DESCRIPTION
....or at least linking them to the glossary.  Some of the explanations I give are pretty dumb, but in these cases a link to the real definition is right there.  I think this kind of bootstrapping can be useful, but maybe it's too inexact.  Slap me down if you must, but let's not leave this doc as unfriendly as it currently is for beginners.