### PR TITLE
Update install.md

### DIFF
--- a/docs/using/install.md
+++ b/docs/using/install.md
@@ -64,7 +64,7 @@ Urbit depends on:
     curses
     gmp
     libsigsegv
-    openssl
+    openssl 1.0.0
 
 Which can usually be installed with the following one-liners:
 


### PR DESCRIPTION
specified that openssl 1.0.0 is the dependency instead of openssl, because some suites (specifically in my case with debian's 'stretch') don't have backports for openssl because specifically the issue I had with installing was one of its dependencies, libssl1.0.0 which seems to be an explicit required version. libssl1.1 and libssl1.0.2 both did not complete the urbit install. I was able to get libssl1.0.0 from jessie and install it onto stretch which solved the issue.