### PR TITLE
updates terminology for rune reference pages

### DIFF
--- a/docs/hoon/rune/bar.md
+++ b/docs/hoon/rune/bar.md
@@ -22,6 +22,6 @@ with changes, useful for recursion among other things:
 > `$()` expands to `%=($)` (["cenhep"](../cen/hep)), accepting 
 > a *jogging* body containing a list of changes to the subject.
 
-## Stems
+## hoons
 
 <list dataPreview="true" className="runes"></list>

--- a/docs/hoon/rune/bar.md
+++ b/docs/hoon/rune/bar.md
@@ -22,6 +22,6 @@ with changes, useful for recursion among other things:
 > `$()` expands to `%=($)` (["cenhep"](../cen/hep)), accepting 
 > a *jogging* body containing a list of changes to the subject.
 
-## hoons
+## Hoons
 
 <list dataPreview="true" className="runes"></list>

--- a/docs/hoon/rune/buc.md
+++ b/docs/hoon/rune/buc.md
@@ -48,6 +48,6 @@ instance, `(map foo bar)` is a table from mold `foo` to mold
 `bar`.  `map` is not a mold; it's a function that makes a mold.
 Molds and mold builders are generally described together.
 
-## hoons
+## Hoons
 
 <list dataPreview="true" className="runes"></list>

--- a/docs/hoon/rune/buc.md
+++ b/docs/hoon/rune/buc.md
@@ -48,6 +48,6 @@ instance, `(map foo bar)` is a table from mold `foo` to mold
 `bar`.  `map` is not a mold; it's a function that makes a mold.
 Molds and mold builders are generally described together.
 
-## Stems
+## hoons
 
 <list dataPreview="true" className="runes"></list>

--- a/docs/hoon/rune/cen.md
+++ b/docs/hoon/rune/cen.md
@@ -11,6 +11,6 @@ We've already covered [`%wing`](../limb/wing) and [`%limb`](../limb/limb).  Thes
 forms of the *invocation* family of hoons, `%`, whose general 
 form is `%=` ("centis").
 
-## hoons
+## Hoons
 
 <list dataPreview="true" className="runes"></list>

--- a/docs/hoon/rune/cen.md
+++ b/docs/hoon/rune/cen.md
@@ -11,6 +11,6 @@ We've already covered [`%wing`](../limb/wing) and [`%limb`](../limb/limb).  Thes
 forms of the *invocation* family of hoons, `%`, whose general 
 form is `%=` ("centis").
 
-## Stems
+## hoons
 
 <list dataPreview="true" className="runes"></list>

