### PR TITLE
adding example to illicitly added =, rune doc

### DIFF
--- a/docs/hoon/rune/tis/com.md
+++ b/docs/hoon/rune/tis/com.md
@@ -9,8 +9,8 @@ title: =, "tiscom"
 
 `[%tscm p=hoon q=hoon]`: expose namespace
 
-`p` evaluates to a noun with some namespace.  From within `q` you may access those 
-names without a wing path (e.g., as in for some face `b` rather than `b.p`), or without 
+`p` evaluates to a noun with some namespace.  From within `q` you may access `p`'s 
+names without a wing path (i.e., you can use face `b` rather than `b.p`), or without 
 invoking a core name when `p` is a core.  This is especially useful for calling arms 
 from an imported library or for calling arms from an stdlib core repeatedly.
 
@@ -19,6 +19,8 @@ from an imported library or for calling arms from an stdlib core repeatedly.
 Regular: *2-fixed*.
 
 ## Examples
+
+With a core:
 
 ```
 > (sum -7 --7)
@@ -30,4 +32,13 @@ Regular: *2-fixed*.
 
 > =,  si  (sum -7 --7)
 --0
+```
+
+With a dojo-defined face:
+
+```
+> =/  fan  [bab=2 baz=[3 qux=4]]
+  =,  fan
+  [bab qux.baz]
+[2 4]
 ```


### PR DESCRIPTION
I mistakenly merged the previous PR for the new `=,` rune page.  Complaints about this new rune page can go here.  I also added an example at @belisarius222 's request.