### PR TITLE
Rob edits

### DIFF
--- a/getting-started/azimuth.udon
+++ b/getting-started/azimuth.udon
@@ -1,8 +1,28 @@
-:-  :~  title/'Azimuth'
+:-  :~  title/'Bridge'
         sort/'3'
     ==
 ;>
 
-# Using Azimuth
+# Bridge
 
-The primary way to interact with Azimuth, our identity platform, is through our application [Bridge](https://github.com/urbit/bridge) and the node libraries that it depends on, azimuth-js and keygen-js. Take a look at the source and play around or see [Getting Started](/docs/getting-started).
+[Bridge](https://github.com/urbit/bridge) is the client we built for interacting with [Azimuth](/docs/pki) and managing points.
+
+To install Bridge, navigate to the [release page](https://github.com/urbit/bridge/releases/) on GitHub. Download the `.zip` file at of the latest version. After you download it, follow the instructions below.
+
+### Verify Checksums
+
+You may wish to validate your downloaded file's checksum to make sure that you weren't given a different file by a malicious third party. To do this, unzip the file you download. Navigate inside the resulting folder, and compare the lines in checksum.txt to SHA-256 hashes of the `build` directory's contents. You can get such a hash by running one of the following commands.
+
+- On MacOS: `shasum -a 256 -c checksums.txt build` in the terminal.
+- On Linux: `sha256sum -c checksums.txt build`
+- On Windows: Go into the `build` directory and verify files individually with `CertUtil -hashFile [file_name] SHA256`
+
+### Installation
+
+To use Bridge:
+
++ Unzip the `.zip` file that you downloaded (`bridge-$version.zip`).
++ Open up your command line interface (Terminal on OSX, Command Prompt on Windows).
++ Navigate to the `bridge-$version` directory, where `$version` is the appropriate version number.
++ Run this command: `python3 -m http.server 5000 --bind 127.0.0.1 --directory build`
++ You can then use the Bridge app by navigating to `http://localhost:5000` in your internet browser.

--- a/introduction/arvo-vs-azimuth.udon
+++ b/introduction/arvo-vs-azimuth.udon
@@ -7,9 +7,9 @@
 
 Urbit is a project, not a single computer system. It has three components: Arvo, the operating system; Azimuth, the identity system; and Aegean, the pattern for creating software experiences for individual Urbit communities. This document compares the first two.
 
-*Arvo* is an operating system that provides the software for a personal server. These personal servers together constitute the peer-to-peer Arvo network. To make this network work on the social level, Arvo is built to work with a system of scarce and immutable identities.
+[*Arvo*](https://github.com/urbit/arvo) is an operating system that provides the software for a personal server. These personal servers together constitute the peer-to-peer Arvo network. To make this network work on the social level, Arvo is built to work with a system of scarce and immutable identities.
 
-*Azimuth* is the public-key infrastructure built to be such a system. A suite of smart-contracts on the Ethereum blockchain, Azimuth determines which Ethereum addresses own which Azimuth identities, called _points_. All point-related operations, such as transfers, are governed at this layer. But Azimuth isn't built strictly for Arvo -- it could be used as a generalized identity system for other projects.
+[*Azimuth*](https://github.com/urbit/azimuth) is the public-key infrastructure built to be such a system. A suite of smart-contracts on the Ethereum blockchain, Azimuth determines which Ethereum addresses own which Azimuth identities, called _points_. All point-related operations, such as transfers, are governed at this layer. But Azimuth isn't built strictly for Arvo -- it could be used as a generalized identity system for other projects.
 
 These otherwise-parallel systems meet when you want to connect to the Arvo network. Your Arvo personal server, called your _ship_, needs to be able to prove cryptographically that it is who it says it is. This proof comes in the form of a keyfile, derived from your point, that you use to start your ship.
 

--- a/introduction/arvo-vs-azimuth.udon
+++ b/introduction/arvo-vs-azimuth.udon
@@ -1,4 +1,5 @@
 :-  :~  title/'Arvo vs. Azimuth'
+        sort/'4'
     ==
 ;>
 

--- a/introduction/galaxies-stars-and-planets.udon
+++ b/introduction/galaxies-stars-and-planets.udon
@@ -10,7 +10,7 @@ That's why we built a system for persistent identity called [Azimuth](../arvo-vs
 
 An Azimuth point is a pronounceable string like `~firbyr-napbes`. It means nothing, but it's easy to remember and say out loud. `~firbyr-napbes` is actually just a 32-bit number (`3.237.967.392`, to be exact) that we turn into a human-memorable string.
 
-Points come in three major classes: *galaxies*, *stars*, and *planets*. You can tell what class a point is in by how long its name is. The address space grows like a family tree. Galaxies are 8-bit and have names like `~mul`. Galaxies can issue 16-bit stars (`~dacpyl`), which can themselves issue 32-bit planets (`~laptel-holfur`).
+Points come in three classes: *galaxies*, *stars*, and *planets*. You can tell what class a point is in by how long its name is. The address space grows like a family tree. Galaxies are 8-bit and have names like `~mul`. Galaxies can issue 16-bit stars (`~dacpyl`), which can themselves issue 32-bit planets (`~laptel-holfur`).
 
 Planets are intended for everyday use by an adult human, and there is a maximum of about 4.3 billion of them (2 to the 32nd power). Stars and galaxies, on the other hand, are meant to act as network infrastructure: in the Arvo network they provide P2P routing and distribute software updates.
 
@@ -26,7 +26,7 @@ Planets are intended for everyday use by an adult human, and there is a maximum 
 
 ## Moons and Comets
 
-In addition to these three main classes, there are two other kinds of Azimuth point.
+In addition to these three classes of Azimuth points, there two other kinds of Urbit identities, but they do _not_ use Azimuth. 
 
 *Moons* are 64 bits, are issued by planets, and have names like `~doznec-salfun-naptul-habrys`. Moons are meant for connected devices: phones, smart TVs, digital thermostats. Moons are not independent, but are subordinated to their parent planet.
 

--- a/introduction/galaxies-stars-and-planets.udon
+++ b/introduction/galaxies-stars-and-planets.udon
@@ -1,0 +1,33 @@
+:-  :~  title/'Galaxies, Stars, and Planets'
+    ==
+;>
+
+# Galaxies, Stars, and Planets
+
+The current internet has no consistent system of identity. There are only quasi-identities such as IP addresses, Google accounts and email addresses, each able to be assumed and abandoned without much trouble. The result is a hostile social experience, since bad actors -- spammers, scammers, malware-spreaders, and harassers -- have an inexhaustible supply of places to hide.
+
+That's why we built a system for persistent identity called [Azimuth](../arvo-vs-azimuth). Azimuth identities are called _points_, and you need one to use the Arvo network. Points are secure, since they are owned and controlled with key-pair the Ethereum blockchain, which Azimuth is built on top of.
+
+An Azimuth point is a pronounceable string like `~firbyr-napbes`. It means nothing, but it's easy to remember and say out loud. `~firbyr-napbes` is actually just a 32-bit number (`3.237.967.392`, to be exact) that we turn into a human-memorable string.
+
+Points come in three major classes: *galaxies*, *stars*, and *planets*. You can tell what class a point is in by how long its name is. The address space grows like a family tree. Galaxies are 8-bit and have names like `~mul`. Galaxies can issue 16-bit stars (`~dacpyl`), which can themselves issue 32-bit planets (`~laptel-holfur`).
+
+Planets are intended for everyday use by an adult human, and there is a maximum of about 4.3 billion of them (2 to the 32nd power). Stars and galaxies, on the other hand, are meant to act as network infrastructure: in the Arvo network they provide P2P routing and distribute software updates.
+
+```
+    Size   Name    Parent  Object      Example
+    -----  ------  ------  ------      -------
+    2^8    galaxy  ~       supernode   ~zod
+    2^16   star    galaxy  supernode   ~dozbud
+    2^32   planet  star    user        ~tasfyn-partyv
+    2^64   moon    planet  device      ~sigsam-nimbot-tasfyn-partyv
+    2^128  comet   ~       bot         ~racmus-mollen-fallyt-linpex--watres-sibbur-modlux-rinmex
+```
+
+## Moons and Comets
+
+In addition to these three main classes, there are two other kinds of Azimuth point.
+
+*Moons* are 64 bits, are issued by planets, and have names like `~doznec-salfun-naptul-habrys`. Moons are meant for connected devices: phones, smart TVs, digital thermostats. Moons are not independent, but are subordinated to their parent planet.
+
+*Comets* are 128-bit points with no parents that can be launched by anyone. They are meant for bots. Being disposable and essentially unlimited, they will likely not be trusted by the others on the Arvo network. They have enormous names, like `~racmus-mollen-fallyt-linpex--watres-sibbur-modlux-rinmex`.


### PR DESCRIPTION
Adds Bridge info to azimuth.udon, which is the destination of a URL printed on paper wallets (via redirect)

Also adds an explanation of the address-space hierarchy in a new document.
