### PR TITLE
updates old-zuse names

### DIFF
--- a/learn/arvo/arvo-internals/ames.udon
+++ b/learn/arvo/arvo-internals/ames.udon
@@ -102,8 +102,7 @@ that is sent over the wire, so be careful not to send anything too
 massive unless you're willing to wait.
 
 But enough about the interface. Grepping in ames.hoon for `%wont`, we
-find that it appears in exactly two places: at its definition in
-`++kiss`, and in `++knob`, where it is handled. We see that we go
+find that it appears in `++knob`. We see that we go
 directly into `++wise:am`.
 
 ```
@@ -152,11 +151,11 @@ This is slightly more complicated, but it's still not all that bad. Our
 inputs, at least, are fairly obvious.
 
 If you glance at the code for a second, you'll see that
-`++wind:ho:um:am` seems to be able to send a message, or `++meal`, given
+`++wind:ho:um:am` seems to be able to send a message, or `++meal:ames`, given
 a `++soup`. This gate, then, just sets up the things we need to for
 `++wind` to do its job.
 
-We first get `rol`, which is a `++rill`, that is, a particular outbound
+We first get `rol`, which is a `++rill:ames`, that is, a particular outbound
 stream. This stream is specific to the path on which we're sending. If
 the path hasn't been used before, then we create it. We let `sex` be the
 number of messages we've already sent on this path.
@@ -171,7 +170,7 @@ crypto. At the moment, we only need our neighbor's life, which we put
 into the meal.
 
 Finally, we call `++wind:ho:um:am` with the `++soup` of the path and
-message number and the `++meal` of the payload itself. For end-to-end
+message number and the `++meal:ames` of the payload itself. For end-to-end
 acknowledged messages, we use `%bund`.
 
 ```
@@ -199,7 +198,7 @@ and (3) sends any packets that are ready to be sent. Yes, our nice
 little linear run of each gate calling exactly one other interesting
 gate is over. We'll go in order here.
 
-`++zuul:lax:as:go` is the what converts a `++meal` into a list of
+`++zuul:lax:as:go` is the what converts a `++meal:ames` into a list of
 actual, 1KB packets.
 
 ```
@@ -403,7 +402,7 @@ the ship names in a packet.
 
 Next, we construct `bod` by simply concatenating the sending ship, the
 receiving ship, and the body of the message. Then, we get the encryption
-mechanism from `++skin`, which may be a 0, 1, 2, or 3, and put it in
+mechanism from `++skin:ames`, which may be a 0, 1, 2, or 3, and put it in
 `tay`.
 
 Next, we concatenate together, bit by bit, some final metadata. We use
@@ -457,7 +456,7 @@ First, we put into `pyz` the id for this message and the number of its
 packets that have not yet been acknowledged, which is of course the
 total number of packets since we haven't even sent the packets.
 
-For every packet, we change three things in the state (`++shed`) of our
+For every packet, we change three things in the state (`++shed:ames`) of our
 packet pump: (1) we increment `nus`, the number of packets sent; (2) we
 put the packet number into `diq` keyed by a hash of the packet; and (3)
 we put the packet into the packet queue, with the basic metadata of its
@@ -573,11 +572,11 @@ to our neighbor. First, we get `fro` and `too`, the "canons" of ourself
 and our neighbor, respectively.
 
 What is this "canon", you ask? A canon is simply a ship plus its
-"ancestors", as defined by `++sein`. For example, the canon of
+"ancestors", as defined by `++sein:title`. For example, the canon of
 `~hoclur-bicrel` is:
 
 ```
-    ~hoclur-bicrel/try=> (saxo ~hoclur-bicrel)
+    ~hoclur-bicrel/try=> (saxo:title ~hoclur-bicrel)
     ~[~hoclur-bicrel ~tasruc ~tug]
 ```
 
@@ -605,7 +604,7 @@ Now, we can finally get to `++busk:ho:um:am`.
 ```
 
 Thankfully, `++busk` is fairly simple. We go through the list of packets
-and convert them to `++boon`s with `++wist:lax:as:go`. These boons are
+and convert them to `++boon:ames`s with `++wist:lax:as:go`. These boons are
 placed into `bin`, and they end up getting processed by `++clop` (this
 happens in `++knob`).
 
@@ -637,7 +636,7 @@ happens in `++knob`).
                   :-  %fast
                   %^  cat  7
                     p.u.yed.caq.dyr
