### PR TITLE
convert sail syntax to markdown/html in md files

### DIFF
--- a/learn/arvo/eyre.md
+++ b/learn/arvo/eyre.md
@@ -47,7 +47,8 @@ Runtime
 Let us follow the loading of a simple cli app, as it bounces from
 browser to server to browser and back.
 
-### Initial request ;a(id "init");
+<span id="init"></span>
+### Initial request
 
 An http request for `http://sampel-sipnym.urbit.org/cli` will be [redirected](dns)
 to the `%eyre` on ~sampel-sipnym, and come in as a `%this` kiss.
@@ -141,7 +142,7 @@ from request data.
 Returning to `++process-auth`, `%get` checks if the yac is authenticated with
 the requested credentials(`anon` requests are always granted), which for the
 fresh new `cyst` is not the case (more on success [later](#auth-ok)). Unless
-authentiacting as a [foreign ship](#xeno), the only thing left is to
+authenticating as a [foreign ship](#xeno), the only thing left is to
 `++show-login-page`, which detects that the requested resource is not `%html`,
 and produces a `%red` pest. For `%js`, `%red`irections `++resolve` to
 `++auth-redir:js`, a line of javascript which prepends `/~~` to the url path.
@@ -182,7 +183,8 @@ to a `[%auth %try {password}]` perk. `%get:process-auth` checks it against
 serves a fresh `auth.json` which reflects the changed `user`. Upon receiving
 this, the page is refreshed to retry the original request.
 
-### Post-authentication: app communication. <a id="auth-ok"/>
+<span id="auth-ok"></span>
+### Post-authentication: app communication.
 
 Upon refresh, `/~~/cli` brings us for the third time to `%get:process-auth`, but
 this time the cookie is set, and the `yac` fetched contains the serving ship as
@@ -205,7 +207,8 @@ of `oryx` that identifies the connection. `++as-aux-request`, an `%is` is a
 `++add-subs:ix`, the ix core fetched `++for-view` by hashing the request
 `++oryx-to-ixor`.
 
-<a id="ixor"/> A view has all the state associated with a client that must be
+<span id="view-ixor"></span>
+A view has all the state associated with a client that must be
 remembered between events. In this case, this is what app/path the request duct
 is associated with; but mainly, `++add-subs:ix` will `pass-note` to `%gall` so
 it `%show`s the data on the path, current and future.
@@ -239,14 +242,16 @@ would occur first, and `%made:axon` would send the gall message proper. In
 either case, eventually a `%mean` or `%nice` arrives, is encoded as json, and
 sent to the client callback.
 
-## A path not taken: magic filenames <a id="mage"/>
+<span id="mage"></span>
+## A path not taken: magic filenames
 
 The `/robots.txt` and `/favicon.(ico|png)` files are static, and served
 immediately when caught by a `++parse`.
 
 XX index.html?
 
-## A path not taken: foreign auth <a id="xeno"/>
+<span id="xeno"></span>
+## A path not taken: foreign auth
 
 While this example details a login `/~/as/own`, it is possible to be
 authenticated as any ship on the network. A request for such seen in
@@ -276,7 +281,8 @@ and sending `%g %nuke`.
 
 XX unmentioned arms: abet, add-poll, adit, ames-gram, anon, ares-to-json, bolo, cyst, doze, even, ford-kill, get-mean, gift, give-json, give-thou, gram, hapt, hasp, host-to-ship, ix, ixor, js, kiss, load, mean-json, move, note, pass-note, perk, perk-auth, pest, poke-test, print-subs, render-tang, resp, root-beak, scry, ses-authed, ses-ya, sign, silk, sine, stay, stem, teba, titl, to-oryx, urb, wait-era, wake, whir, wush, xml, ya, ye
 
-### Appendix A: DNS <a id="dns"/>
+<span id="dns"></span>
+### Appendix A: DNS
 
 The `*.urbit.org` domain can be used to access destroyers and cruisers. In the
 common case oh hosted ships, this is done by dynamic DNS directly to the hosting
@@ -344,8 +350,8 @@ When a new version of a page becomes available, it is useful to propagate it to 
 - `/~/on/[hash].json` retuns `true` when a page may require updating.
 - `/~/on/[hash].js` is a lightweight script that polls for the above. It is primarily used in error messages.
 
-;a(id "auth");
-## 1.3 Authentication
+<span id="auth"></span>
+### 1.3 Authentication
 
 Authenticated requests are accomplished through sessions, tracked with cookies which are set on the first such request.
 - `/~/as/[user]/...` is an authenticated request to `...`, where `user` can be a `@p` ship, `'own'`, `'any'`, or `'anon'`.
@@ -370,11 +376,10 @@ So far, all the paths specified have been GET requests. Authentication, however,
 - `POST {oryx, wire, xyro} /~/to/[app]/[mark].json`, where `xyro` is data that will be converted to the `mark`. In the simplest case, `/~/to/hello/json.json` will pass `xyro` through verbatim, sending `[%json xyro]` to the `++poke` arm of app `%hello`.
 - `POST {oryx, wire, xyro} /~/to/<ship>/[app]/[mark].json` is a foreign message send, as above.
 
-;a(id "subs");
+<span id="subs"></span>
 ### 1.5 Subscriptions
 
-;a(id "of-ixor");
-
+<span id="of-ixor"></span>
 - `/~/of/[ixor]` is an `EventSource`: a conceptually infinite file containing a stream of events. By default, it sends a newline every 30 seconds serving to signal that the connection is alive to both the server and IP middleware.
   + `/~/of/[ixor]?poll={n}` is a long-polling fallback interface. Produces event number `{n}`, blocking until it occurs. Its contexts can be affected by `POST` requests with a body of `{oryx, wire}`, and a query string of `PUT` or `DELETE`. They return either `{mark}`(which may be `null`), or [`{fail, mess}`](#mean-json)
 - `/~/in/[hash].json` is a dual to [`/~/on`](#on-change). It binds `mod` events, which echo the requesting token.
@@ -382,14 +387,15 @@ So far, all the paths specified have been GET requests. Authentication, however,
 
 
 
-;a(id "temp");
+<span id="temp"></span>
 ### 1.6 Ablative
 
 These interfaces will temporarily exist to aid development, and are to be considered unstable.
 - `/~/debug/...` access normally inaccessible pages. For example, `/~/debug/as.html` will present the login page, regardless of current session status.
 
 
-## 2. Client state ;a(id "client");
+<span id="client"></span>
+## 2. Client state
 
 Some information is stored on, and provided to, browser clients
 
@@ -397,7 +403,8 @@ Some information is stored on, and provided to, browser clients
 
 Authenticated users receive a cookie on the domain of `*.urbit.org`. The cookie contains a client session token, keyed by the serving ship.
 
-### 2.2 Authentication ;a(id "auth-json");
+<span id="auth-json"></span>
+### 2.2 Authentication
 
 It is common(e.g. by the `%urb` mark) to set window.urb to the contents of `/~/auth.json`:
 - `ship` is the serving ship
@@ -415,7 +422,8 @@ To this object, `/main/lib/urb.js` adds helpers:
 - `drop({path,app?=urb.app}, cb?)` pulls the subscription
 - `util` is an object containing methods for converting between JavaScript types and Hoon atom odors.
 
-## 3. Requests ;a(id "kiss");
+<span id="kiss"></span>
+## 3. Requests
 
 ## `[%born port=@ud]`, unix init
 
@@ -477,18 +485,23 @@ Sometimes, messages are received from other ships. They are expected to take the
 
 *Gifts given in response:* [`%nice` or `%mean`](#ack).
 
-#### 3.4.1 `gram` <a id="gram"/>
+<span id="gram"></span>
+#### 3.4.1 `gram`
 
-There are three messages of note, all concerning authentication <a id="foreign"/>
-- `[/lon ses]` <a id="lon"/> is a login request, which contains the session wishing to authenticate.
+<span id="foreign"></span>
+There are three messages of note, all concerning authentication
+<span id="lon"></span>
+- `[/lon ses]` is a login request, which contains the session wishing to authenticate.
 - if the session is already authorized, a reply of `[/aut ses]` from (%eyre on) a foreign ship prescribes that the session is henceforth allowed to act on its behalf. All waiting `/~/as` are resolved as successful.
 - otherwise, `[/hat ses hart]` contains the ship's preferred hostname. This can then be used to redirect the client. All waiting `/~/as` are given `307 Redirect`s to `/~/am` on the provided host.
 
 *Gifts given in response:* nice?
 
-## 4. Responses ;a(id "gift");
+<span id="gift"></span>
+## 4. Responses
 
-### 4.1 `[%nice ~]`, `[%mean ares]`, network acknowledgement ;a(id "ack");
+<span id="ack"></span>
+### 4.1 `[%nice ~]`, `[%mean ares]`, network acknowledgement
 
 A `%nice` is given upon receiving an [ames message](#gram), indicating succesful receipt. `%mean` is currently unused directly, but reserved for error conditions.
 
@@ -503,25 +516,31 @@ Most requests are served with one coherent response, consisting of
 - `q=mess`, response headers
 - `r=(unit octs)`, an optional body
 
-### 4.3 `[%that httr]`, partial HTTP response ;a(id "that");
+<span id="that"></span>
+### 4.3 `[%that httr]`, partial HTTP response
 
 [EventStream responses](#of-ixor) consist of multiple sequential chunks. Treated as `%thou`, except the request is kept open.
 
-### 4.4 `[%thar (unit octs)]`, partial HTTP body ;a(id "thar");
+<span id="thar"></span>
+### 4.4 `[%thar (unit octs)]`, partial HTTP body
 
 Complementing `%that`, `%thar` is a body chunk, containing an event. An empty `%thar` signals for the connection to be closed.
 
 Body chunks, besides `[1 '\0a']`(a heartbeat newline), are encoded from `even` events. The stem becomes the [`event` field](#eventsource), and the content, `data` lines.
 
-#### 4.4.1 `even`, event types ;a(id "even");
+<span id="even"></span>
+#### 4.4.1 `even`, event types
 
 There are three events that a [client subscription](#subs) will be given.
 
-- `[%news hash]`;a(id "even-news"); is a `%f` update, and contains the relevant dependency token.
-- `[%rush [term path] wain]` ;a(id "even-rush"); is sourced subscription data.
+<span id="even-news"></span>
+- `[%news hash]` is a `%f` update, and contains the relevant dependency token.
+<span id="even-rush"></span>
+- `[%rush [term path] wain]` is sourced subscription data.
 - `[%mean [term path] ares]` is a sourced subscription error.
 
-## 5. Vane requests ;a(id "note");
+<span id="note"></span>
+## 5. Vane requests
 
 ### 5.1 ``[%a %wont sock `[path *]`gram]``, outbound message
 
@@ -529,14 +548,16 @@ The `%a` interface provides conveyance of [messages](#gram) over UDP.
 
 Signs a `%woot` upon message arrival.
 
-### 5.2 `[%b ?(%wait %rest) time]`, timeout set/unset ;a(id "wait");
+<span id="wait"></span>
+### 5.2 `[%b ?(%wait %rest) time]`, timeout set/unset
 
 All open [subscriptions](#of-ixor) require a "heartbeat" newline every `~s30`. When this fails to arrive, a complementary timer is set for `~m1`, after which the client is considered to have departed.
 The `%b` timer interface is used to schedule the next such event, or cancel past scheduled ones when a connection closes.
 
 Signs a `%wake` upon timer activation.
 
-### 5.3 `[%f %wasp @uvI]`, dependency listen ;a(id "wasp");
+<span id="wasp"></span>
+### 5.3 `[%f %wasp @uvI]`, dependency listen
 
 Knowledge of filesystem changes, requested by `/~/on` and `/~/in`, is requested the `%wasp` note. It contains the hash token which identifies a set of dependencies to query. Saved as a (live[live](#live)#live] request in case of cancellation when caused by `/~/on`.
 
@@ -557,7 +578,8 @@ The simplest functional request is the construction of a page. Saved as a [live]
 - A `beam`(path in `%clay`) is decoded from the request path.
 - A `/web/<nyp ced quy>` virtual path is appended, span-encoding method, auth, and query string.
 
-### `[%cast mark %done ~ cage]`, convert ;a(id "done");
+<span id="done"></span>
+### `[%cast mark %done ~ cage]`, convert
 
 This is used when communicating with apps, in both directions.
 - Client messages are encoded as JSON objects, but can contain many different marks. Ones sent to non-`json.json` endpoints are `%cast` to he relevant mark, with a `cage` of `[%json p:!>(*json) jon]`, prior to being sent onwards to applications with `[%g %mess]`.
@@ -567,13 +589,15 @@ This is used when communicating with apps, in both directions.
 
 The end goal of many a userspace `hymn.hook` is to provide UI for a `%gall` app. To accommodate this, various functionality needs to be interfaced with.
 
-### `[%mess hapt ship cage]`, app message ;a(id "mess");
+<span id="mess"></span>
+### `[%mess hapt ship cage]`, app message
 
 After a `/~/to` POST has been received, and possibly converted to the correct mark, it is sent to `%g` for processing. The `hapt` is the destination, the `ship` is the source, the `cage` is the marked message data.
 
 Signs a `%nice` or `%mean`, in userspace or upon crashing.
 
-### `[%show hapt ship path]`, app subscription ;a(id "show");
+<span id="show"></span>
+### `[%show hapt ship path]`, app subscription
 
 An `/~/is` PUT, if not already registered, results in a new subscription. A request for such contains the destination `hapt`, requesting `ship`, and app-internal `path`.
 
@@ -591,15 +615,18 @@ An `/~/is` DELETE is used to remove a subscription, and is converted straightfor
 
 Signs an empty `%mean` for each open subscription that is closed.
 
-## 6. In-flight metadata ;a(id "whir");
+<span id="whir"></span>
+## 6. In-flight metadata
 
 Various state can be associated with requests, but not necessarily be returned in responses to them.
 
-### 6.1 `~`, dropthrough ;a(id "wire-drop");
+<span id="wire-drop"></span>
+### 6.1 `~`, dropthrough
 
 If the response should be sent statelessly further up the duct, the `wire` is empty. This is used in `%f` pure functional page generation.
 
-### 6.2 `[?(%y %n) ...]`, stability ;a(id "wire-live");
+<span id="wire-live"></span>
+### 6.2 `[?(%y %n) ...]`, stability
 
 The first element of a [`%b` timer](#wait) path distinguishes between live(%y) and dying(%n) channels.
 
@@ -611,15 +638,18 @@ Designates which stream to act upon. Present on `%b` timer cards.
 
 Present on `%f` dependency news. Looked up in [the state](#bolo) to see if any response is necessary.
 
-### 6.5 `/to/<hasp>/<ship>`, app ;a(id "wire-to");
+<span id="wire-to"></span>
+### 6.5 `/to/<hasp>/<ship>`, app
 
 Present on `%f` translations of message marks
 
-### 6.6 `/is/[ixor]/{hasp path}`, subscription ;a(id "wire-is");
+<span id="wire-is"></span>
+### 6.6 `/is/[ixor]/{hasp path}`, subscription
 
 Subscription requests. Present on `%g` subscription requests, and `%f` translations of [`%rush` subscription data](#show).
 
-## 7. Vane responses ;a(id "sign");
+<span id="sign"></span>
+## 7. Vane responses
 
 The goal of requests is to cause some manner of result. Specifically,
 
@@ -655,13 +685,15 @@ The former is [served](#mime) back to the requester(i.e. the remaining duct), an
 
 A `%rush` arrives on a [subscription wire](#wire-is), and is then sent [for conversion](#done) to the correct mark. An unexpected `%rush` is `%nuke`d.
 
-## 8. Server state ;a(id "bolo");
+<span id="bolo"></span>
+## 8. Server state
 
 There is a quantity of data that persists between events.
 
 ### 8.1 Global
 
-- `path` ;a(id "prefix"); the default path which is prepended to relative plain requests. Initialized to `/<our>`, the serving ship; this interprets the first element of requests as a desk, and injects a `case` of `0`.
+<span id="prefix"></span>
+- `path` the default path which is prepended to relative plain requests. Initialized to `/<our>`, the serving ship; this interprets the first element of requests as a desk, and injects a `case` of `0`.
 - `(jar ship hart)` remembered hostnames in order of preference, made accessible through `.^`
   + The default values(for self) are `http://<ship>.urbit.org:80` if not on a fake network, followed by `https://0.0.0.0:[port]`.
 - `(jug deps (each duct oryx))`, `/~/on` and `/~/in` endpoints listening to `%c` updates.
@@ -671,7 +703,8 @@ There is a quantity of data that persists between events.
 - `(map hole sink)`, session state.
 - `(map hole ,[ship ?])`, foreign session names, along with their origin ships and whether they are authorized to act on our behalf.
 
-### 8.2 `live`, per-request state ;a(id "live");
+<span id="live"></span>
+### 8.2 `live`, per-request state
 
 To honor request cancellations, each unserved request must track which effect it is causing.
 + `[%exec whir]` if it is a ford data request
@@ -679,7 +712,8 @@ To honor request cancellations, each unserved request must track which effect it
 + `[%xeno ship]` if this is a proxied request
 + `[%poll ixor]` if this is a session long-poll
 
-### 8.3 `sink`, per-session state ;a(id "sink");
+<span id="sink"></span>
+### 8.3 `sink`, per-session state
 
 Each `hole` has associated authentication state.
 - `priv`, a random secret that verifies the session, stored in cookie.
@@ -687,11 +721,13 @@ Each `hole` has associated authentication state.
 - `(jug ship ,[path duct])`, authentication `/~/as` requests waiting on foreign ships.
 - `(set oryx)`, views associated with this session. Dual of `hole` in `stem`.
 
-### 8.4 `stem`, per-view state ;a(id "stem");
+<span id="stem"></span>
+### 8.4 `stem`, per-view state
 
 Each `oryx` has active subscription state.
 - `hole`, session in which this view resides. Dual of `(set oryx)` in `sink`.
-- `ixor` ;a(id "ixor"); , a cached hash of the `oryx` that is used as a subscription id, by the `/~/of` EventStream.
+<span id="ixor"></span>
+- `ixor`, a cached hash of the `oryx` that is used as a subscription id, by the `/~/of` EventStream.
 - `[,@u (map ,@u even)]`, queued [events](#even). Has a maximum size.
 - `(unit ,[duct @u ?])`, http connection, its last received event, and whether it is a long-poll request.
 - `(set deps)`, subscribed `/~/in` points. Mirrored in `bolo`.
@@ -701,11 +737,15 @@ Each `oryx` has active subscription state.
 ## Appendix A: Glossary
 
 - An `oryx` is a CSRF token used for [authenticated requests](#auth)
-- `mean.json` ;a(id "mean-json"); is a rendering of hoon `ares`: an error message formatted as `{fail:'type',mess:"Error message"}`
-- `urb.js` ;a(id "urb-js"); is the standard client-side implementation of the `%eyre` protocols, normally found in `/=main=/lib`
-- The act of "serving" ;a(id "mime"); , refers to the wrapping of a `%mime` cage in an HTTP `200 Success` response, and errors or other marks being [sent to ford](#done) for conversion. Inside a `sign`, this conversion occurs along the same [`wire`](#wire); otherwise, the `wire` is [empty](#wire-drop).
+<span id="mean-json"></span>
+- `mean.json` is a rendering of hoon `ares`: an error message formatted as `{fail:'type',mess:"Error message"}`
+<span id="urb-js"></span>
+- `urb.js` is the standard client-side implementation of the `%eyre` protocols, normally found in `/=main=/lib`
+<span id="mime"></span>
+- The act of "serving", refers to the wrapping of a `%mime` cage in an HTTP `200 Success` response, and errors or other marks being [sent to ford](#done) for conversion. Inside a `sign`, this conversion occurs along the same [`wire`](#wire); otherwise, the `wire` is [empty](#wire-drop).
 
-## Appendix B: EventSource ;a(id "eventsource");
+<span id="eventsource"></span>
+## Appendix B: EventSource
 
 UNIMPLEMENTED
 

--- a/reference/glossary.md
+++ b/reference/glossary.md
@@ -9,15 +9,13 @@ from the strange words within.
 As Dijkstra put it: "The purpose of abstraction is not to be vague, but
 to create a new semantic level in which one can be absolutely precise."
 
-;h3
-  ;div(id "application"): application
-==
+<span id="application"></span>
+### application
 
 Also known as an “app,” an _application_ is a Hoon program that can hold state.
 
-;h3
-  ;div(id "arm"): arm
-==
+<span id="arm"></span>
+### arm
 
 An _arm_ is a named, functionally-computed attribute of a [core](#core).
 
@@ -45,9 +43,8 @@ dry.
 _See [advanced types](/docs/reference/hoon-expressions/advanced/)_.
 
 
-;h3
-  ;div(id "arvo"): Arvo
-==
+<span id="arvo"></span>
+### Arvo
 
 The Urbit operating system and kernel. Arvo's state is a pure function of its
 event log, and it serves as the Urbit event manager. It contains vanes, which are
@@ -192,9 +189,8 @@ An atom type is _warm_ or _cold_ based on whether the constant exists.
 
 _See [basic types](/docs/reference/hoon-expressions/basic)_
 
-;h3
-  ;div(id "aura"): aura
-==
+<span id="aura"></span>
+### aura
 
 An aura is a soft atom type. They appear as strings beginning with `@`. Auras
 represent the structure of an atom, print format, or other semantics. Its
@@ -297,9 +293,8 @@ least-significant bit first. Represented as the aura `@t`.
     'hello'
 ```
 
-;h3
-  ;div(id "core"): core
-==
+<span id="core"></span>
+### core
 
 A _core_ is a [cell](#nock-cell) of `[code data]`, where we call the
 code head the _battery_ and the data tail the _payload_. All code-data
@@ -366,9 +361,8 @@ _no_.
 Why? It's fresh, it's different, it's new. And it's annoying. And it
 keeps you on your toes. And it's also just intuitively right.
 
-;h3
-  ;div(id "gate"): gate
-==
+<span id="gate"></span>
+### gate
 
 A _gate_ is a [core](#core) with one [arm](#arm) -- Hoon's closest
 analog to a function. To call a gate on an argument, replace the sample
@@ -453,9 +447,8 @@ _More information on Hall can be found [here](/docs/learn/arvo/arvo-internals/ha
 _Hood_ orchestrates many of the Urbit initialization systems necessary
 for boot.
 
-;h3
-  ;div(id "hoon"): Hoon
-==
+<span id="hoon"></span>
+### Hoon
 
 Hoon is a strict, higher-order typed functional language that compiles itself
 to Nock.
@@ -464,11 +457,8 @@ The Hoon source file is located in `/home/sys/hoon.hoon` within your urbit.
 
 _More information can be found in the [hoon](/docs/learn/arvo/hoon) section._
 
-- ;div
-    ;h5
-      ;div(id "mint"): Mint
-    ==
-  ==
+<span id="mint"></span>
+- ##### Mint
 
   _Mint_ is the Hoon compiler function. Mint takes the subject type and the
   expression source (a [hoon](#a-hoon), for example) and produces the product
@@ -560,9 +550,8 @@ you desire.
 15
 ```
 
-;h3
-  ;div(id "limb"): limb
-==
+<span id="limb"></span>
+### limb
 
 A _limb_ is an attribute or variable reference. A limb is an [arm](#arm) or a
 [leg](#leg).
@@ -585,82 +574,59 @@ found, the result is the product of the arm.
 _See [Limbs and wings](/docs/hoon-expressions/limb/)_
 
 
-;h3
-  ;div(id "move"): formula
-==
+<span id="move"></span>
+### move
 
 A move is the [Arvo](#arvo) equivalent of a syscall.
 
 
-;h3
-  ;div(id "noun"): noun
-==
+<span id="noun"></span>
+### noun
 
 In [Nock](#nock) and [Hoon](#hoon), a _noun_ is an atom or a cell.
 
 
-;h3
-  ;div(id "nock"): Nock
-==
+<span id="nock"></span>
+### Nock
 
 Nock is a Turing-complete, non-lambda combinator interpreter. It's
 Urbit's low-level programming language. Nock is functional and typeless.
 
-- ;div
-    ;h5
-      ;div(id "nock-noun"): noun
-    ==
-    ;div: an _atom_ or a _cell_.
-  ==
+<span id="nock-noun"></span>
+- ##### noun
 
-- ;div
-    ;h5
-      ;div(id "nock-atom"): atom
-    ==
-    any natural number, including zero.
-  ==
+  an _atom_ or a _cell_.
 
-  - ;div
-      ;h5
-        ;div(id "nock-cell"): cell
-      ==
-      any ordered pair of nouns.
-    ==
+<span id="nock-atom"></span>
+- ##### atom
 
-  - ;div
-      ;h5
-        ;div(id "nock-cell"): cell
-      ==
-      any ordered pair of nouns.
-    ==
+  any natural number, including zero.
 
-  - ;div
-      ;h5
-        ;div(id "nock-subject"): subject
-      ==
-      a noun - the data against which a _formula_ is evaluated.
-    ==
+<span id="nock-cell"></span>
+- ##### cell
 
-  - ;div
-      ;h5
-        ;div(id "nock-formula"): formula
-      ==
-      a noun - a function at the nock level.
-    ==
+  any ordered pair of nouns.
 
-  - ;div
-      ;h5
-        ;div(id "nock-product"): product
-      ==
-      a noun - the result of evaluating a formula against a subject.
-    ==
+<span id="nock-subject"></span>
+- ##### subject
+
+  a noun - the data against which a _formula_ is evaluated.
+
+<span id="nock-formula"></span>
+- ##### formula
+
+  a noun - a function at the nock level.
+
+<span id="nock-product"></span>
+- ##### product
+
+  a noun - the result of evaluating a formula against a subject.
 
 _See the [Nock definition](/docs/learn/arvo/nock/definition)._
 
 
-;h3
-  ;div(id "mark"): mark
-==
+<span id="mark"></span>
+### mark
 
 A _mark_ is Urbit's version of a MIME type, if a MIME type was an
 executable specification. The mark is just a label that's used as a path
@@ -741,9 +707,8 @@ whose number is its bottom half. So the planet `~firbyr-napbes`,
   A ship's _pier_ is its Unix directory.  For planets, the name of the pier is
   usually the planet name.
 
-;h3
-  ;div(id "structure"): structure
-==
+<span id="structure"></span>
+### structure
 
 A _structure_ is an idempotent [gate](#gate) (function) that constructs and
 validates types in Hoon.
@@ -771,9 +736,8 @@ Here's some common structure terminology:
 
 _See [mold hoons](/docs/reference/hoon-expressions/rune/buc/)._
 
-;h3
-    ;div(id "rune"): rune
-==
+<span id="rune"></span>
+### rune
 
 A Hoon _rune_ is a pair of ASCII symbols used to begin a
 [Hoon expression](#a-hoon).
@@ -842,9 +806,8 @@ The head of `+n` is `+2n`, the tail is `+(2n+1)`.
 `+7` is a special address for gates, because the position is defined
 (by convention) as the context of a gate and of all cores.
 
-;h3
-  ;div(id "talk"): talk
-==
+<span id="talk"></span>
+### talk
 
 _Talk_ is Urbit's built-in chat app. It’s one example of an app that can be
 built on top of Hall, the Urbit back-end messaging system.

--- a/using/messaging.md
+++ b/using/messaging.md
@@ -137,9 +137,8 @@ Now you can tell your friends to `;join ~your-urbit/my-channel`.
 
 ---
 
-;h2
-  ;div(id "manual"): Manual
-==
+<span id="manual"></span>
+## Manual
 
 Hall's design is similar in spirit to
 [NNTP](https://en.wikipedia.org/wiki/Network_News_Transfer_Protocol),
@@ -319,9 +318,8 @@ For example:
 sampel-palnet:talk> ;depict %coolbox 'cool messages only. NO EXCEPTIONS.'
 ```
 
-;h6
-  ;div(id "filter"): Filter
-==
+<span id="filter"></span>
+###### Filter
 
 Syntax: `;filter %name [capitals] [unicode]`
 

--- a/using/shell.md
+++ b/using/shell.md
@@ -212,9 +212,7 @@ number of vane names.
 
 ## Manual
 
-;h3(class "first child")
-Sources and sinks
-==
+### Sources and sinks
 
 A Dojo command is either a *source* or a *sink*. A source is just something
 that can be printed to your console or the result of some computation. A


### PR DESCRIPTION
I used an empty `<span>` placed on the line above the "target" to embed an `id` to be linked to.  This is to separate the markdown from the html required for `id`s.

I replaced `<a>` tags of the form `<a id="some-id"/>` (`<a>` tags are not self-closing) with `<span>`s.

There were two places with `id="ixor"` in `learn/arvo/eyre.md` so I renamed the first one `view-ixor` but I can't tell if that's the right thing to do.

I deleted `(class "first child")` when converting `using/shell.md`.  I don't know if that's what we want.
