### PR TITLE
Change to meson

### DIFF
--- a/docs/using/install.md
+++ b/docs/using/install.md
@@ -52,7 +52,7 @@ Which can usually be installed with the following one-liners:
 ```
 # macOS (Homebrew) https://treehouse.github.io/installation-guides/mac/homebrew
 # Linuxbrew http://linuxbrew.sh/
-$ brew install autoconf automake cmake gcc git gmp libsigsegv libtool python2 openssl
+$ brew install autoconf automake cmake gcc git gmp libsigsegv libtool meson ninja pkg-config python2 openssl re2c
 
 # macOS (Macports)
 $ sudo port install autoconf automake cmake gmp libsigsegv openssl
@@ -80,11 +80,12 @@ Once your dependencies are installed the rest is easy:
 ```
 $ git clone https://github.com/urbit/urbit
 $ cd urbit
-$ make # gmake on FreeBSD
+$ ./scripts/bootstrap
+$ ./scripts/build
 ```
 
-After running `make`, your Urbit executable is in `bin/urbit`. Install
-it wherever you'd like.
+After running the build script, your Urbit executable is in `bin/urbit`.
+Install it wherever you'd like.
 
 ```
 $ sudo install -m 0755 bin/urbit /usr/local/bin

--- a/docs/using/install.md
+++ b/docs/using/install.md
@@ -12,11 +12,11 @@ Installing Urbit is easy. It just takes a few minutes to get an
 instance up and running on the network. 
 
 Urbit is designed to run on any Unix box with an internet connection.
-Debian (jessie), Mac OS X, FreeBSD and Fedora all work well.
+macOS, Ubuntu/Debian, FreeBSD, and Fedora all work well.
 
 If you run into trouble installing Urbit, please let us know via
 email, [questions@urbit.org](mailto:questions@urbit.org), or on the