-                  (en:crua q.u.yed.caq.dyr mal)
+                  (en:crub:crypto q.u.yed.caq.dyr mal)
               ==
 ```
 
@@ -648,9 +647,9 @@ First, if we are sending a message to ourself, then we simply create a
 `%ouzo` boon with a bunted lane. Otherwise, if there are no routing
 candidates, there is nothing we can do, so we return nil.
 
-Next, we get the `dore` of the first routing candidate. If we're looking
+Next, we get the `++dore:ames` of the first routing candidate. If we're looking
 at the neighbor to whom we're trying to send the message, then we simply
-use the `dore` that we already have. Otherwise, we get a default `dore`.
+use the `++dore:ames` that we already have. Otherwise, we get a default `++dore:ames`.
 
 If we're the first routing candidate, or if we have don't have a lane to
 this candidate, then we skip this candidate and move on to the next one.
@@ -660,7 +659,7 @@ we also try to send on later routing candidates as well. Otherwise, we
 only send on this one candidate.
 
 Finally, we create the actual `%ouzo` boon. The lane is the one from our
-`dore`. If we're sending it directly to our intended recipient, and we
+`++dore:ames`. If we're sending it directly to our intended recipient, and we
 haven't been told to use a specific lane, then we just send the packet
 directly. Otherwise, we wrap it in a little `%fore` meal, telling the
 intermediary to whom we wish it to be sent. If we have already set up a
@@ -705,7 +704,7 @@ earlier.
 Here, though, we call `++gnaw:am` to process the packet. The arguments
 to `++gnaw` are the same as those to the `%hear` kiss: the lane on which
 the packet was received and the packet itself. The other argument is
-just `%good`, which is a `++cape` saying that we expect the packet to
+just `%good`, which is a `++cape:ames` saying that we expect the packet to
 succeed. If a formal error occurs, then since we have a transactional
 event system, the `%hear` event will never be considered to have
 actually happened, and unix will send a `%hole` kiss so that we may send
@@ -728,7 +727,7 @@ a negative acknowledgment.
 
 First, we check the protocol number. If it is not correct, then we
 simply ignore the packet entirely. Otherwise, we parse the packet with
-`++bite`, which converts a packet atom into a `cake`, that is, a triple
+`++bite`, which converts a packet atom into a `++cake:ames`, that is, a triple
 of the `sock` (pair of sender and receiver), the `skin` (encryption
 type), and the data.
 
@@ -763,7 +762,7 @@ to these cores.
 
 The new stuff here, then, is the `++la` core and the `++chew` arm. The
 `++la` sets up a core for this particular packet, containing the current
-success/failure `cape`, the lane it was sent on, the encryption type,
+success/failure `++cape:ames`, the lane it was sent on, the encryption type,
 and a hash of the packet, used as an id.
 
 `++chew` is called with the encryption type and the message itself. It
@@ -795,7 +794,7 @@ we'll go into in just a minute.
 
 We now do the same two checks and store the results in `eng` and `bou`.
 If our neighbor has, like the prodigal son, returned after an extended
-absense, then we send a `%wine` boon as the proverbial fatted calf,
+absence, then we send a `%wine` boon as the proverbial fatted calf,
 which is simply printed out to the console. Likewise, if we are meeting
 one with whom we have never had the pleasure of acquainting ourselves,
 we send a message to the console to that effect.
@@ -849,7 +848,7 @@ send the result to `++chow` for interpretation and handling.
                     (chow(aut sin) ((hard meal) (cue (dy:q:sen:gus key bod))))
 ```
 
-For symmetric encryption, we first get the `hand`, which is the hash of
+For symmetric encryption, we first get the `++hand`, which is the hash of
 the symmetric key. We pass it to `++kuch:lax:as:go`, which returns the
 key if we either have used it before or we have proposed it. If we have
 proposed it, then we change its status from proposed to real. If
@@ -1024,7 +1023,7 @@ message, then we resend the ack. Note that `did.rum` is the number of
 packets we acknowledged, positively or negatively while `bum.rum` is a
 map of message numbers to negative acknowledgments. Thus, if a message
 number is less than `did.rum`, then if it's in `bum.rum` then it was
-negatively acknowledged, otherwise it's postively acknowledged. Thus, we
+negatively acknowledged, otherwise it's positively acknowledged. Thus, we
 are constant in space with the number of successful messages and linear
 in the number of failed messages. We'll document `++cook` later on, but
 suffice it to say that it sends an acknowledgment. It is to end-to-end
@@ -1054,7 +1053,7 @@ Otherwise, we're ready for a packet, so we process it.
                 :_  bin
                 :^    %mulk
                     [our her]
-                  `soap`[[p:sen:gus clon:diz] cha did.rum]
+                  `soap:ames`[[p:sen:gus clon:diz] cha did.rum]
                 u.s.u.cun
               ==
 ```
@@ -1563,71 +1562,7 @@ involved.
 
 ## Data Models
 
-### `++fort`, formal state
-
-```
-    ++  fort                                                ::  formal state
-              $:  %0                                        ::  version
-                  gad=duct                                  ::  client interface
-                  hop=@da                                   ::  network boot date
-                  ton=town                                  ::  security
-                  zac=(map ship corn)                       ::  flows by server
-              ==                                            ::
-```
-
-This is the state of our vane. Anything that must be remembered between
-calls to ames must be stored in this state.
-
-`%0` is the version of the ames state model itself. If the data model
-`++fort` changes, then this number needs to be incremented, and an
-adapter must be written to upgrade the old state into the new state.
-Note that this is the version number of the model itself, not the
-contents. When the data changes, there is of course no need to change
-this.
-
-`gad` is a `duct` over which we send `%send` cards to unix. This card is
-initialized when unix sends a `%barn` card as vere starts up. Vere
-treats this duct specially -- don't send anything weird over it.
-
-`hop` is the network boot date. This is set when the `%kick` card is
-sent by vere on start up.
-
-`ton` is a `++town`, where we store all of our security/encryption
-state. Note that this is shared across all ships on a pier.
-
-`zac` is a map of ships to `++corn`. This stores all the per-ship state.
-The keys to this map are the ships on the current pier.
-
-### `++town`, all security state
-
-```
-    ++  town                                                ::  all security state
-              $:  lit=@ud                                   ::  imperial modulus
-                  any=@                                     ::  entropy
-                  urb=(map ship sufi)                       ::  all keys and routes
-                  fak=?                                     ::
-              ==                                            ::
-```
-
-This is the security state of our pier.
-
-`lit` is unused.
-
-`any` is 256 bits of entropy. This entropy is used and updated in
-exactly two places: when we send a `%junk` card, and when we generate a
-new symmetric key in `++griz:lax:as:go`. When it is updated, it is
-updated by a SHA-256 hash of the current time and the old value of the
-entropy.
-
-`urb` is a map of ships to `++sufi`. This is where we store all the
-per-ship state for the pier. The keys to this map are the ships on the
-current pier.
-
-`fak` is true if we are on a fake network. This disables certain
-security checks so that anyone may run a fake `~zod`. This is used only
-for development. To use, run vere with the `-F` option.
-
-### `++sufi`, domestic host
+### `++sufi:ames`, domestic host
 
 ```
     ++  sufi                                                ::  domestic host
