### PR TITLE
Typo: wutzap

### DIFF
--- a/docs/hoon/rune/wut/zap.md
+++ b/docs/hoon/rune/wut/zap.md
@@ -2,14 +2,14 @@
 navhome: /docs/
 next: true
 sort: 7
-title: ?: "wutzap"
+title: ?! "wutzap"
 ---
 
 # `?! "wutzap"`
 
 `[%wtzp p=hoon]`: logical not.
 
-## Expands to 
+## Expands to
 
 ```
 .=(| p)


### PR DESCRIPTION
Fix the title for "wutzap" entry to show the rune `?!` instead of `?:`