--- a/docs/hoon/rune/col.md
+++ b/docs/hoon/rune/col.md
@@ -11,6 +11,6 @@ The `:` ("col") hoons, `:-` and friends, are simple and regular.
 All `:` hoons expand to `:-` ("colhep"), which makes a pair 
 (just like the Lisp [`cons`](https://en.wikipedia.org/wiki/Cons) operator).
 
-## Stems
+## hoons
 
 <list dataPreview="true" className="runes"></list>

--- a/docs/hoon/rune/col.md
+++ b/docs/hoon/rune/col.md
@@ -11,6 +11,6 @@ The `:` ("col") hoons, `:-` and friends, are simple and regular.
 All `:` hoons expand to `:-` ("colhep"), which makes a pair 
 (just like the Lisp [`cons`](https://en.wikipedia.org/wiki/Cons) operator).
 
-## hoons
+## Hoons
 
 <list dataPreview="true" className="runes"></list>

--- a/docs/hoon/rune/dot.md
+++ b/docs/hoon/rune/dot.md
@@ -9,6 +9,6 @@ title: Nock . ("dot")
 
 Anything Nock can do, Hoon can do also.
 
-## hoons
+## Hoons
 
 <list dataPreview="true" className="runes"></list>

--- a/docs/hoon/rune/dot.md
+++ b/docs/hoon/rune/dot.md
@@ -9,6 +9,6 @@ title: Nock . ("dot")
 
 Anything Nock can do, Hoon can do also.
 
-## Twigs
+## hoons
 
 <list dataPreview="true" className="runes"></list>

--- a/docs/hoon/rune/ket.md
+++ b/docs/hoon/rune/ket.md
@@ -14,6 +14,6 @@ constraints.
 The `nest` algorithm which tests subtyping is conservative;
 it never allows invalid nests, it sometimes rejects valid nests.
 
-## hoons
+## Hoons
 
 <list dataPreview="true" className="runes"></list>

--- a/docs/hoon/rune/ket.md
+++ b/docs/hoon/rune/ket.md
@@ -14,6 +14,6 @@ constraints.
 The `nest` algorithm which tests subtyping is conservative;
 it never allows invalid nests, it sometimes rejects valid nests.
 
-## Twigs
+## hoons
 
 <list dataPreview="true" className="runes"></list>

--- a/docs/hoon/rune/sem.md
+++ b/docs/hoon/rune/sem.md
@@ -8,6 +8,6 @@ title: Make ; ("sem")
 
 Miscellaneous useful macros.
 
-## Twigs
+## hoons
 
 <list dataPreview="true" className="runes"></list>

--- a/docs/hoon/rune/sem.md
+++ b/docs/hoon/rune/sem.md
@@ -8,6 +8,6 @@ title: Make ; ("sem")
 
 Miscellaneous useful macros.
 
-## hoons
+## Hoons
 
 <list dataPreview="true" className="runes"></list>

--- a/docs/hoon/rune/sig.md
+++ b/docs/hoon/rune/sig.md
@@ -10,6 +10,6 @@ title: Hint ~ ("sig")
 Twigs that use Nock `10` to pass non-semantic info to the
 interpreter.
 
-## Twigs
+## hoons
 
 <list dataPreview="true" className="runes"></list>

--- a/docs/hoon/rune/sig.md
+++ b/docs/hoon/rune/sig.md
@@ -10,6 +10,6 @@ title: Hint ~ ("sig")
 Twigs that use Nock `10` to pass non-semantic info to the
 interpreter.
 
-## hoons
+## Hoons
 
 <list dataPreview="true" className="runes"></list>

--- a/docs/hoon/rune/tis.md
+++ b/docs/hoon/rune/tis.md
@@ -30,6 +30,6 @@ course, we are creating a copy, not modifying the original.
 
 There are many flow stems, all small variations on these three.
 
-## Twigs
+## hoons
 
 <list dataPreview="true" className="runes"></list>

--- a/docs/hoon/rune/tis.md
+++ b/docs/hoon/rune/tis.md
@@ -30,6 +30,6 @@ course, we are creating a copy, not modifying the original.
 
 There are many flow stems, all small variations on these three.
 
-## hoons
+## Hoons
 
 <list dataPreview="true" className="runes"></list>

--- a/docs/hoon/rune/wut.md
+++ b/docs/hoon/rune/wut.md
@@ -30,6 +30,6 @@ analyzed.
 If the compiler detects that the branch is degenerate (only one
 side is taken), it fails with an error.
 
-## Twigs
+## hoons
 
 <list dataPreview="true" className="runes"></list>

--- a/docs/hoon/rune/wut.md
+++ b/docs/hoon/rune/wut.md
@@ -30,6 +30,6 @@ analyzed.
 If the compiler detects that the branch is degenerate (only one
 side is taken), it fails with an error.
 
-## hoons
+## Hoons
 
 <list dataPreview="true" className="runes"></list>

--- a/docs/hoon/rune/zap.md
+++ b/docs/hoon/rune/zap.md
@@ -7,6 +7,6 @@ title: Wild ! ("zap")
 
 # Wild `!` ("zap")
 
-## hoons
+## Hoons
 
 <list dataPreview="true" className="runes"></list>

--- a/docs/hoon/rune/zap.md
+++ b/docs/hoon/rune/zap.md
@@ -7,6 +7,6 @@ title: Wild ! ("zap")
 
 # Wild `!` ("zap")
 
-## Twigs
+## hoons
 
 <list dataPreview="true" className="runes"></list>


### PR DESCRIPTION
The rune category pages inaccurately (and inconsistently) designated expressions as either "Twigs" or "Stems"