@@ -1643,7 +1578,7 @@ This is the security state of a domestic server.
 
 `hoy` is a list of the ships directly above us in the hierarchy of
 ships. For example, for `~hoclur-bicrel`, this would be `~tasruc` and
-`~tug`. See `++sein`.
+`~tug`. See `++sein:title`.
 
 `val` is a list of our private keys.
 
@@ -1651,20 +1586,20 @@ ships. For example, for `~hoclur-bicrel`, this would be `~tasruc` and
 
 `seh`
 
-`hoc` is a map of ships to `++dore`. The stores all the security
-informatoin about foreign ships. The keys to this map are the neighbors
+`hoc` is a map of ships to `++dore:ames`. The stores all the security
+information about foreign ships. The keys to this map are the neighbors
 (ships we have been in contact with) of this domestic server.
 
-### `++wund`, private keys
+### `++wund:ames`, private keys
 
 ```
     ++  wund  (list ,[p=life q=ring r=acru])                ::  mace in action
 ```
 
 This is a list of our own private keys, indexed by life. The key itself
-is the `++ring`, and the `++acru` is the encryption engine. We generate
-the `++acru` from the private key by calling `++weur`. Thus, we can at
-any time regenerate our `++wund` from a `++mace`. The current crypto is
+is the `++ring`, and the `++acru:ames` is the encryption engine. We generate
+the `++acru:ames` from the private key by calling `++weur`. Thus, we can at
+any time regenerate our `++wund:ames` from a `++mace:ames`. The current crypto is
 at the head of the list and can be accessed with `++sen:as:go`.
 
 ### `++ring`, private key
@@ -1675,7 +1610,7 @@ at the head of the list and can be accessed with `++sen:as:go`.
 
 This is a private key. The first byte is reserved to identify the type
 of cryptography. Lower-case means public key, upper-case means public
-key, and the letter identifies which `++acru` to use.
+key, and the letter identifies which `++acru:ames` to use.
 
 ### `++pass`, public key
 
@@ -1685,18 +1620,18 @@ key, and the letter identifies which `++acru` to use.
 
 This is a public key. The first byte is reserved to identify the type of
 cryptography. Lower-case means public key, upper-case means public key,
-and the letter identifies which `++acru` to use.
+and the letter identifies which `++acru:ames` to use.
 
-### `++mace`, private secrets
+### `++mace:ames`, private secrets
 
 ```
     ++  mace  (list ,[p=life q=ring])                       ::  private secrets
 ```
 
 This is a list of the our private keys, indexed by life. From this we
-can generate a `++wund` for actual use.
+can generate a `++wund:ames` for actual use.
 
-### `++skin`, encoding stem
+### `++skin:ames`, encoding stem
 
 ```
     ++  skin  ?(%none %open %fast %full)                    ::  encoding stem
@@ -1705,9 +1640,9 @@ can generate a `++wund` for actual use.
 This defines the type of encryption used for each message. `%none`
 refers to messages sent in the clear, `%open` refers to signed messages,
 `%full` refers to sealed messages, and `%fast` refers to symmetrically
-encrypted messages. See `++acru` for details.
+encrypted messages. See `++acru:ames` for details.
 
-### `++acru`, asymmetric cryptosuite
+### `++acru:ames`, asymmetric cryptosuite
 
 ```
     ++  acru                                                ::  asym cryptosuite
@@ -1738,11 +1673,10 @@ encrypted messages. See `++acru` for details.
 
 This is an opaque interface for a general asymmetric cryptosuite. Any
 form of asymmetric cryptography can be dropped in to be used instead of
-the default. Right now, there are two cryptosuites, `++crua`, which is
-your standard RSA, and `++crub`, which is elliptic curve crypto but is
-mostly stubbed out at the moment.
+the default. Right now, there is one cryptosuite: `++crub:crypto:crypto`,
+which is elliptic-curve cryptography.
 
