### PR TITLE
don't bold(udon)/italicize(md) `|reset` or `|start` in Hood section o…

### DIFF
--- a/using/shell.md
+++ b/using/shell.md
@@ -196,13 +196,13 @@ number of vane names.
 ~your-urbit:dojo> |reload %clay %eyre
 ```
 
-*`|reset`* - Reloads `hoon.hoon` and all modules. No arguments.
+`|reset` - Reloads `hoon.hoon` and all modules. No arguments.
 
 ```
 ~your-urbit:dojo> |reset
 ```
 
-*`|start`* - Starts an app. Accepts an app name.
+`|start` - Starts an app. Accepts an app name.
 
 ```
 ~your-urbit:dojo> |start %curl


### PR DESCRIPTION
…f using/shell.md

I don't know why we would bold or italic here so I deleted it.