### PR TITLE
Adding a comment to `++turn`

### DIFF
--- a/docs/hoon/library/2b.md
+++ b/docs/hoon/library/2b.md
@@ -1016,7 +1016,9 @@ A list.
     > (turn (limo [1 2 3 4 ~]) a)
     ~[5 6 7 8]
 
+#### Discussion
 
+`turn` is Hoon's version of 'map' in Haskell.
 
 ***
 ### `++weld`


### PR DESCRIPTION
Adding a note that `++turn` is Hoon's version of Haskell's 'map'