-#### `++as:acru`, asymmetric operations
+#### `++as:acru:ames`, asymmetric operations
 
 ```
               ++  as  ^?                                    ::  asym ops
@@ -1757,29 +1691,29 @@ mostly stubbed out at the moment.
 This is the core that defines the standard asymmetric cryptography
 operations.
 
-`++seal:as:acru` allows us to send a message encrypted with someone's
+`++seal:as:acru:ames` allows us to send a message encrypted with someone's
 public key so that only they may read it. If Alice seals a message with
 Bob's public key, then she can be sure that Bob is the only one who can
-read it. This is associated with the `++skin` `%full`.
+read it. This is associated with the `++skin:ames` `%full`.
 
-`++sign:as:acru` allows us to sign a message with our private key so
+`++sign:as:acru:ames` allows us to sign a message with our private key so
 that others can verify that we sent the message. If Alice signs a
 message with her private key, then Bob can verify with her public key
 that it was indeed Alice who sent it. This is associated with the
-`++skin` `%open`.
+`++skin:ames` `%open`.
 
-`++sure:as:acru` is the dual to `++sign:as:acru`. It allows us to verify
+`++sure:as:acru:ames` is the dual to `++sign:as:acru:ames`. It allows us to verify
 that a message we have received is indeed from the claimed sender. If
 Alice sends a message with her private key, then Bob can use this arm to
 verify that it was indeed Alice who sent it. This is associated with the
-`++skin` `%open`.
+`++skin:ames` `%open`.
 
-`++tear:as:acru` is the dual to `++seal:as:acru`. It allows us to read a
+`++tear:as:acru:ames` is the dual to `++seal:as:acru:ames`. It allows us to read a
 message that we can be sure is only read by us. If Alice seals a message
 with Bob's public key, then Bob can use this arm to read it. This is
-associated with the `++skin` `%full`.
+associated with the `++skin:ames` `%full`.
 
-#### `++de:acru`, `++dy:acru`, and `++en:acru`, symmetric encryption/decryption
+#### `++de:acru:ames`, `++dy:acru:ames`, and `++en:acru:ames`, symmetric encryption/decryption
 
 ```
               ++  de  |+([a=@ b=@] *(unit ,@))              ::  symmetric de, soft
@@ -1787,18 +1721,18 @@ associated with the `++skin` `%full`.
               ++  en  |+([a=@ b=@] _@)                      ::  symmetric en
 ```
 
-Symmetric encryption is associated with the `++skin` `%fast`.
+Symmetric encryption is associated with the `++skin:ames` `%fast`.
 
-`++de:acru` decrypts a message with a symmetric key, returning `~` on
+`++de:acru:ames` decrypts a message with a symmetric key, returning `~` on
 failure and `[~ u=data]` on success.
 
-`++dy:acru` decrypts a message with a symmetric key, crashing on
+`++dy:acru:ames` decrypts a message with a symmetric key, crashing on
 failure. This should almost always be defined as, and should always be
 semantically equivalent to, `(need (de a b))`.
 
-`++en:acru` encrypts a message with a symmetric key.
+`++en:acru:ames` encrypts a message with a symmetric key.
 
-#### `++ex:acru`, exporting data
+#### `++ex:acru:ames`, exporting data
 
 ```
               ++  ex  ^?                                    ::  export
@@ -1809,18 +1743,18 @@ semantically equivalent to, `(need (de a b))`.
                 --
 ```
 
-`++fig:ex:acru` is our fingerprint, usually a hash of our public key.
+`++fig:ex:acru:ames` is our fingerprint, usually a hash of our public key.
 This is used, for example, in `++zeno`, where every carrier owner's
 fingerprint is stored so that we can ensure that carriers are indeed
 owned by their owners
 
-`++pac:ex:acru` is our default passcode, which is unused at present.
+`++pac:ex:acru:ames` is our default passcode, which is unused at present.
 
-`++pub:ex:acru` is the `++pass` form of our public key.
+`++pub:ex:acru:ames` is the `++pass` form of our public key.
 
-`++sec:ex:acru` is the `++ring` form of our private key.
+`++sec:ex:acru:ames` is the `++ring` form of our private key.
 
-#### `++nu:acru`, reconstructors
+#### `++nu:acru:ames`, reconstructors
 
 ```
               ++  nu  ^?                                    ::  reconstructors
@@ -1830,21 +1764,17 @@ owned by their owners
                 --
 ```
 
-These arms allow us to reconstruct a `++acru` from basic data.
+These arms allow us to reconstruct a `++acru:ames` from basic data.
 
-`++pit:nu:acru` constructs a `++acru` from the width of our intended key
+`++pit:nu:acru:ames` constructs a `++acru:ames` from the width of our intended key
 and seed entropy. This is usually used in the initial construction of
-the `++acru`.
+the `++acru:ames`.
 
-`++nol:nu:acru` constructs a `++acru` from a "naked ring", meaning a
-`++ring` without the initial byte identifying the type of crypto. There
-is often a helper arm that that wraps this; see `++weur` for `++crua`
-and `++wear` for `++crub`.
+`++nol:nu:acru:ames` constructs a `++acru:ames` from a "naked ring", meaning a
+`++ring` without the initial byte identifying the type of crypto.
 
-`++com:nu:acru` constructs a `++acru` from a "naked pass", meaning a
-`++ring` without the initial byte identifying the type of crypto. There
-is often a helper arm that that wraps this; see `++haul` for `++crua`
-and `++hail` for `++crub`.
+`++com:nu:acru:ames` constructs a `++acru:ames` from a "naked pass", meaning a
+`++ring` without the initial byte identifying the type of crypto.
 
 ### `++will`, certificate
 
@@ -1874,7 +1804,7 @@ issued \~tasruc's deed).
 that the carrier fingerprints are correct. This allows us to create fake
 networks for development without interfering with the real network.
 
-### `++step`, identity stage
+### `++step:ames`, identity stage
 
 ```
     ++  step  ,[p=bray q=gens r=pass]                       ::  identity stage
