### PR TITLE
clarifies Bridge instructions

### DIFF
--- a/getting-started/azimuth.udon
+++ b/getting-started/azimuth.udon
@@ -23,7 +23,7 @@ To use Bridge:
 
 *Note:* Bridge allows you both make reads and writes to the Ethereum blockchain. Writing to the blockchain, such as changing your networking keys, will incur a transaction cost that will require you to have some ETH in your address.
 
-Once the program is running in your browser, go through each step presented according to what kind of wallet you have. There's a few login options you'll be presented with. A notable option is *Urbit Master Ticket*. This is for those who used our Wallet Generator software. If you bought points from an Urbit sale and then used the Wallet Generator, your networking keys will be set for you. All other login options will result in you needing to set your own networking keys.
+Once the program is running in your browser, go through each step presented according to what kind of wallet you have. There are a few login options you'll be presented with. A notable option is *Urbit Master Ticket*. This is for those who used our Wallet Generator software. If you bought points from an Urbit sale and then used the Wallet Generator, your networking keys will be set for you. All other login options will result in you needing to set your own networking keys.
 
 *Ethereum Prv*:
 

--- a/getting-started/azimuth.udon
+++ b/getting-started/azimuth.udon
@@ -25,8 +25,6 @@ To use Bridge:
 
 Once the program is running in your browser, go through each step presented according to what kind of wallet you have. There are a few login options you'll be presented with. A notable option is *Urbit Master Ticket*. This is for those who used our Wallet Generator software. If you bought points from an Urbit sale and then used the Wallet Generator, your networking keys will be set for you. All other login options will result in you needing to set your own networking keys.
 
-*Ethereum Prv*:
-
 ## Accept Your Transfer
 
 After you access your Ethereum address, if a point was sent to that address,

--- a/getting-started/azimuth.udon
+++ b/getting-started/azimuth.udon
@@ -23,7 +23,9 @@ To use Bridge:
 
 *Note:* Bridge allows you both make reads and writes to the Ethereum blockchain. Writing to the blockchain, such as changing your networking keys, will incur a transaction cost that will require you to have some ETH in your address.
 
-Once the program is running in your browser, go through each step presented according to what kind of wallet you have.
+Once the program is running in your browser, go through each step presented according to what kind of wallet you have. There's a few login options you'll be presented with. A notable option is *Urbit Master Ticket*. This is for those who used our Wallet Generator software. If you bought points from an Urbit sale and then used the Wallet Generator, your networking keys will be set for you. All other login options will result in you needing to set your own networking keys.
+
+*Ethereum Prv*:
 
 ## Accept Your Transfer
 


### PR DESCRIPTION
The "login" options are clarified here, because they have implications for the messiest part of Bridge: setting networking keys.