### PR TITLE
Fixed small layout problem in ++sear doc (4f.md).

### DIFF
--- a/docs/hoon/library/4f.md
+++ b/docs/hoon/library/4f.md
@@ -761,6 +761,7 @@ Accepts
 -------
 
 `tub` is a `++nail`.
+
 Produces
 --------
 


### PR DESCRIPTION
*Before*
=

![sear-before](https://user-images.githubusercontent.com/15039850/36064502-6530a80a-0e51-11e8-922f-195474736bde.png)


*After*
=

![sear-after](https://user-images.githubusercontent.com/15039850/36064503-6b00882c-0e51-11e8-8589-2577dabc2314.png)