@@ -1890,7 +1820,7 @@ lives.
 
 `r` is the public key for this stage in the identity.
 
-### `++bray`
+### `++bray:ames`
 
 ```
     ++  bray  ,[p=life q=(unit life) r=ship s=@da]          ::  our parent us now
@@ -1898,7 +1828,7 @@ lives.
 
 XXX
 
-### `++gens`, general identity
+### `++gens:ames`, general identity
 
 ```
     ++  gens  ,[p=lang q=gcos]                              ::  general identity
@@ -1910,7 +1840,7 @@ localized based on this.
 
 `q` is the description of the ship.
 
-### `++gcos`, identity description
+### `++gcos:ames`, identity description
 
 ```
     ++  gcos                                                ::  id description
@@ -1949,7 +1879,7 @@ negligible, so submarines are not issued by any ship. They must simply
 assert their presence, and they are all considered children of \~zod.
 This is the underworld of Urbit, where anonymity reigns supreme.
 
-### `++what`, logical destroyer identity
+### `++what:ames`, logical destroyer identity
 
 ```
     ++  what                                                ::  logical identity
@@ -1973,7 +1903,7 @@ A `%lord` is a male person. The name used here should be a real name.
 
 A `%punk` is a person who is identified only by a handle.
 
-### `++whom`, real person
+### `++whom:ames`, real person
 
 ```
     ++  whom  ,[p=@ud q=govt r=sect s=name]                 ::  year/govt/id
@@ -1990,7 +1920,7 @@ information that could be observed with the briefest of interactions.
 
 `s` is the real name of the person.
 
-### `++govt`
+### `++govt:ames`
 
 ```
     ++  govt  path                                          ::  country/postcode
@@ -1998,7 +1928,7 @@ information that could be observed with the briefest of interactions.
 
 This is the location of the user, usually of the form "country/zip".
 
-### `++sect`
+### `++sect:ames`
 
 ```
     ++  sect  ?(%black %blue %red %orange %white)           ::  banner
@@ -2006,7 +1936,7 @@ This is the location of the user, usually of the form "country/zip".
 
 XXX
 
-### `++name`
+### `++name:ames`
 
 ```
     ++  name  ,[p=@t q=(unit ,@t) r=(unit ,@t) s=@t]        ::  first mid/nick last

--- a/learn/arvo/arvo-internals/clay.udon
+++ b/learn/arvo/arvo-internals/clay.udon
@@ -1,4 +1,4 @@
-:-  :~  navhome/'/docs/'
+rang:clay`case:clay`:-  :~  navhome/'/docs/'
         navuptwo/'true'
         next/'true'
         sort/'3'
@@ -478,7 +478,7 @@ at least skimming, this so that you get a rough idea of how our state is
 organized.
 
 The types that are certainly worth reading are `++raft`, `++room`,
-`++dome`, `++ankh`, `++rung`, `++rang`, `++blob`, `++yaki`, and `++nori`
+`++dome:clay`, `++ankh:clay`, `++rung:clay`, `++rang:clay`, `++blob:clay`, `++yaki:clay`, and `++nori:clay`
 (possibly in that order). All in all, though, this section isn't too
 long, so many readers may wish to quickly read through all of it. If you
 get bored, though, just skip to the next section. You can always come
@@ -562,7 +562,7 @@ ducts from where the subscriptions requests came. The results will be
 produced along these ducts. The values are a description of the
 requested information.
 
-#### `++rave`, general subscription request
+#### `++rave:clay`, general subscription request
 
 ```
     ++  rave                                                ::  general request
@@ -585,7 +585,7 @@ When we store a request, we store subscriptions with a little extra
 information so that we can determine whether new versions actually
 affect the path we're subscribed to.
 
-#### `++mood`, single subscription request
+#### `++mood:clay`, single subscription request
 
 ```
     ++  mood  ,[p=care q=case r=path]                       ::  request in desk
@@ -595,7 +595,7 @@ This represents a request for the state of the desk at a particular
 commit, specfied by `q`. `p` specifies what kind of information is
 desired, and `r` specifies the path we are requesting.
 
-#### `++moat`, range subscription request
+#### `++moat:clay`, range subscription request
 
 ```
     ++  moat  ,[p=case q=case r=path]                       ::  change range
@@ -611,12 +611,12 @@ by the path or to any of its children.
     ++  moot  ,[p=case q=case r=path s=(map path lobe)]     ::
 ```
 
-This is just a `++moat` plus a map of paths to lobes. This map
+This is just a `++moat:clay` plus a map of paths to lobes. This map
 represents the data at the node referenced by the path at case `p`, if
 we've gotten to that case (else null). We only send a notification along
 the subscription if the data at a new revision is different than it was.
 
