### PR TITLE
remove title text from image markdown in learn/arvo/arvo-internals/ha…

### DIFF
--- a/learn/arvo/arvo-internals/hall.udon
+++ b/learn/arvo/arvo-internals/hall.udon
@@ -435,7 +435,7 @@ We will only display the delta generation parts of the flow. Delta application i
 Hall-to-Hall subscriptions happen when a source gets added to a story. This is done with a `%source` action, and results in a `%peer` move being sent (prompted by a `%story %follow` delta).
 Upon receiving a valid peer on a `/circle` path, the subscribing ship is added to that circle's presence map.
 
-![subscriptions implementation flow](https://media.urbit.org/docs/hall/diagrams/flow-subscriptions.png "subscriptions implementation flow")
+![subscriptions implementation flow](https://media.urbit.org/docs/hall/diagrams/flow-subscriptions.png)
 
 ```
 ++  poke-talk-action      :<  we got poked with an action.
@@ -452,7 +452,7 @@ Upon receiving a valid peer on a `/circle` path, the subscribing ship is added t
 
 Once a query has opened, Hall will receive updates on it, rumors. The changes describes in these rumors are applied via the following flow.
 
-![rumor implementation flow](https://media.urbit.org/docs/hall/diagrams/flow-rumors.png "report diff implementation flow")
+![rumor implementation flow](https://media.urbit.org/docs/hall/diagrams/flow-rumors.png)
 
 ```
 ++  diff-talk-rumor       :<  we got a query update.
@@ -467,7 +467,7 @@ Once a query has opened, Hall will receive updates on it, rumors. The changes de
 
 To send messages, the user sends a `%convey` or `%phrase` action, resulting in a `%publish` command being sent to the involved partners. Receiving a `%publish` command causes its messages to be added to the story through the creation of a `%story %grams` delta.
 
-![messaging implementation flow](https://media.urbit.org/docs/hall/diagrams/flow-messaging.png "messaging implementation flow")
+![messaging implementation flow](https://media.urbit.org/docs/hall/diagrams/flow-messaging.png)
 
 ```
 ++  poke-talk-action      :<  we got poked with an action.


### PR DESCRIPTION
…ll.udon (temporary?)

The udon parser doesn't handle title text markdown in links or images.
(It doesn't handle images at all but see https://github.com/urbit/arvo/pull/1085.)

So this patch gets rid of the title text.  If/when udon handles title
text these can be re-added.

This patch assumes the udon image patch will land.  If it doesn't
the image markdown should be changed to link markdown.
