### PR TITLE
Update install instructions to use ninja to install urbit and libraries

### DIFF
--- a/docs/using/install.md
+++ b/docs/using/install.md
@@ -76,7 +76,7 @@ git clone https://github.com/urbit/urbit
 cd urbit
 ./scripts/bootstrap
 ./scripts/build
-sudo install -m 0755 ./build/urbit /usr/local/bin
+sudo ninja -C build meson-install
 urbit
 ```
 
@@ -91,7 +91,7 @@ git clone https://github.com/urbit/urbit
 cd urbit
 ./scripts/bootstrap
 ./scripts/build
-sudo install -m 0755 ./build/urbit /usr/local/bin
+sudo ninja -C build meson-install
 urbit
 ```
 
@@ -110,7 +110,7 @@ git clone https://github.com/urbit/urbit
 cd urbit
 ./scripts/bootstrap
 ./scripts/build
-sudo install -m 0755 ./build/urbit /usr/local/bin
+sudo env "PATH=$PATH" ninja -C build meson-install
 urbit
 ```
 
@@ -125,7 +125,7 @@ git clone https://github.com/urbit/urbit
 cd urbit
 ./scripts/bootstrap
 ./scripts/build
-sudo install -m 0755 ./build/urbit /usr/local/bin
+sudo ninja -C build meson-install
 urbit
 ```
 
@@ -140,7 +140,7 @@ git clone https://github.com/urbit/urbit
 cd urbit
 ./scripts/bootstrap
 ./scripts/build
-sudo install -m 0755 ./build/urbit /usr/local/bin
+sudo ninja -C build meson-install
 urbit
 ```
 
@@ -155,7 +155,7 @@ git clone https://github.com/urbit/urbit
 cd urbit
 ./scripts/bootstrap
 ./scripts/build
-sudo install -m 0755 ./build/urbit /usr/local/bin
+sudo ninja -C build meson-install
 urbit
 ```
 
@@ -170,7 +170,7 @@ git clone https://github.com/urbit/urbit
 cd urbit
 ./scripts/bootstrap
 ./scripts/build
-sudo install -m 0755 ./build/urbit /usr/local/bin
+sudo ninja -C build meson-install
 urbit
 ```
 
@@ -185,7 +185,7 @@ git clone https://github.com/urbit/urbit
 cd urbit
 ./scripts/bootstrap
 ./scripts/build
-sudo install -m 0755 ./build/urbit /usr/local/bin
+sudo ninja -C build meson-install
 urbit
 ```
 

--- a/docs/using/install.md
+++ b/docs/using/install.md
@@ -76,7 +76,7 @@ git clone https://github.com/urbit/urbit
 cd urbit
 ./scripts/bootstrap
 ./scripts/build
-sudo ninja -C build meson-install
+sudo ninja -C ./build/ meson-install
 urbit
 ```
 
@@ -91,7 +91,7 @@ git clone https://github.com/urbit/urbit
 cd urbit
 ./scripts/bootstrap
 ./scripts/build
-sudo ninja -C build meson-install
+sudo ninja -C ./build/ meson-install
 urbit
 ```
 
@@ -110,7 +110,7 @@ git clone https://github.com/urbit/urbit
 cd urbit
 ./scripts/bootstrap
 ./scripts/build
-sudo env "PATH=$PATH" ninja -C build meson-install
+sudo env "PATH=$PATH" ninja -C ./build/ meson-install
 urbit
 ```
 
@@ -125,7 +125,7 @@ git clone https://github.com/urbit/urbit
 cd urbit
 ./scripts/bootstrap
 ./scripts/build
-sudo ninja -C build meson-install
+sudo ninja -C ./build/ meson-install
 urbit
 ```
 
@@ -140,7 +140,7 @@ git clone https://github.com/urbit/urbit
 cd urbit
 ./scripts/bootstrap
 ./scripts/build
-sudo ninja -C build meson-install
+sudo ninja -C ./build/ meson-install
 urbit
 ```
 
@@ -155,7 +155,7 @@ git clone https://github.com/urbit/urbit
 cd urbit
 ./scripts/bootstrap
 ./scripts/build
-sudo ninja -C build meson-install
+sudo ninja -C ./build/ meson-install
 urbit
 ```
 
@@ -170,7 +170,7 @@ git clone https://github.com/urbit/urbit
 cd urbit
 ./scripts/bootstrap
 ./scripts/build
-sudo ninja -C build meson-install
+sudo ninja -C ./build/ meson-install
 urbit
 ```
 
@@ -185,7 +185,7 @@ git clone https://github.com/urbit/urbit
 cd urbit
 ./scripts/bootstrap
 ./scripts/build
-sudo ninja -C build meson-install
+sudo ninja -C ./build/ meson-install
 urbit
 ```
 


### PR DESCRIPTION
Installation instructions worked on the Mac, but didn't work on AWS.  When I tried to run `urbit` I got this:
```
urbit: error while loading shared libraries: liblibuv.so.1: cannot open shared object file: No such file or directory
```

Digging around in the `build` directory, it looked like `ninja` could install all the libraries if you asked it to, i.e. do `meson-install`.  So that's what the updated instructions call out.

In my case, I had decided to use `linuxbrew` on AWS, which installs `ninja` somewhere outside of `root`'s path.  Hence the command for `linuxbrew` copies the user's PATH over to `root` before running `ninja`.