### PR TITLE
Update basic.md to clarify how to run p1.hoon

### DIFF
--- a/docs/arvo/basic.md
+++ b/docs/arvo/basic.md
@@ -75,7 +75,7 @@ Your `%clay` filesystem should acknowledge the newly added files.
 
 Run an example to ensure it worked:
 
-    ~fintud-macrep:dojo> +project-euler/p1
+    ~fintud-macrep:dojo/examples> +project-euler-p1
     233.168
 
 Euler 1


### PR DESCRIPTION
The current version indicates to readers that it p1.hoon should be run from the home desk rather than from the new examples desk. And apparently file inclusions are usually concatenated with hep instead of fas, so I changed that. Both +project-euler-p1 and +project-euler/p1 work, though.