-### ` `++care`, clay submode
+### `++care:clay`, clay submode
 
 ```
     ++  care  ?(%u %v %w %x %y %z)                          ::  clay submode
@@ -625,11 +625,11 @@ the subscription if the data at a new revision is different than it was.
 This specifies what type of information is requested in a subscription
 or a scry.
 
-`%u` requests the `++rang` at the current moment. Because this
+`%u` requests the `++rang:clay` at the current moment. Because this
 information is not stored for any moment other than the present, we
-crash if the `++case` is not a `%da` for now.
+crash if the `++case:clay` is not a `%da` for now.
 
-`%v` requests the `++dome` at the specified commit.
+`%v` requests the `++dome:clay` at the specified commit.
 
 `%w` requests the revsion number of the desk.
 
@@ -655,7 +655,7 @@ our children. `r` is a map to null rather than a set so that the
 ordering of the map will be equivalent to that of `r:ankh`, allowing
 efficient conversion.
 
-#### `++case`, specifying a commit
+#### `++case:clay`, specifying a commit
 
 ```
     ++  case                                                ::  ship desk case spur
@@ -669,9 +669,9 @@ A commit can be referred to in three ways: `%da` refers to the commit
 that was at the head on date `p`, `%tas` refers to the commit labeled
 `p`, and `%ud` refers to the commit numbered `p`. Note that since these
 all can be reduced down to a `%ud`, only numbered commits may be
-referenced with a `++case`.
+referenced with a `++case:clay`.
 
-#### `++dome`, desk data
+#### `++dome:clay`, desk data
 
 ```
     ++  dome                                                ::  project state
@@ -695,7 +695,7 @@ commit.
 the total number of numbered commits.
 
 `hit` is a map of numerical ids to hashes of commits. These hashes are
-mapped into their associated commits in `hut:rang`. In general, the keys
+mapped into their associated commits in `hut:rang:clay`. In general, the keys
 of this map are exactly the numbers from 1 to `let`, with no gaps. Of
 course, when there are no numbered commits, `let` is 0, so `hit` is
 null. Additionally, each of the commits is an ancestor of every commit
@@ -805,14 +805,14 @@ satisfied.
 `fod` is the same set as `bom`, but from a different perspective. In
 particular, the values of `fod` are the same as the values of `bom`, and
 the `p` out of the values of `bom` are the same as the keys of `fod`.
-Thus, we can map ducts to their associated request number and `++rave`,
-and we can map numbers to their associated duct and `++rave`.
+Thus, we can map ducts to their associated request number and `++rave:clay`,
+and we can map numbers to their associated duct and `++rave:clay`.
 
 `haw` is a map from simple requests to their values. This acts as a
 cache for requests that have already been made. Thus, the second request
-for a particular `++mood` is nearly instantaneous.
+for a particular `++mood:clay` is nearly instantaneous.
 
-#### `++rang`, data store
+#### `++rang:clay`, data store
 
 ```
     ++  rang  $:  hut=(map tako yaki)                       ::
@@ -825,25 +825,25 @@ is stored, but it is only meaningful if we know the hash of what we're
 looking for.
 
 `hut` is a map from hashes to commits. We often get the hashes from
-`hit:dome`, which keys them by logical id. Not every commit has an id.
+`hit:dome:clay`, which keys them by logical id. Not every commit has an id.
 
 `lat` is a map from hashes to the actual data. We often get the hashes
 from a `++yaki`, a commit, which references this map to get the data.
-There is no `++blob` in any `++yaki`. They are only accessible through
+There is no `++blob:clay` in any `++yaki:clay`. They are only accessible through
 this map.
 
-#### `++tako`, commit reference
+#### `++tako:clay`, commit reference
 
 ```
     ++  tako  ,@                                            ::  yaki ref
 ```
 
-This is a hash of a `++yaki`, a commit. These are most notably used as
-the keys in `hut:rang`, where they are associated with the actual
-`++yaki`, and as the values in `hit:dome`, where sequential ids are
+This is a hash of a `++yaki:clay`, a commit. These are most notably used as
+the keys in `hut:rang:clay`, where they are associated with the actual
+`++yaki:clay`, and as the values in `hit:dome:clay`, where sequential ids are
 associated with these.
 
-#### `++yaki`, commit
+#### `++yaki:clay`, commit
 
 ```
     ++  yaki  ,[p=(list tako) q=(map path lobe) r=tako t=@da] ::  commit
@@ -858,24 +858,24 @@ practice merges have exactly two parents. This may change in the future.
 For commit 1, there is no parent.
 
 `q` is a map of the paths on a desk to the data at that location. If you
-understand what a `++lobe` and a `++blob` is, then the type signature
+understand what a `++lobe:clay` and a `++blob:clay` is, then the type signature
 here tells the whole story.
 
 `r` is the hash associated with this commit.
 
 `t` is the date at which this commit was made.
 
-#### `++lobe`, data reference
+#### `++lobe:clay`, data reference
 
 ```
     ++  lobe  ,@                                            ::  blob ref
 ```
 
-This is a hash of a `++blob`. These are most notably used in `lat:rang`,
-where they are associated with the actual `++blob`, and as the values in
-`q:yaki`, where paths are associated with their data in a commit.
+This is a hash of a `++blob:clay`. These are most notably used in `lat:rang:clay`,
+where they are associated with the actual `++blob:clay`, and as the values in
+`q:yaki:clay`, where paths are associated with their data in a commit.
 
-#### `++blob`, data
+#### `++blob:clay`, data
 
 ```
     ++  blob  $%  [%delta p=lobe q=lobe r=udon]             ::  delta on q
@@ -993,7 +993,7 @@ This space intentionally left undocumented. This stuff is not known to
 work, and will likely change when we get a well-typed clay. Also, this
 is not a complicated type; it is not difficult to work out the meaning.
 
