### PR TITLE
Update getting-started.udon

### DIFF
--- a/getting-started.udon
+++ b/getting-started.udon
@@ -241,15 +241,15 @@ urbit
 ```
 # Bash
 
-sudo pacman -Syu
-sudo pacman -S curl gcc git gmp libsigsegv ncurses ninja openssl python
-curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-sudo python3 get-pip.py
+sudo pacman -Syyu
+sudo pacman -S --needed curl gcc git gmp libsigsegv ncurses ninja openssl python python-pip meson
 git clone https://github.com/urbit/urbit
 cd urbit
 ./scripts/bootstrap
 ./scripts/build
-sudo ninja -C ./build/ meson-install
+cd build
+ninja
+sudo ninja meson-install
 urbit
 ```
 


### PR DESCRIPTION
makes sure pacman is using latest repos
added --needed to pacman so existing packages aren't reinstalled
installed pip via pacman instead of curl which is tidier
added meson to pacman install line
separated building tests from final executable install to minimize superuser usage and not leave root-owned files lying around