### PR TITLE
Fix Gall text/hyperlink in glossary.

### DIFF
--- a/reference/glossary.udon
+++ b/reference/glossary.udon
@@ -173,8 +173,8 @@ Below are Arvo modules, which are called "vanes".
 
   Gall is located at `/home/sys/vane/gall.hoon` within your urbit.
 
-  More in-depth information on Ford can be found
-  [`here`](/docs/tutorials/internals/gall/).
+  More in-depth information on Gall can be found
+  [`here`](/docs/learn/arvo/arvo-internals/gall/).
 
 ### atom
 


### PR DESCRIPTION
This fixes a typo in the Gall section that had referred to Ford, and also updates the "more info" link to match the newer scheme used throughout the docs.