-#### `++nori`, repository action
+#### `++nori:clay`, repository action
 
 ```
     ++  nori                                                ::  repository action
@@ -1009,7 +1009,7 @@ we can apply a label to a commit.
 In the `|` case, we will simply label the current commit with the given
 label. In the `&` case, we will apply the given changes.
 
-#### `++soba`, delta
+#### `++soba:clay`, delta
 
 ```
     ++  soba  ,[p=cart q=(list ,[p=path q=miso])]           ::  delta
@@ -1021,7 +1021,7 @@ of changes keyed by the file they're changing. Thus, the paths are paths
 to files to be changed while `miso` is a description of the change
 itself.
 
-#### `++miso`, ankh delta
+#### `++miso:clay`, ankh delta
 
 ```
     ++  miso                                                ::  ankh delta
@@ -1037,7 +1037,7 @@ We can delete a file, in which case `p` is the contents of the old file.
 Finally, we can mutate that file, in which case the `udon` describes the
 changes we are applying to the file.
 
-#### `++mizu`, merged state
+#### `++mizu:clay`, merged state
 
 ```
     ++  mizu  ,[p=@u q=(map ,@ud tako) r=rang]              ::  new state
@@ -1051,7 +1051,7 @@ are to be inserted. The keys to this should always be the numbers from
 commits and data. Since these are merged into the current state, no old
 commits or data need be here.
 
-#### `++riff`, request/desist
+#### `++riff:clay`, request/desist
 
 ```
     ++  riff  ,[p=desk q=(unit rave)]                       ::  request/desist
@@ -1062,7 +1062,7 @@ contains a `rave`, then this opens a subscription to the desk for that
 data. If `q` is null, then this tells clay to cancel the subscription
 along this duct.
 
-#### `++riot`, response
+#### `++riot:clay`, response
 
 ```
     ++  riot  (unit rant)                                   ::  response/complete
@@ -1072,7 +1072,7 @@ A riot is a response to a subscription. If null, the subscription has
 been completed, and no more responses will be sent. Otherwise, the
 `rant` is the produced data.
 
-#### `++rant`, response data
+#### `++rant:clay`, response data
 
 ```
     ++  rant                                                ::  namespace binding
@@ -1103,7 +1103,7 @@ of a desk. This allows us to easily keep track of a remote repository --
 all the new information we need is contained in the `nako`.
 
 `gar` is a map of the revisions in the range to the hash of the commit
-at that revision. These hashes can be used with `hut:rang` to find the
+at that revision. These hashes can be used with `hut:rang:clay` to find the
 commit itself.
 
 `let` is either the last revision number in the range or the most recent
@@ -1115,7 +1115,7 @@ revision number, whichever is smaller.
 
 As with all vanes, there are exactly two ways to interact with clay.
 `%clay` exports a namespace accessible through `.^`, which is described
-above under `++care`. The primary way of interacting with clay, though,
+above under `++care:clay`. The primary way of interacting with clay, though,
 is by sending kisses and receiving gifts.
 
 ```
@@ -1150,7 +1150,7 @@ changes to the filesystem. Whenever we add, remove, or edit a file, one
 of these cards is sent. The `p` is the ship whose filesystem we're
 trying to change, the `q` is the desk we're changing, and the `r` is the
 request change. For the format of the requested change, see the
-documentation for `++nori` above.
+documentation for `++nori:clay` above.
 
 When a file is changed in the unix filesystem, vere will send a `%into`
 kiss. This tells clay that the duct over which the kiss was sent is the
@@ -1184,7 +1184,7 @@ filesystem for a ship.
 This is called to perform a merge. This is most visibly called by
 :update to update the filesystem of the current ship to that of its
 sein. The `p` and `q` are as in `%info`, and the `r` is the description
-of the merge. See `++mizu` above.
+of the merge. See `++mizu:clay` above.
 
 XX
 `XX                [%wake ~]                                 ::  timer activate XX`
@@ -1209,7 +1209,7 @@ it into a `%warp`.
 
 This is a request for information about a particular desk. This is, in
 its most general form, a subscription, though in many cases it is the
-trivial case of a subscription -- a read. See `++riff` for the format of
+trivial case of a subscription -- a read. See `++riff:clay` for the format of
 the request.
 
 ## Lifecycle of a Local Read
@@ -1433,7 +1433,7 @@ than the present. Since we don't store that information for any other
 time, we can't produce it in a referentially transparent manner for any
 time other than the present.
 
-Then, we try to read the requested `mood` `p.rav`. If we can't access
+Then, we try to read the requested `mood:clay` `p.rav`. If we can't access
 the request data right now, we call `++duce` to put the request in our
 queue to be satisfied when the information becomes available.
 
@@ -1555,7 +1555,7 @@ stored in `arvo/clay.hoon`. We examine `++case-to-aeon:ze`.
         ==
 ```
 
-We handle each type of `case` differently. The latter two types are
+We handle each type of `case:clay` differently. The latter two types are
 easy.
 
 If we're requesting a revision by label, then we simply look up the

--- a/learn/arvo/arvo-internals/clay.udon
+++ b/learn/arvo/arvo-internals/clay.udon
@@ -647,7 +647,7 @@ if `q:ankh` is null), then this produces null.
     ++  arch  ,[p=@uvI q=(unit ,@uvI) r=(map ,@ta ,~)]      ::  fundamental node
 ```
 
