### PR TITLE
Update to Demo, Syntax, and Concepts docs

### DIFF
--- a/docs/hoon/concepts.md
+++ b/docs/hoon/concepts.md
@@ -94,10 +94,8 @@ an AST, becomes the tagged union:
 [%clhp p=hoon q=hoon]
 ```
 
-The %clhp is for "colhep".
-
-Keep in mind that `p` and `q` would be parsed too.  So if `p` is `2` 
-and `q` is 17, the parsed result is:
+The `%clhp` is for "colhep". Keep in mind that `p` and `q` would be 
+parsed too.  So if `p` is `2` and `q` is 17, the parsed result is:
 
 ```
 [%clhp p=[%sand p=%ud q=2] q=[%sand p=%ud q=17]]

--- a/docs/hoon/concepts.md
+++ b/docs/hoon/concepts.md
@@ -80,7 +80,7 @@ it's still fun and useful to [learn more](../../nock).
 ### <a name="hoon">`hoon`</a> (AST node)
 
 A [`hoon`](../reference) is the result of parsing a Hoon source 
-expression into an AST node. Because every Hoon programs is, 
+expression into an AST node. Because every Hoon program is, 
 in its entirety, a single expression of Hoon, the result of parsing 
 a whole Hoon program into an AST is a single `hoon`.
 
@@ -101,7 +101,9 @@ parsed too.  So if `p` is 2 and `q` is 17, the parsed result is:
 [%clhp p=[%sand p=%ud q=2] q=[%sand p=%ud q=17]]
 ```
 
-To parse Hoon source into a hoon AST, use `ream` on a `cord`, e.g.:
+The 2 and 17 have each been parsed as `%sand`-tagged `hoon`s, which 
+represent constant atoms. To parse Hoon source into a hoon AST, use 
+`ream` on a `cord`, e.g.:
 
 ```
 (ream ':-(2 17)')
@@ -151,8 +153,13 @@ is the hoon.
 
 A `type` defines a set (finite or infinite) of nouns and ascribes 
 some semantics to it.  There is no direct syntax for defining 
