### PR TITLE
Replace $-(* *) with gate.  This matches PR #618 in the arvo repository.

### DIFF
--- a/docs/hoon/library/2b.md
+++ b/docs/hoon/library/2b.md
@@ -899,7 +899,7 @@ Source
 
     ++  turn                                                ::  transform
       ~/  %turn
-      |*  {a/(list) b/$-(* *)}
+      |*  {a/(list) b/gate}
       |-
       ?~  a  ~
       [i=(b i.a) t=$(a t.a)]

--- a/docs/hoon/library/2i.md
+++ b/docs/hoon/library/2i.md
@@ -410,7 +410,7 @@ XX interface changing.
 ### `+-rib:by`
 
       +-  rib                                               ::  transform + product
-        |*  {b/* c/$-(* *)}
+        |*  {b/* c/gate}
         |-  ^+  [b a]
         ?~  a  [b ~]
         =+  d=(c n.a b)
@@ -431,7 +431,7 @@ XX interface changing, possibly disappearing
 Transform values
 
       +-  run                                               ::  apply gate to values
-        |*  b/$-(* *)
+        |*  b/gate
         |-
         ?~  a  a
         [n=[p=p.n.a q=(b q.n.a)] l=$(a l.a) r=$(a r.a)]

--- a/docs/hoon/library/2n.md
+++ b/docs/hoon/library/2n.md
@@ -139,16 +139,16 @@ Examples
 ***
 ### `++hard`
 
-Demands that a specific type be produced, crashing the program is it is
+Demands that a specific type be produced, crashing the program if it is
 not.
 
 Source
 ------
 
-    ++  hard                                                ::  force coerce to span
-      |*  han/mold
+    ++  hard                                                ::  force remold
+      |*  han/gate
       |=  fud/*  ^-  han
-      ~|  %hard
+      ~_  leaf+"hard"
       =+  gol=(han fud)
       ?>(=(gol fud) gol)
     ::
@@ -177,8 +177,8 @@ is not.
 Source
 ------
 
-    ++  soft                                                ::  maybe coerce to span
-      |*  han/$-(* *)
+    ++  soft                                                ::  maybe remold
+      |*  han/gate
       |=  fud/*  ^-  (unit han)
       =+  gol=(han fud)
       ?.(=(gol fud) ~ [~ gol])

--- a/docs/hoon/library/3g.md
+++ b/docs/hoon/library/3g.md
@@ -128,7 +128,7 @@ Mold generator for an edge
 Source
 ------
 
-    ++  like  |*  a/$-(* *)                                 ::  generic edge
+    ++  like  |*  a/gate                                    ::  generic edge
               |=  b/_`*`[(hair) ~]                          ::
               :-  p=(hair -.b)                              ::
               ^=  q                                         ::

--- a/docs/hoon/library/4f.md
+++ b/docs/hoon/library/4f.md
@@ -159,7 +159,7 @@ Source
 
     ++  cook                                                ::  apply gate
       ~/  %cook
-      |*  {poq/$-(* *) sef/rule}
+      |*  {poq/gate sef/rule}
       ~/  %fun
       |=  tub/nail
       =+  vex=(sef tub)


### PR DESCRIPTION
`++hard` has a code/comment change to match the current `hoon.hoon` on `master`.

`++soft` has a comment change to match the current `hoon.hoon` on `master`.