-This is analogous to `++ankh` except that the we have neither our
+This is analogous to `++ankh:clay` except that the we have neither our
 contents nor the ankhs of our children. The other fields are exactly the
 same, so `p` is a hash of the associated ankh, `u.q`, if it exists, is a
 hash of the contents of this node, and the keys of `r` are the names of

--- a/learn/arvo/arvo-internals/ford.udon
+++ b/learn/arvo/arvo-internals/ford.udon
@@ -545,11 +545,11 @@ Wide-form `/#` does not need a delimiter:
 At the moment, only HTTP requests forwarded by `%eyre` contain any extra arguments,
 and using this rune outside of that context will cause an error. Requests from `%eyre`
 contain an argument representing the query string, which can be parsed using the
-standard library gate `++fuel`.
+standard library gate `++fuel:html`.
 
 Example:
 ```
-/=  gas  /$  fuel
+/=  gas  /$  fuel:html
 ::
 :*
   %who    {<(~(get ju aut.ced.gas) 0)>}
@@ -560,7 +560,7 @@ Example:
 produces: [%who '~zod' %where /ford/pages/web %case 60]
 
 Wide-form `/$` takes its arguments inside brackets, like `/~`:
-`/=gas=/$[fuel]`
+`/=gas=/$[fuel:html]`
 
 ### `/%` propagate extra arguments into renderers
 

--- a/learn/arvo/arvo-internals/gall.udon
+++ b/learn/arvo/arvo-internals/gall.udon
@@ -768,7 +768,7 @@ be null here because we aren't doing any authentication; a mark, in this
 case the http request mark `&httr`; and some data in the form of a
 `cage`, which is a `[mark vase]`. This is confusing, so the mold in the
 code quoted above includes a bunch of otherwise unnecessary faces for
-the purpose of illustration. Compare: `[%hiss p=(unit iden) q=mark
+the purpose of illustration. Compare: `[%hiss p=(unit user) q=mark
 r=cage]` from `zuse`.
 
 > You can grep zuse.hoon and arvo.hoon for most of these definitions. However, beware the ambiguity surrounding "hiss": there's ++hiss in section 3bI of `zuse` ("Arvo structures"), and there's `%hiss` the move that is sent to %eyre to make our HTTP request happen. Here we're talking about the latter. See `++kiss-eyre` in `zuse`.
@@ -2002,7 +2002,7 @@ Thus, we're producing our state unchanged.
 
 Our list of moves is the result of a call to `++turn`. `++turn` is what many
 languages call "map" -- it runs a function on every item in a list and collects
-the results in a list. The list is `(prey /example-path bow)` and the function
+the results in a list. The list is `(prey:pubsub:userlib /example-path bow)` and the function
 is the `|=` line right after it.
 
 `prey:pubsub:userlib` is a standard library function defined in `zuse.hoon`. It takes a path

--- a/reference/library/2q.udon
+++ b/reference/library/2q.udon
@@ -105,7 +105,7 @@ which is a day atom and a time.
 
 #### Discussion
 
-See also: [`year`](../3c), [`yore`](../3c) [`stud`](../2q), [`dust`](../2q)
+See also: [`year`](../3c), [`yore`](../3c)
 
 ---
 ### `++knot`

--- a/reference/library/5f.udon
+++ b/reference/library/5f.udon
@@ -13,7 +13,7 @@
 XML name
 
 An XML name (tag name or attribute name) with an optional namespace.  Parsed by
-`++name` within `++poxa`, rendered by `++name` within `++poxo`.
+`++name:de-xml:html` in `zuse.hoon`, rendered by `++name:en-xml:html` in `zuse.hoon`.
 
 #### Source
 
@@ -41,7 +41,7 @@ See also: `++sail`
 
 XML node.
 
-Parsed by `++apex` within `++poxa`, rendered by `++poxo`.
+Parsed by `++apex` within `++apex:de-xml:html` in `zuse.hoon`, rendered by `++apex:en-xml:html` in `zuse.hoon`.
 
 #### Source
 
@@ -72,13 +72,12 @@ A list of `++manx`.
 
 
 
-
 ---
 ### `++mars`
 
 XML CDATA
 
-Implicitly produced by `++chrd` within `++poxa`
+Implicitly produced by `++chrd` within `++chrd:de-xml:html`
 
 #### Source
 
@@ -98,7 +97,7 @@ List of XML attributes
 Each `++mart` is a list of pairs of `++mane` and
 `++tape`.
 
-Parsed by `++attr` within `++poxa`, rendered by `++attr` within `++poxo`
+Parsed by `++attr:de-xml:html` in `zuse.hoon`, rendered by `++attr:en-xml:html` in `zuse.hoon`.
 
 #### Source
 
@@ -109,14 +108,13 @@ Parsed by `++attr` within `++poxa`, rendered by `++attr` within `++poxo`
 #### Examples
 
 
-
 ---
 ### `++marx`
 
 XML tag
 
 A `++marx` is a pair of a tag name, `++mane` and a list of attributes,
-`++mart`. Parsed by `++head` `++poxa`, rendered within `++poxo`.
+`++mart`. Parsed by `++head:de-xml:html` in `zuse.hoon`, rendered within `++de-xml:html` in `zuse.hoon`.
 
 #### Source
 


### PR DESCRIPTION
I erred on the side of being overly specific within vane documentation: I replaced things like `++ankh` with `++ankh:clay`, and so forth