-forum: [urbit.org/fora](https://urbit.org/fora). You can also chat
+forum: [fora.urbit.org](https://fora.urbit.org). You can also chat
 with us at [urbit.org/stream](https://urbit.org/stream).
 
 > Urbit is alpha software. It’s not yet completely stable, its crypto
@@ -41,57 +41,157 @@ gmp
 libcurl
 libsigsegv
 libtool
+libuv
+meson
+ninja
 openssl
 python2
 ragel
 re2c
 ```
 
-Which can usually be installed with the following one-liners:
+### Instructions
+
+First, you'll install the required dependencies to build Urbit from source. Then, you'll clone the Urbit source code, hosted on Github. Next, you'll bootstrap the Git submodules needed for the build. Lastly, you'll run a [Meson](https://github.com/mesonbuild/meson) build on the Urbit source to create your Urbit binary for your host operating system. Then, finally, you'll be able to boot your urbit.
+
+For your host OS platform and relevant package installer, run the respective Bash shell commands listed below in a fresh terminal window to get Urbit installed:
+
+> For those new to the command line, see:
+>
+> - Mac: [Introduction to the Mac OS X Command Line](http://blog.teamtreehouse.com/introduction-to-the-mac-os-x-command-line)
+> - Linux: [An Introduction to the Linux Terminal](https://www.digitalocean.com/community/tutorials/an-introduction-to-the-linux-terminal) 
+
+#### macOS 
+
+##### Homebrew
+
+> [Homebrew installation guide](https://treehouse.github.io/installation-guides/mac/homebrew)
 
 ```
-# macOS (Homebrew) https://treehouse.github.io/installation-guides/mac/homebrew
-# Linuxbrew http://linuxbrew.sh/
-$ brew install autoconf automake cmake gcc git gmp libsigsegv libtool meson ninja pkg-config python2 openssl re2c
+# Bash
 
-# macOS (Macports)
-$ sudo port install autoconf automake cmake gmp libsigsegv openssl
-
-# Ubuntu or Debian
-$ sudo apt-get install autoconf automake cmake exuberant-ctags g++ git libcurl4-gnutls-dev libgmp3-dev libncurses5-dev libsigsegv-dev libssl-dev libtool make openssl python ragel re2c zlib1g-dev
-
-# Fedora
-$ sudo dnf install autoconf automake cmake ctags gcc gcc-c++ git gmp-devel libcurl-devel libsigsegv-devel libtool ncurses-devel openssl openssl-devel python2 ragel re2c
-
-# FreeBSD
-$ pkg install autoconf automake cmake curl gcc git gmake gmp libsigsegv libtool python ragel re2c
-
-# Arch
-$ pacman -S autoconf automake cmake curl gcc git gmp libsigsegv libtool ncurses openssl python ragel re2c
-
-# AWS
-$ sudo yum install --enablerepo epel autoconf automake cmake ctags gcc gcc-c++ git gmp-devel libcurl-devel libsigsegv-devel libtool ncurses-devel openssl-devel python re2c
+brew update
+brew install autoconf automake cmake gcc git gmp libsigsegv libtool meson ninja pkg-config python2 openssl re2c
+git clone https://github.com/urbit/urbit
+cd urbit
+./scripts/bootstrap
+./scripts/build
+sudo install -m 0755 ./build/urbit /usr/local/bin
+urbit
 ```
 
-### Clone and make
-
-Once your dependencies are installed the rest is easy:
+##### Macports
 
 ```
-$ git clone https://github.com/urbit/urbit
-$ cd urbit
-$ ./scripts/bootstrap
-$ ./scripts/build
+# Bash
+
+sudo port selfupdate
+sudo port install autoconf automake cmake gmp libsigsegv meson openssl
+git clone https://github.com/urbit/urbit
+cd urbit
+./scripts/bootstrap
+./scripts/build
+sudo install -m 0755 ./build/urbit /usr/local/bin
+urbit
 ```
 
-After running the build script, your Urbit executable is in `build/urbit`.
-Install it wherever you'd like.
+#### Linux
+
+##### Linuxbrew
+
+> [Linuxbrew](http://linuxbrew.sh/)
 
 ```
-$ sudo install -m 0755 build/urbit /usr/local/bin
+# Bash
+
+brew update
+brew install autoconf automake cmake gcc git gmp libsigsegv libtool meson ninja pkg-config python2 openssl re2c
+git clone https://github.com/urbit/urbit
+cd urbit
+./scripts/bootstrap
+./scripts/build
+sudo install -m 0755 ./build/urbit /usr/local/bin
+urbit
 ```
 
-Test that it works:
+##### Ubuntu or Debian
+
+```
+# Bash
+
+sudo apt-get update
+sudo apt-get install autoconf automake cmake exuberant-ctags g++ git libcurl4-gnutls-dev libgmp3-dev libncurses5-dev libsigsegv-dev libssl-dev libtool make meson openssl python ragel re2c zlib1g-dev
+git clone https://github.com/urbit/urbit
+cd urbit
+./scripts/bootstrap
+./scripts/build
+sudo install -m 0755 ./build/urbit /usr/local/bin
+urbit
+```
+
+##### Fedora
+
+```
+# Bash
+
+sudo dnf upgrade
+sudo dnf install autoconf automake cmake ctags gcc gcc-c++ git gmp-devel libcurl-devel libsigsegv-devel libtool meson ncurses-devel openssl openssl-devel python2 ragel re2c
+git clone https://github.com/urbit/urbit
+cd urbit
+./scripts/bootstrap
+./scripts/build
+sudo install -m 0755 ./build/urbit /usr/local/bin
+urbit
+```
+
+##### FreeBSD
+
+```
+# Bash
+
+pkg upgrade
+pkg install autoconf automake cmake curl gcc git gmake gmp libsigsegv libtool meson python ragel re2c
+git clone https://github.com/urbit/urbit
+cd urbit
+./scripts/bootstrap
+./scripts/build
+sudo install -m 0755 ./build/urbit /usr/local/bin
+urbit
+```
+
+##### Arch
+
+```
+# Bash
+
+pacman -Syu
+pacman -S autoconf automake cmake curl gcc git gmp libsigsegv libtool meson ncurses openssl python ragel re2c
+git clone https://github.com/urbit/urbit
+cd urbit
+./scripts/bootstrap
+./scripts/build
+sudo install -m 0755 ./build/urbit /usr/local/bin
+urbit
+```
+
+##### AWS
+
+```
+# Bash
+
+sudo yum update
+sudo yum install --enablerepo epel autoconf automake cmake ctags gcc gcc-c++ git gmp-devel libcurl-devel libsigsegv-devel libtool meson ncurses-devel openssl-devel python re2c
+git clone https://github.com/urbit/urbit
+cd urbit
+./scripts/bootstrap
+./scripts/build
+sudo install -m 0755 ./build/urbit /usr/local/bin
+urbit
+```
+
+### Test for successful installation
+
+After running your installed `urbit` command, check to see if the following output was printed:
 
 ```
 $ urbit
@@ -145,14 +245,15 @@ Simple Usage:
    urbit <myplanet or mycomet> to restart an existing urbit
 ```
 
+If so, then you're ready to boot your urbit. If not, check that you entered each Bash command correctly for your host OS platform. If you're still experiencing issues, feel free to drop into [Urbit chat](https://urbit.org/stream) for troubleshooting help.
+
 ### Boot your urbit
 
-And you're done! If you're running Urbit on a normal modern PC or Mac, or
-on a large cloud instance, move onto the next [setup](../setup/) section to 
-boot your urbit. 
+You've now installed the Urbit binary. If you're running Urbit on a normal modern PC or Mac, or
+on a large cloud instance, move onto the next [setup](../setup/) section. 
 
-If you're running Urbit in the cloud on a small instance, however, read
-the below section, as you may need to additionally configure swap space.
+If you're running Urbit in the cloud on a small instance, read
+the below section, as you may need to additionally configure swap space, then continue.
 
 ### (Set up swap)
 
@@ -164,7 +265,7 @@ configuration is smaller than this, and you need to manually configure a
 swapfile.
 
 Digital Ocean has a post on adding swap 
-[here](https://www.digitalocean.com/community/tutorials/how-to-add-swap-on-ubuntu-14-04).  
+[here](https://www.digitalocean.com/community/tutorials/how-to-add-swap-space-on-ubuntu-16-04).
 For Amazon there’s a StackOverflow thread 
 [here](http://stackoverflow.com/questions/17173972/how-do-you-add-swap-to-an-ec2-instance).
 

--- a/docs/using/install.md
+++ b/docs/using/install.md
@@ -84,11 +84,11 @@ $ ./scripts/bootstrap
 $ ./scripts/build
 ```
 
-After running the build script, your Urbit executable is in `bin/urbit`.
+After running the build script, your Urbit executable is in `build/urbit`.
 Install it wherever you'd like.
 
 ```
-$ sudo install -m 0755 bin/urbit /usr/local/bin
+$ sudo install -m 0755 build/urbit /usr/local/bin
 ```
 
 Test that it works:


### PR DESCRIPTION
This is a first draft of changes to the install documentation for meson. It works for brew based systems, but macports and all the other package managers still need to be updated.