### PR TITLE
Remove meson version from bash install script

### DIFF
--- a/getting-started.udon
+++ b/getting-started.udon
@@ -212,7 +212,7 @@ urbit
 sudo apt-get update
 sudo apt-get install g++ git libcurl4-gnutls-dev libgmp3-dev libncurses5-dev libsigsegv-dev libssl-dev make openssl pkg-config python python3 python3-pip zlib1g-dev ninja-build
 sudo -H pip3 install --upgrade pip
-sudo -H pip3 install meson==0.29
+sudo -H pip3 install meson
 
 git clone https://github.com/urbit/urbit
 cd urbit
@@ -246,7 +246,7 @@ popd
 curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 sudo /usr/local/bin/python3 get-pip.py
 # downgrade meson to avoid dependencies that redhat can't meet
-sudo -H /usr/local/bin/pip3 install meson==0.29
+sudo -H /usr/local/bin/pip3 install meson
 
 
 git clone git://github.com/ninja-build/ninja.git && cd ninja

--- a/learn/azimuth.udon
+++ b/learn/azimuth.udon
@@ -9,4 +9,4 @@ Azimuth is a general-purpose public-key infrastructure (PKI) on the Ethereum blo
 
 Azimuth is not, however, part of the Urbit stack. Azimuth is a parallel system that be used as a generalized identity system for other projects. Azimuth "touches" the Urbit ecosystem when a point is used to boot a virtual computer on the Urbit network for the first time. When that happens, the point considered *linked* to Azimuth and the point’s full powers are available for use. Once a point is linked, it cannot be unlinked. 
 
-A metaphor might make the relationship between these two systems to understand: Azimuth is the bank vault that stores the deed to your house. The Urbit network is the neighborhood that you live in. 
+A metaphor might make the relationship between these two systems easier to understand: Azimuth is the bank vault that stores the deed to your house. The Urbit network is the neighborhood that you live in. 


### PR DESCRIPTION
I couldn't build on Debian 9 with current script because the meson version was so old.