### PR TITLE
use %28 and %29 for parens within markdown link urls

### DIFF
--- a/concepts/technical-overview.md
+++ b/concepts/technical-overview.md
@@ -53,7 +53,7 @@ there is a risk of losing functional purity; your urbit cannot _guarantee_ that
 the side effects in question actually occur.  What's the solution?
 
 Each urbit is
-[sandboxed](https://en.wikipedia.org/wiki/Sandbox_(computer_security%29) in a
+[sandboxed](https://en.wikipedia.org/wiki/Sandbox_%28computer_security%29) in a
 virtual machine, Vere, which runs on Unix.  Code running in your urbit cannot
 make Unix system calls or otherwise directly affect the underlying platform.
 Strictly speaking, internal urbit code can only change internal urbit state; it

--- a/learn/hoon/hoon-tutorial/atoms-auras-and-simple-cell-types.md
+++ b/learn/hoon/hoon-tutorial/atoms-auras-and-simple-cell-types.md
@@ -3,7 +3,7 @@ title = "Atoms, Auras, and Simple Cell Types"
 weight = 24
 template = "doc.html"
 +++
-Like most modern high-level programming languages, Hoon has a type system.  Because Hoon is a functional programming language, its type system differs somewhat from those of non-functional languages.  In the next few lessons we'll go over Hoon's type system and point out some of its distinctive features.  Certain advanced topics (e.g. type [polymorphism](https://en.wikipedia.org/wiki/Polymorphism_(computer_science%29)) won't be addressed until a later chapter.
+Like most modern high-level programming languages, Hoon has a type system.  Because Hoon is a functional programming language, its type system differs somewhat from those of non-functional languages.  In the next few lessons we'll go over Hoon's type system and point out some of its distinctive features.  Certain advanced topics (e.g. type [polymorphism](https://en.wikipedia.org/wiki/Polymorphism_%28computer_science%29)) won't be addressed until a later chapter.
 
 A type is ordinarily understood to be a set of values.  Examples: the set of all atoms is a type, the set of all cells is a type, and so on.
 
@@ -23,7 +23,7 @@ In the most straightforward sense, atoms simply are unsigned integers.  But they
 
 The piece of type information that determines how Hoon interprets an atom is called an *aura*.  The set of all atoms is indicated with the symbol `@`.  An aura is indicated with `@` followed by some letters, e.g., `@ud` for unsigned decimal.  Accordingly, the Hoon type system does more than track sets of values.  It also tracks certain other relevant metadata about how those values are to be interpreted.
 
-How is aura information generated so that it can be tracked?  One way involves *type inference*.  In certain cases Hoon's type system can infer the type of an expression using syntactic clues.  In the most straightforward case of type inference, the expression is simply data as a [literal](https://en.wikipedia.org/wiki/Literal_(computer_programming%29).  Hoon recognizes the aura literal syntax and infers that the data in question is an atom with the aura associated with that syntax.
+How is aura information generated so that it can be tracked?  One way involves *type inference*.  In certain cases Hoon's type system can infer the type of an expression using syntactic clues.  In the most straightforward case of type inference, the expression is simply data as a [literal](https://en.wikipedia.org/wiki/Literal_%28computer_programming%29).  Hoon recognizes the aura literal syntax and infers that the data in question is an atom with the aura associated with that syntax.
 
 To see the inferred type of a literal expression in the dojo, use the `?` operator.  (Note: this operator isn't part of the Hoon programming language; it's a dojo-only tool.  It's a very useful tool for learning about types in Hoon, however.)
 

--- a/learn/hoon/hoon-tutorial/cores-again.md
+++ b/learn/hoon/hoon-tutorial/cores-again.md
@@ -275,7 +275,7 @@ For each random number generation, the `rng` core has a different seed number.  
 \/                                                                           \/
 ```
 
-`eny` is an environment value for [entropy](https://en.wikipedia.org/wiki/Entropy_(computing%29).  Its value changes every time it's evaluated.  We can use `eny` to produce a seed value for `rng` and retry the `=^` expression from above:
+`eny` is an environment value for [entropy](https://en.wikipedia.org/wiki/Entropy_%28computing%29).  Its value changes every time it's evaluated.  We can use `eny` to produce a seed value for `rng` and retry the `=^` expression from above:
 
 ```
 > =rng ~(. og eny)

--- a/learn/hoon/hoon-tutorial/gates.md
+++ b/learn/hoon/hoon-tutorial/gates.md
@@ -7,7 +7,7 @@ In this lesson you're going to learn about Hoon functions.
 
 ## What is a Function?
 
-The word 'function' is used in various ways, but let's start by talking about them in the [mathematical sense](https://en.wikipedia.org/wiki/Function_(mathematics%29).  Roughly put, a function takes one or more arguments (i.e., input values) and returns a value.  What the return value is depends solely on the argument(s), and nothing else.  For example, we can understand multiplication as a function: it takes two numbers and returns another number.  It doesn't matter where you ask, when you ask, or what kind of hat you're wearing when you ask.  If you pass the same two numbers (e.g., `3` and `4`), you get the same answer returned every time (`12`).
+The word 'function' is used in various ways, but let's start by talking about them in the [mathematical sense](https://en.wikipedia.org/wiki/Function_%28mathematics%29).  Roughly put, a function takes one or more arguments (i.e., input values) and returns a value.  What the return value is depends solely on the argument(s), and nothing else.  For example, we can understand multiplication as a function: it takes two numbers and returns another number.  It doesn't matter where you ask, when you ask, or what kind of hat you're wearing when you ask.  If you pass the same two numbers (e.g., `3` and `4`), you get the same answer returned every time (`12`).
 
 That output value depends solely upon input value(s) is an important property of functions.  This property is called [referential transparency](https://en.wikipedia.org/wiki/Referential_transparency), and we make use of it throughout the Urbit software stack.
 

--- a/learn/hoon/hoon-tutorial/hoon-syntax.md
+++ b/learn/hoon/hoon-tutorial/hoon-syntax.md
@@ -5,9 +5,9 @@ template = "doc.html"
 +++
 The study of Hoon can be divided into two parts: syntax and semantics.
 
-The [syntax](https://en.wikipedia.org/wiki/Syntax_(programming_languages%29) of a programming language is the set of rules that determine what counts as admissible code in that language.  It determines which characters may be used in the source, and also how these characters may be assembled to constitute a program.  Attempting to run a program that doesn't follow these rules will result in a syntax error.
+The [syntax](https://en.wikipedia.org/wiki/Syntax_%28programming_languages%29) of a programming language is the set of rules that determine what counts as admissible code in that language.  It determines which characters may be used in the source, and also how these characters may be assembled to constitute a program.  Attempting to run a program that doesn't follow these rules will result in a syntax error.
 
-The [semantics](https://en.wikipedia.org/wiki/Semantics_(computer_science%29) of a programming language concerns the meaning of the various parts of that language's code.
+The [semantics](https://en.wikipedia.org/wiki/Semantics_%28computer_science%29) of a programming language concerns the meaning of the various parts of that language's code.
 
 In this lesson we cover Hoon's syntax.  A strict account of Hoon's syntax would refrain from making any reference at all to semantics, but for ease of exposition we won't be quite so fastidious.
 
@@ -51,7 +51,7 @@ Note that the list includes two separate whitespace forms: `ace` for a single sp
 
 ## Expressions of Hoon
 
-An [expression](https://en.wikipedia.org/wiki/Expression_(computer_science%29) is a combination of characters that the language interprets and evaluates as producing a value.  Hoon programs are made up entirely of expressions.
+An [expression](https://en.wikipedia.org/wiki/Expression_%28computer_science%29) is a combination of characters that the language interprets and evaluates as producing a value.  Hoon programs are made up entirely of expressions.
 
 Hoon expressions can be either basic or complex.  Basic expressions of Hoon are fundamental, meaning that they can't be broken down into smaller expressions.  Complex expressions are made up of smaller expressions (which are called *subexpressions*).
 
@@ -61,7 +61,7 @@ There are many categories of Hoon expressions: noun literals, wing expressions, 
 
 A noun is either an atom or a cell.  An atom is an unsigned integer and a cell is a pair of nouns.
 
-There are [literal](https://en.wikipedia.org/wiki/Literal_(computer_programming%29) expressions for each kind of noun.  A noun literal is just a notation for representing a fixed noun value.
+There are [literal](https://en.wikipedia.org/wiki/Literal_%28computer_programming%29) expressions for each kind of noun.  A noun literal is just a notation for representing a fixed noun value.
 
 We start with atom literals.  Each of these is a basic expression of Hoon that evaluates to itself.  Examples:
 

--- a/learn/hoon/hoon-tutorial/nouns.md
+++ b/learn/hoon/hoon-tutorial/nouns.md
@@ -120,7 +120,7 @@ Atoms are nothing more than unsigned integers -- natural numbers -- but it's oft
 
 We use auras because data isn't always represented as a positive decimal number. Sometimes we want to represent data as binary, as text, or as a negative number. Auras allow us to to use such types of data _without changing the underlying atom_.
 
-We won't fully explain auras and their various uses yet.  Auras will be covered more comprehensively in a later lesson.  For now let's just look at the various kinds of [literal syntax](https://en.wikipedia.org/wiki/Literal_(computer_programming%29) associated with a few atom auras.
+We won't fully explain auras and their various uses yet.  Auras will be covered more comprehensively in a later lesson.  For now let's just look at the various kinds of [literal syntax](https://en.wikipedia.org/wiki/Literal_%28computer_programming%29) associated with a few atom auras.
 
 In computer science, a 'literal' is an expression that represents and evaluates to a fixed value.  The default syntax of an atom literal is the German-style decimal notation, as seen above.  Let's look at some other atom literal syntaxes: unsigned binary, unsigned hexadecimal, signed decimal, signed binary and hexadecimal.
 

--- a/learn/hoon/hoon-tutorial/simple-one-gate-programs.md
+++ b/learn/hoon/hoon-tutorial/simple-one-gate-programs.md
@@ -552,7 +552,7 @@ This rune is often used for modifying the value of a face whose value was set be
 
 ## Recursion
 
-How do we do loops in Hoon?  Like other functional programming languages Hoon uses [recursion](https://en.wikipedia.org/wiki/Recursion_(computer_science%29).  In rough terms, a recursive function solves a problem in part by calling on itself to solve a slightly easier or smaller case of the same problem.  The self-calling loop continues until the simplified problem is so simple that it has a trivial solution.
+How do we do loops in Hoon?  Like other functional programming languages Hoon uses [recursion](https://en.wikipedia.org/wiki/Recursion_%28computer_science%29).  In rough terms, a recursive function solves a problem in part by calling on itself to solve a slightly easier or smaller case of the same problem.  The self-calling loop continues until the simplified problem is so simple that it has a trivial solution.
 
 Seeing an example will make this process easier to understand.
 

--- a/learn/hoon/hoon-tutorial/structures-and-complex-types.md
+++ b/learn/hoon/hoon-tutorial/structures-and-complex-types.md
@@ -28,7 +28,7 @@ Structures play different roles in different code contexts.  First, let's look a
 
 The `@`, `^`, and `[? *]` subexpressions have no effect on the overall value produced.
 
-It's important to understand that these casts don't affect the [runtime](https://en.wikipedia.org/wiki/Run_time_(program_lifecycle_phase%29) semantics of a program at all.  They affect only the compiler behavior at compile-time.  The compiler does these type-checks when compiling, but the resulting code has no value corresponding to the types above.
+It's important to understand that these casts don't affect the [runtime](https://en.wikipedia.org/wiki/Run_time_%28program_lifecycle_phase%29) semantics of a program at all.  They affect only the compiler behavior at compile-time.  The compiler does these type-checks when compiling, but the resulting code has no value corresponding to the types above.
 
 Accordingly, the structures produced by the type subexpressions above aren't part of the program's runtime semantics.  They are compile-time values only.
 
@@ -265,7 +265,7 @@ nest-fail
 
 ### `$?` Define a Union
 
-In set theory, the [union](https://en.wikipedia.org/wiki/Union_(set_theory%29) of sets A and B is a set containing all members of both A and B.  For example, the union of the set of even integers and the set of odd integers is the set of all integers.
+In set theory, the [union](https://en.wikipedia.org/wiki/Union_%28set_theory%29) of sets A and B is a set containing all members of both A and B.  For example, the union of the set of even integers and the set of odd integers is the set of all integers.
 
 It's useful to be able to define a type that is the union of other types.  The `$?` rune lets us do this.  The `$?` takes a series of subexpressions, each of which must be a structure.  The resulting type is the union of all types indicated in the expression.  For example, `$?(%green %yellow %red)` is the union of the types indicated by `%green`, `%yellow`, and `%red`.
 

--- a/learn/hoon/hoon-tutorial/the-subject-and-its-legs.md
+++ b/learn/hoon/hoon-tutorial/the-subject-and-its-legs.md
@@ -477,7 +477,7 @@ In fact, you may already know how to find the answer.  The subject is a noun and
 
 This noun (or a modified version of it) is the subject used for Hoon expressions entered into the dojo.
 
-We can't explain every part of the subject just yet, but you should be able to recognize some of it.  There is a face, `our`, serving as a label for the urbit's name.  Another face, `now`, is a label for an absolute date.  `eny` is a face for an atom serving as [entropy](https://en.wikipedia.org/wiki/Entropy_(computing%29).  The value for `eny` is different every time it's checked.
+We can't explain every part of the subject just yet, but you should be able to recognize some of it.  There is a face, `our`, serving as a label for the urbit's name.  Another face, `now`, is a label for an absolute date.  `eny` is a face for an atom serving as [entropy](https://en.wikipedia.org/wiki/Entropy_%28computing%29).  The value for `eny` is different every time it's checked.
 
 ```
 > our

--- a/learn/hoon/hoon-tutorial/type-checking-and-type-inference.md
+++ b/learn/hoon/hoon-tutorial/type-checking-and-type-inference.md
@@ -139,7 +139,7 @@ It's helpful to know *that* Hoon infers the type of any given expression, but it
 
 ### Literals
 
-[Literals](https://en.wikipedia.org/wiki/Literal_(computer_programming%29) are expressions that represent fixed values.  Some examples (with the inferred type on the right):
+[Literals](https://en.wikipedia.org/wiki/Literal_%28computer_programming%29) are expressions that represent fixed values.  Some examples (with the inferred type on the right):
 
 ```
 123                   @ud

--- a/learn/hoon/hoon-tutorial/type-polymorphism.md
+++ b/learn/hoon/hoon-tutorial/type-polymorphism.md
@@ -3,7 +3,7 @@ title = "Type Polymorphism"
 weight = 31
 template = "doc.html"
 +++
-There are many cases in which one may want to write a function that accepts as input various different types of data.  Such a function is said to be [polymorphic](https://en.wikipedia.org/wiki/Polymorphism_(computer_science%29).  ("Polymorphism" = "many forms"; so polymorphic functions accept many forms of data as input.)
+There are many cases in which one may want to write a function that accepts as input various different types of data.  Such a function is said to be [polymorphic](https://en.wikipedia.org/wiki/Polymorphism_%28computer_science%29).  ("Polymorphism" = "many forms"; so polymorphic functions accept many forms of data as input.)
 
 One relatively trivial form of polymorphism involves sub-typing.  A gate whose sample is a raw `noun` can accept any Hoon data structure as input -- it's just that the sample will only be treated as a raw noun.  For example, consider the `copy` gate below:
 
@@ -28,7 +28,7 @@ In this lesson we'll go over Hoon's support for more interesting polymorphic fun
 
 Hoon supports type polymorphism at the core level.  That is, each core has certain polymorphic properties that are tracked and maintained as metadata by Hoon's type system.  (See `+$  type` of `hoon.hoon`.)  These properties determine the extent to which a core can be used as an interface for values of various types.
 
-This is rather vaguely put so far.  We can clarify by talking more specifically about the kinds of polymorphism supported in Hoon.  There are two kinds of type polymorphism for cores: [genericity](https://en.wikipedia.org/wiki/Generic_programming), to include certain kinds of of [parametric polymorphism](https://en.wikipedia.org/wiki/Parametric_polymorphism); and [variance polymorphism](https://en.wikipedia.org/wiki/Covariance_and_contravariance_(computer_science%29), which involves making use of special sub-typing rules for cores.
+This is rather vaguely put so far.  We can clarify by talking more specifically about the kinds of polymorphism supported in Hoon.  There are two kinds of type polymorphism for cores: [genericity](https://en.wikipedia.org/wiki/Generic_programming), to include certain kinds of [parametric polymorphism](https://en.wikipedia.org/wiki/Parametric_polymorphism); and [variance polymorphism](https://en.wikipedia.org/wiki/Covariance_and_contravariance_%28computer_science%29), which involves making use of special sub-typing rules for cores.
 
 If you don't understand these very well, that's okay.  We'll explain them.  Let's begin with the former.
 
@@ -203,7 +203,7 @@ For example, we have `list`s, `tree`s, and `set`s in Hoon, which are each define
   $@(~ [i=item t=(list item)])
 ```
 
-The `+*` rune is especially useful for defining [containers](https://en.wikipedia.org/wiki/Container_(abstract_data_type%29) of various kinds.  Indeed, `list`s, `tree`s, and `set`s are all examples of containers.  You can have a `(list @)`, a `(list ^)`, a `(list *)`, and so on.  Or a `(tree @)`, a `(tree ^)`, a `(tree *)`, etc.  And the same for `set`.
+The `+*` rune is especially useful for defining [containers](https://en.wikipedia.org/wiki/Container_%28abstract_data_type%29) of various kinds.  Indeed, `list`s, `tree`s, and `set`s are all examples of containers.  You can have a `(list @)`, a `(list ^)`, a `(list *)`, and so on.  Or a `(tree @)`, a `(tree ^)`, a `(tree *)`, etc.  And the same for `set`.
 
 One nice thing about containers defined by `+*` is that they nest in the expected way.  Intuitively a `(list @)` should nest under `(list *)`, because `@` nests under `*`.  And so it does:
 


### PR DESCRIPTION
fixes https://github.com/urbit/docs/issues/481