-types; they are always defined by inference (ie, by
+types; they are always defined by inference (i.e., by
 [`mint`](#mint)), usually using a constructor (`mold`).
+
+All types are assembled out of base types defined in `++type`. 
+(Look up `++  type` in hoon.hoon for examples.) When the compiler 
+does type-inference on a prorgam, it assembles complex types out 
+of the simpler built-in types.
 
 ### `gate` (function)
 
@@ -211,9 +218,11 @@ To resolve limb `foo`, [`mint`](#mint) searches the subject depth-first,
 head-first for either a `face` named `foo`, or a `core` with the
 arm `foo`.  If it finds a face, the product is a *leg*, or
 subtree of the subject.  If it finds a core, it computes the arm
-formula with that core as the subject.
+formula with that core as the subject. A limb can also be a slot 
+(direct tree address), like `+15`.
 
-A limb can also be a slot (direct tree address), like `+15`.
+The hoon compiler always resolves a limb to a tree axis lookup, 
+regardless of the kind of limb.
 
 `boo:[foo=12 baz=23 boo=34]` evaluates to `34`. 
 `+6:[foo=12 baz=23 boo=34]` evaluates to `baz=23`.

--- a/docs/hoon/concepts.md
+++ b/docs/hoon/concepts.md
@@ -85,8 +85,8 @@ in its entirety, a single expression of Hoon, the result of parsing
 a whole Hoon program into an AST is a single `hoon`.
 
 As the noun that the parser produces, a hoon is a tagged union of
-the form `[tag data]`, where the tag is a constant such as `%brts`
-which matches up with the appropriate type of data (often more 
+the form `[tag data]`, where the tag is a constant such as `%brts`,
+which is matched up with the appropriate type of data (often more 
 `hoon`s).  For example, the expression `:-(p q)`, once parsed into 
 an AST, becomes the tagged union:
 

--- a/docs/hoon/concepts.md
+++ b/docs/hoon/concepts.md
@@ -98,14 +98,16 @@ and is matched up with the appropriate type of data (often more
 The `%clhp` is produced from the rune `:-` (i.e. "colhep"). The 2 and 
 17 have each been parsed as `%sand`-tagged hoons, which represent 
 atoms (in this case each with an aura of `%ud`, i.e. unsigned 
-decimal). To parse Hoon source into a hoon AST, use `ream` on a `cord` 
-containing Hoon source, e.g.:
+decimal).
+
+To parse Hoon source into a hoon AST, use `ream` on a `cord` 
+containing Hoon source, try the following in `dojo`:
 
 ```
 (ream ':+(12 7 %a)')
 ```
 
-Try the above in the `:dojo` to get:
+The result should be:
 
 ```
 [%clls p=[%sand p=%ud q=12] q=[%sand p=%ud q=7] r=[%rock p=%tas q=97]]
@@ -116,19 +118,14 @@ Try the above in the `:dojo` to get:
 [`mint`](#mint) is the Hoon compiler.  It maps a cell `[type hoon]`
 to a cell `[type nock]`, where a [`type`](#type) is type 
 information, a [`hoon`](#hoon) is a parsed expression (AST), and a 
-`nock` is a Nock formula. `mint` accepts a type and a parsed 
-source expression; it produces a product type and an executable 
-formula.
-
-As part of the type-checking process, mint checks that the output 
-type "nests" within the input type, i.e. that the output type is a 
-subset of the input type. If not, mint halts with a `nest-fail` 
-crash.
+`nock` is a Nock formula. `mint` takes as input the subject type 
+and a parsed source expression; it produces a product type and an 
+executable formula.
 
 Calculating the output type from the input `hoon` is called "type 
 inference". If you've used another typed functional language, like 
-Haskell, Hoon's type inference does the same job but with less 
-intelligence.
+Haskell, the Hoon compiler's type inference does the same job but 
+with less intelligence.
 
 Haskell infers backward and forward; Hoon only infers forward.
 Hoon can't figure out the type of a noun from how you use it,
@@ -140,15 +137,27 @@ which makes your program more readable anyway.  Also, the dumber
 the compiler, the easier it is for a dumb human to understand
 what the compiler is thinking.
 
-To compile an example `hoon` from the last subsection into Nock, 
-try the following in `:dojo`:
+The `mint` gate is inside the core `++  ut`, so call it using the 
+following syntax:
 
 ```
-(mint:ut %noun [%clhp p=[%sand p=%ud q=2] q=[%sand p=%ud q=17]])
+(~(<gate> <core> <arg 1>) <arg 2> <arg 3>)
 ```
 
-The `%noun` is the input `type` for `mint`, and the tree after that 
-is the input `hoon`.
+The `<gate>` is mint, the `<core>` is `ut`, `<arg 1>` is the subject 
+type, and `<arg 3>` is the parsed Hoon AST (i.e., a `hoon` from the 
+last section). What's `<arg 2>`? It's another piece of type 
+information. As part of the type-checking process, mint checks that 
+the output type "nests" within the input type, i.e. that the output 
+type is a subset of the input type. If not, mint halts with a 
+`nest-fail` crash. 
+
+Let's compile an example `hoon` from the last subsection into Nock. 
+Try the following in `:dojo`:
+
+```
+(~(mint ut %noun) %noun [%clhp p=[%sand p=%ud q=2] q=[%sand p=%ud q=17]])
+```
 
 ### <a name="type">`type`</a> (type, as range)
 

--- a/docs/hoon/concepts.md
+++ b/docs/hoon/concepts.md
@@ -146,8 +146,8 @@ following in `:dojo`:
 (mint:ut %noun [%clhp p=[%sand p=%ud q=2] q=[%sand p=%ud q=17]])
 ```
 
-The `%noun` is type information, and the tagged union after that 
-is the hoon.
+The `%noun` is for the data type of the subject, and the tagged 
+union after that is the hoon.
 
 ### <a name="type">`type`</a> (type, as range)
 

--- a/docs/hoon/concepts.md
+++ b/docs/hoon/concepts.md
@@ -95,7 +95,7 @@ an AST, becomes the tagged union:
 ```
 
 The `%clhp` is for "colhep". Keep in mind that `p` and `q` would be 
-parsed too.  So if `p` is `2` and `q` is 17, the parsed result is:
+parsed too.  So if `p` is 2 and `q` is 17, the parsed result is:
 
 ```
 [%clhp p=[%sand p=%ud q=2] q=[%sand p=%ud q=17]]

--- a/docs/hoon/concepts.md
+++ b/docs/hoon/concepts.md
@@ -101,7 +101,7 @@ atoms (in this case each with an aura of `%ud`, i.e. unsigned
 decimal).
 
 To parse Hoon source into a hoon AST, use `ream` on a `cord` 
-containing Hoon source, try the following in `dojo`:
+containing Hoon source. Try the following in `dojo`:
 
 ```
 (ream ':+(12 7 %a)')
@@ -122,10 +122,10 @@ information, a [`hoon`](#hoon) is a parsed expression (AST), and a
 and a parsed source expression; it produces a product type and an 
 executable formula.
 
-Calculating the output type from the input `hoon` is called "type 
-inference". If you've used another typed functional language, like 
-Haskell, the Hoon compiler's type inference does the same job but 
-with less intelligence.
+Calculating the output type from the input `hoon` and subject type 
+is called "type inference". If you've used another typed functional 
+language, like Haskell, the Hoon compiler's type inference does the 
+same job but with less intelligence.
 
 Haskell infers backward and forward; Hoon only infers forward.
 Hoon can't figure out the type of a noun from how you use it,

--- a/docs/hoon/concepts.md
+++ b/docs/hoon/concepts.md
@@ -32,7 +32,7 @@ a few new words is a small price for avoiding this pain point.
 ## Concepts
 
 A few major Hoon concepts: `noun` (data), `nock` (interpreter),
-[`mint`](#mint) (compiler), [`hoon`](#hoon) (AST node),
+[`hoon`](#hoon) (AST node), [`mint`](#mint) (compiler), 
 `gate` (function), `mold` (constructor), `core` (object), `mark`
 (protocol).
 
@@ -117,11 +117,12 @@ Try it in the `:dojo` to get:
 
 ### <a name="mint">`mint`</a> (compiler)
 
-[`mint`](#mint) is the Hoon compiler.  It maps a cell `[type hoon]` to a
-cell `[type nock]`, where a [`type`](#type) is a type, a [`hoon`](#hoon)
-is a parsed expression (AST), and a `nock` is a Nock formula.  `mint` accepts
-a subject type and a parsed source expression; it produces a product type
-and an executable formula.
+[`mint`](#mint) is the Hoon compiler.  It maps a cell `[type hoon]`
+to a cell `[type nock]`, where a [`type`](#type) is type 
+information, a [`hoon`](#hoon) is a parsed expression (AST), and a 
+`nock` is a Nock formula.  `mint` accepts a subject type and a parsed 
+source expression; it produces a product type and an executable 
+formula.
 
 Calculating the output type from the input type and the source
 code is called "type inference". If you've used another typed

--- a/docs/hoon/demo.md
+++ b/docs/hoon/demo.md
@@ -29,19 +29,19 @@ $(count (add 1 count))          :: 15
 ```
 
 Hoon is a functional language.  FizzBuzz is usually defined as a
-side effect, but officially Hoon has no side effects.  This code 
-will *return* a list of strings, not *print* a list of strings. 
-(Of course, if you run this code from the Urbit `dojo` (shell) you 
-will be able to see the product.)
+side effect, but officially Hoon has no side effects.  Accordingly, 
+this code will *return* a list of strings, not *print* a list of 
+strings. (Of course, if you run this code from the Urbit `dojo` 
+(shell) you will be able to see the product.)
 
 The code produces a list in which each item is either a number 
 (as a string), "Fizz", "Buzz", or "Fizzbuzz". The value `~` is 
 "null" and indicates the end of the list.
 
 Line 1 uses the `|=` 
-*[rune](https://urbit.org/docs/about/glossary#rune)* to define a 
-function of one argument, `end`, which is of the type `atom` (i.e. 
-an unsigned integer).
+[rune](https://urbit.org/docs/about/glossary#rune) to define a 
+function that takes one argument, labelled `end`.  The argument 
+is of the type `atom` (i.e. an unsigned integer).
 
 Line 2 declares a variable, `count`, with initial value `1`.
 
@@ -49,8 +49,8 @@ Line 3 begins a loop.
 
 Line 4 defines the product of the loop as a list of `tape`s. 
 (A `tape` is a list of characters, one of Hoon's two string 
-types.)  The `^-` rune is used for defining the product type the function 
-is to return. 
+types.)  The `^-` rune is used for defining the type of data the 
+function is to return. 
 
 Line 5 uses the `?:` rune, which is a conditional. This line 
 checks whether `count` equals `end`.  If so, line 6 (and the

--- a/docs/hoon/demo.md
+++ b/docs/hoon/demo.md
@@ -55,7 +55,7 @@ function is to return.
 Line 5 uses the `?:` rune, which is a conditional. This line 
 checks whether `count` equals `end`.  If so, line 6 (and the
 whole loop) returns the value `~`.  The list is finished.  If not, 
-line 7 produces a `cell`, which is an ordered pair. The pair will 
+line 7 produces a 'cell', which is an ordered pair. The pair will 
 be: (a) the next item in the list, determined by lines 8-14; and 
 (b) the rest of the list, determined by line 15.
 

--- a/docs/hoon/demo.md
+++ b/docs/hoon/demo.md
@@ -55,9 +55,9 @@ function is to return.
 Line 5 uses the `?:` rune, which is a conditional. This line 
 checks whether `count` equals `end`.  If so, line 6 (and the
 whole loop) returns the value `~`.  The list is finished.  If not, 
-line 7 produces an ordered pair.  This pair will be: (a) the next 
-item in the list, determined by lines 8-14; and (b) the rest of 
-the list, determined by line 15.
+line 7 produces a `cell`, which is an ordered pair. The pair will 
+be: (a) the next item in the list, determined by lines 8-14; and 
+(b) the rest of the list, determined by line 15.
 
 (a) The head of the pair is: (i) "FizzBuzz", or "Fizz", or 
 "Buzz", if the respective tests hit; otherwise, it's 

--- a/docs/hoon/reference.md
+++ b/docs/hoon/reference.md
@@ -1,12 +1,12 @@
 ---
 navhome: /docs/
 sort: 21
-title: Twig reference
+title: Expression reference
 ---
 
-# Twig reference
+# Expression reference
 
-#### A catalog of all twig stems:
+#### A catalog of expressions:
 
 <div class="book">
 

--- a/docs/hoon/syntax.md
+++ b/docs/hoon/syntax.md
@@ -119,37 +119,42 @@ pairs). We pronounce runes using their glyph names&mdash;for `:-`,
 we say "colhep".
 
 Each rune is followed by one or more subexpressions. The number and 
-kind of subexpressions depend on the rune used.
+kind of subexpressions depend on which rune is used.
 
 ```
 :-  25
 3
 ```
 
-This twig uses `:-` to produce a cell: `[25 3]`. There are always two 
-subexpressions following the `:-` in syntactically correct Hoon code, 
-the first of which, when evaluated, becomes the *head* (i.e., the left) 
-and the second of which becomes the *tail* (i.e., the right).
+The `:-` rune is always followed by two 'value' subexpressions to 
+produce a cell: `[25 3]`. The first subexpression, when evaluated, 
+becomes the *head* (i.e., the left) of the cell, and the second 
+becomes the *tail* (i.e., the right).
 
-Hoon expressions are sometimes called 
-[twigs](https://urbit.org/docs/about/glossary#twig). You'll find that 
-Hoon code has a tree-like structure, so you can think of the various 
-expressions as twigs of the tree.  The subexpressions following the 
-rune are sometimes called the *children* of that twig.
+There are two kinds of expressions in Hoon: *value* and *pattern*. 
+Value expressions evaluate to any sort of data. They can be as simple 
+as `25`, or they may require more computation, as in `(add 22 3)`. The 
+`:-` expression above is itself a value expression, as are the vast 
+majority of Hoon expressions.
 
-## Tall and flat forms
+A pattern expression must be a *mold*, which we'll explain a bit 
+[later](https://urbit.org/docs/hoon/basic).
 
-There are two kinds of Hoon expression syntax: *tall* and *flat*.
-Most runes can be used in both tall and flat twigs. Tall twigs can 
-contain flat twigs, but not vice versa.
+## Tall and flat styles
 
-The `:-` expression in the last subsection was in tall form.  Here's 
+There are two styles of Hoon expression syntax: *tall* and *flat*.
+Most runes can be used in both tall and flat styles. Tall expressions 
+are (typically) multi-line, but flat expressions must not have line 
+breaks in them. Tall expressions may contain flat ones, but not vice 
+versa.
+
+The `:-` expression in the last subsection was in tall style.  Here's 
 the flat equivalent:
 
 `:-(25 3)`
 
-Visually, a tall twig looks like a "statement" and a flat twig
-like an "expression," preserving the attractive visual shape of
+Visually, the tall style looks more "statement"-like and flat-style 
+looks "expression"-like, preserving the attractive visual shape of
 procedural code without the nasty side effects.
 
 ## Regular and irregular forms
@@ -159,7 +164,7 @@ There is a regular flat form and a regular tall form; most runes
 have both kinds of implementation.  All tall forms are regular.
 
 Some runes also have *irregular forms*, which follow no
-principles at all.  All irregular forms are flat.
+general principles at all.  All irregular forms are flat.
 
 ```
 .=  22
@@ -172,52 +177,51 @@ follow, and returns a boolean. Above is the tall, regular form of
 
 `=(22 23)`
 
-Some twigs have *only* irregular forms.
+Some kinds of expression have *only* irregular forms.
 
 ## Tall regular form
 
 Tall regular forms start with a rune followed by a `gap`.
-(Remember, a `gap` is any whitespace other than `ace`.) After 
-that are the number and types of subexpressions appropriate for 
-that rune.  Each subexpression is separated from its neighboring 
-subexpressions by a `gap`.
+(Remember, a `gap` is any whitespace other than `ace`, or a line 
+break.) After that are the number and types of subexpressions 
+appropriate for that rune.  Each subexpression is separated from 
+its neighboring subexpressions by a `gap`.
 
-Let's call everything in the twig after the initial rune the twig 
-*body*. There are four body subtypes: *fixed*, *running*, *jogging*, 
+Everything after the initial rune in an expression is called the 
+*body*. There are four body types: *fixed*, *running*, *jogging*, 
 and *[battery](https://urbit.org/docs/about/glossary#battery)*. 
 
 Runes with a *fixed* number of subexpressions self-terminate. For 
 instance, the `:-` and `.=` runes each have two subexpressions 
-and are self-terminating.  Otherwise the twig is terminated by both
-a `gap`, then either `==` (*running* or *jogging*, most twigs) or
-`--` (*battery*).
+and are self-terminating.  Otherwise the body is terminated by a 
+`gap` followed by either `==` (*running* or *jogging*, most runes) 
+or `--` (*battery*).
 
-The *running* body has a list of *children* (i.e., subexpressions). 
-The *jogging* body has a list of child pairs, where the members of 
+The *running* body is a list of *children* (i.e., subexpressions). 
+The *jogging* body is a list of child pairs, where the members of 
 each pair are separated by a `gap`.  The *battery* body is
-a list of symbol-child pairs, separated by a gap, prefixed by `++`
-and then a gap.
+a list of symbol-child pairs, each separated by a `gap`. See below 
+for examples of each body type.
 
 This definition is enough to write Hoon that will parse.  But 
 writing code with optimal whitespace management requires some 
 additional informal conventions.
 
 Whitespace design in Hoon is an art, not a science.  It involves
-both tall/flat mode switches and well-shaped gaps.  (Hoon layout
+both tall/flat style switches and well-shaped gaps.  (Hoon layout
 could probably be done automatically with reasonable quality.
 But it would at least take machine learning, not a rule engine.)
 
 There are only two real *rules* in Hoon whitespace design: don't
 go past 80 characters, and don't use (completely) blank lines.
-Otherwise, if it looks good and is easy to read, it's good.  The 
+Otherwise, if it looks good and is easy to read, it's fine.  The 
 best way to learn the art is to do everything by convention
 until you know what you're doing.  Here are the conventions:
 
 ### Conventions: *fixed*
 
-Twig bodies with *fixed* fanout use "backstep" indentation, which 
-slopes backward and to the right by two spaces per line.  The first
-twig child is two spaces after the end of the rune.
+Expressions with *fixed* bodies use "backstep" indentation, which 
+slopes backward and to the right by two spaces per line.
 
 Some *1-fixed*, *2-fixed*, *3-fixed* and *4-fixed* examples:
 
@@ -238,14 +242,15 @@ r
 s
 ```
 
-In optimal usage of backstep indentation, the most complicated twigs 
-are at the bottom, keeping code flow vertical rather than diagonal.
+In optimal usage of backstep indentation, the most complicated 
+expressions are at the bottom, keeping code flow vertical rather than 
+diagonal.
 
 ### Conventions: *running*
 
-A *running* twig body (a simple child list) puts the first child two
-spaces after the end of the rune, and the following children straight 
-down:
+A *running* body (a simple child list of arbitrary length) puts the 
+first child two spaces after the end of the rune, and the following 
+children straight down:
 
 A *running* example:
 
@@ -260,10 +265,10 @@ A *running* example:
 
 ### Conventions: *jogging*
 
-A *jogging* twig body (a list of child pairs) is like a running 
-body, but with a pair of children on each line, separated by 
+A *jogging* body (a list of child pairs of arbitrary length) is like 
+a running body, but with a pair of children on each line separated by 
 two spaces. Most jogging bodies start with a *fixed* sequence; 
-the first jogging pair is below and two steps backward from the 
+the first pair is below and two steps backward from the 
 last fixed child.
 
 There are two jogging conventions: *flat* (pair on one line) and
@@ -315,10 +320,10 @@ conventional example:
 
 Flat regular form starts with the rune, followed by `pal`, `(` 
 (left parenthesis), followed by a body whose subexpressions
-are separated by `ace` (one space), followed by `par`, `)` (right
-parenthesis).
+are all separated by `ace`s (single spaces), followed by `par`, 
+`)` (right parenthesis).
 
-A twig in flat form, `:if`, `?:`, `{$if p/twig q/twig r/twig}`:
+A expression in flat form, `?:`, which is 3-fixed:
 
 `?:(p q r)`
 


### PR DESCRIPTION
Minor revisions, clarifications, removing the words "twig" and "span" from the Syntax and Concepts docs.