### PR TITLE
replace gap with ace between foo and |=

### DIFF
--- a/docs/hoon/rune/tis/lus.md
+++ b/docs/hoon/rune/tis/lus.md
@@ -26,10 +26,10 @@ Regular: *2-fixed*.
 ## Examples
  
 ```
-~zod:dojo> =foo  |=  a=@
-                 =+  b=1
-                 =+  c=2
-                 :(add a b c)
+~zod:dojo> =foo |=  a=@
+                =+  b=1
+                =+  c=2
+                :(add a b c)
 ~zod:dojo> (foo 5)
 8
 ```


### PR DESCRIPTION
it won't work in the dojo with two spaces between foo and |=