### PR TITLE
"next" link of trees-sets-maps corrected

### DIFF
--- a/learn/arvo/hoon/trees-sets-and-maps.udon
+++ b/learn/arvo/hoon/trees-sets-and-maps.udon
@@ -323,4 +323,4 @@ You can use `run` of `by` to apply a gate to each value in a map, producing a ma
 
 There are other map functions in the Hoon standard library that didn't cover here.
 
-### [Next Lesson: Type Polymorphism](../type-polymorphism)
+### [Next Lesson: Examples](../examples)


### PR DESCRIPTION
Now the link points to 2.11 instead of 3.1