### PR TITLE
Fix relative link bug in URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Urbit docs
 
-These are the urbit docs as they appear on [urbit.org](urbit.org/docs/).
+These are the urbit docs as they appear on [urbit.org](https://urbit.org/docs/).
 
 We've found it helps to have a clone of the docs on hand in case urbit.org
 experiences high traffic. Follow these steps to get these into your ship:


### PR DESCRIPTION
The markdown is interpreting `urbit.org/docs` as `https://github.com/urbit/docs/blob/master/urbit.org/docs`.

Adding `https://` think that should fix it.