### PR TITLE
Remove explicit meson version from install instructions

### DIFF
--- a/getting-started.udon
+++ b/getting-started.udon
@@ -177,7 +177,7 @@ urbit
 sudo apt-get update
 sudo apt-get install autoconf automake cmake exuberant-ctags g++ git libcurl4-gnutls-dev libgmp3-dev libncurses5-dev libsigsegv-dev libssl-dev libtool make openssl pkg-config python python3 python3-pip ragel re2c zlib1g-dev
 sudo -H pip3 install --upgrade pip
-sudo -H pip3 install meson==0.29
+sudo -H pip3 install meson
 
 # we need ninja 1.5.1
 # 'apt-get install ninja-build' gives us 0.1.3
@@ -222,8 +222,7 @@ popd
 
 curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 sudo /usr/local/bin/python3 get-pip.py
-# downgrade meson to avoid dependencies that redhat can't meet
-sudo -H /usr/local/bin/pip3 install meson==0.29
+sudo -H /usr/local/bin/pip3 install meson
 
 
 git clone git://github.com/ninja-build/ninja.git && cd ninja


### PR DESCRIPTION
Current release-candidate fails to build (in libent) with meson 0.29, but builds fine with latest (0.49).

Maybe we want to pin to 0.49 instead of going with "whatever is latest"? But we already weren't specifying a specific version in the macOS or Arch install instructions, so...