### PR TITLE
fixes typos in bus.udon

### DIFF
--- a/reference/hoon-expressions/rune/bus.udon
+++ b/reference/hoon-expressions/rune/bus.udon
@@ -49,13 +49,12 @@ Molds and mold builders are generally described together.
 A structure is a noun produced, usually at compile-time, for use in tracking types.  In most cases, structures don't exist in the runtime semantics.
 
 A structure for the base in `p`. `%noun` is any noun; `%atom` is any
-atom; `%cell` is a cell of nouns; `%flag` is a loobean, ``?(`@f`0
-`@f`1)``. `%null` is zero with aura `@n`.
+atom; `%cell` is a cell of nouns; `%flag` is a loobean. `%null` is zero with aura `@n`.
 
 ##### Syntax
 
 Irregular: `*` makes `%noun`, `^` makes `%cell`, `?` makes
-`%bean`, `~` makes `%null`, `@aura` makes atom `aura`.
+`%flag`, `~` makes `%null`, `@aura` makes atom `aura`.
 
 ## Runes
 


### PR DESCRIPTION
I just took out the `?(@f0 @f1)` because it seemed like confusing gibberish (is `@f` even an aura?)