### PR TITLE
rearranges getting-started.udon so it's easier to follow

### DIFF
--- a/getting-started.udon
+++ b/getting-started.udon
@@ -7,7 +7,7 @@
 
 # Getting Started
 
-Welcome to Urbit, a personal server that makes you the owner of your digital life. Urbit isn't ready for serious use yet, but it definitely works. Follow this step-by-step guide to get an Azimuth point, install Urbit, and join the community.
+Welcome to Urbit, a personal server that makes you the owner of your digital life. Urbit isn't ready for serious use yet, but it's available to try out. Follow this step-by-step guide to get an Azimuth point, install Urbit, and join the community.
 
 ### [Step 1: Using Bridge](using-bridge)
 
@@ -31,7 +31,7 @@ You've already encountered some new terminology on this page, and you'll encount
 
 - Arvo is the name of the Urbit operating system.
 - An instance of the Arvo operating system is called a _ship_.
-- The network linking ships on this network is called "the Arvo network."
-- Azimuth is the name of the Urbit identity layer.
-- If you want to get on the Arvo network, an Azimuth-based identity called a _point_.
-- Urbit is the project as the whole, which includes all of these elements and more.
+- Ships communicate with one another over "the Arvo network."
+- Azimuth is an Ethereum-based PKI used to give each ship a unique identity on the Arvo network.
+- An Azimuth identity is called a _point_. You'll need a point to use the Arvo network.
+- Urbit refers to the project as a whole, including Arvo, Azimuth, and other system components.

--- a/getting-started.udon
+++ b/getting-started.udon
@@ -7,36 +7,31 @@
 
 # Getting Started
 
-Pages in this section are guides to getting you started with Urbit.
+Pages in this section are step-by-step instructions to getting you started with Urbit. Follow the guides below in the order that they are listed.
 
-But first, the absolute basics. Arvo is the name of the Urbit operating system and the name of network. Azimuth is the name of the Urbit identity layer. Urbit is the project as the whole.
-
-An instance of the Arvo operating system is called a _ship_. If you want to get on the Arvo network, you need an Azimuth identity, called a _point_.
-
-## Urbit Identities
-
-An Azimuth point functions as an identity and a network address for Arvo. A ship can't use the Arvo network unless it's been booted with the keys registered to a point.
-
-Points are generally not freely available, so you will need to either purchase one or get one from a friend. To receive one, you will need an Ethereum wallet that supports the BIP39 mnemonic seed functionality, which allows you to access your wallet with a series of dictionary words. Hardware wallets, such as Ledger and TREZOR devices, satisfy this requirement. So do various web-based wallets.
-
-Once you have such a wallet, give your Ethereum address to the person who agreed to give you a point. Have them transfer the point to your address, and continue to the with our guides below.
-
-## Guides
-
-Follow these guides in the order that they are listed.
-
-### [Using Bridge](using-bridge)
+### [Step 1: Using Bridge](using-bridge)
 
 Bridge is our client for managing Azimuth points. This guide will tell you how to use it to get your point's _keyfile_, the item you need to boot your ship booted onto the Arvo network.
 
-### [Installing Urbit](installing-urbit)
+### [Step 2: Installing Urbit](installing-urbit)
 
 This guide will tell you everything you need to know about installing our software.
 
-### [Booting a Ship](booting-a-ship)
+### [Step 3: Booting a Ship](booting-a-ship)
 
 This guide will walk you through the process of getting your ship operational and on the Arvo network.
 
-### [Creating a Development Ship](creating-a-development-ship)
+### [Optional: Creating a Development Ship](creating-a-development-ship)
 
 If you just want to do development work with Arvo, and don't need to be on the Urbit network, this section is for you.
+
+## Overview
+
+You're going to encounter some new terminology using this guide, so let's go over the basics.
+
+- Arvo is the name of the Urbit operating system.
+- An instance of the Arvo operating system is called a _ship_.
+- The network linking ships on this network is called "the Arvo network."
+- Azimuth is the name of the Urbit identity layer.
+- If you want to get on the Arvo network, an Azimuth-based identity called a _point_.
+- Urbit is the project as the whole, which includes all of these elements and more.

--- a/getting-started.udon
+++ b/getting-started.udon
@@ -7,7 +7,7 @@
 
 # Getting Started
 
-Welcome to Urbit, a personal server that makes you the owner of your digital life. Urbit isn't ready for serious use yet, but it's available to try out. Follow this step-by-step guide to get an Azimuth point, install Urbit, and join the community.
+Welcome to Urbit, a personal server. Urbit isn't ready for serious use yet, but it's available to try out. Follow this step-by-step guide to get an Azimuth point, install Urbit, and join the community.
 
 ### [Step 1: Using Bridge](using-bridge)
 

--- a/getting-started.udon
+++ b/getting-started.udon
@@ -7,27 +7,27 @@
 
 # Getting Started
 
-Pages in this section are step-by-step instructions to getting you started with Urbit. Follow the guides below in the order that they are listed.
+Welcome to Urbit, a personal server that makes you the owner of your digital life. Urbit isn't ready for serious use yet, but it definitely works. Follow this step-by-step guide to get an Azimuth point, install Urbit, and join the community.
 
 ### [Step 1: Using Bridge](using-bridge)
 
-Bridge is our client for managing Azimuth points. This guide will tell you how to use it to get your point's _keyfile_, the item you need to boot your ship booted onto the Arvo network.
+In order to join the Urbit network, you need an Azimuth point, which acts like an identity and a password for your Urbit ship. Bridge is our client for managing Azimuth points. This guide tells you how to use Bridge to get your point's _keyfile_, which you need to boot your ship.
 
 ### [Step 2: Installing Urbit](installing-urbit)
 
-This guide will tell you everything you need to know about installing our software.
+The Urbit software is a command-line application that runs the Arvo operating system. This guide walks you through the installation process.
 
 ### [Step 3: Booting a Ship](booting-a-ship)
 
-This guide will walk you through the process of getting your ship operational and on the Arvo network.
+This guide teaches you how to get your ship operational and onto the Arvo network.
 
 ### [Optional: Creating a Development Ship](creating-a-development-ship)
 
-If you just want to do development work with Arvo, and don't need to be on the Urbit network, this section is for you.
+If you want to develop software for Arvo, or if you just want to try the operating system without connecting to the network, this section is for you.
 
-## Overview
+## Terminology
 
-You're going to encounter some new terminology using this guide, so let's go over the basics.
+You've already encountered some new terminology on this page, and you'll encounter more as you proceed with this guide. Let's go over the basics:
 
 - Arvo is the name of the Urbit operating system.
 - An instance of the Arvo operating system is called a _ship_.


### PR DESCRIPTION
People reported that they found the getting-started page hard to follow. This makes it more straightforwardly a map to our getting-started guides.