### PR TITLE
Remove list headers, delete some spurious span tags

### DIFF
--- a/learn/arvo/eyre.md
+++ b/learn/arvo/eyre.md
@@ -47,7 +47,6 @@ Runtime
 Let us follow the loading of a simple cli app, as it bounces from
 browser to server to browser and back.
 
-<span id="init"></span>
 ### Initial request
 
 An http request for `http://sampel-sipnym.urbit.org/cli` will be [redirected](dns)
@@ -183,7 +182,6 @@ to a `[%auth %try {password}]` perk. `%get:process-auth` checks it against
 serves a fresh `auth.json` which reflects the changed `user`. Upon receiving
 this, the page is refreshed to retry the original request.
 
-<span id="auth-ok"></span>
 ### Post-authentication: app communication.
 
 Upon refresh, `/~~/cli` brings us for the third time to `%get:process-auth`, but
@@ -207,7 +205,6 @@ of `oryx` that identifies the connection. `++as-aux-request`, an `%is` is a
 `++add-subs:ix`, the ix core fetched `++for-view` by hashing the request
 `++oryx-to-ixor`.
 
-<span id="view-ixor"></span>
 A view has all the state associated with a client that must be
 remembered between events. In this case, this is what app/path the request duct
 is associated with; but mainly, `++add-subs:ix` will `pass-note` to `%gall` so
@@ -242,7 +239,6 @@ would occur first, and `%made:axon` would send the gall message proper. In
 either case, eventually a `%mean` or `%nice` arrives, is encoded as json, and
 sent to the client callback.
 
-<span id="mage"></span>
 ## A path not taken: magic filenames
 
 The `/robots.txt` and `/favicon.(ico|png)` files are static, and served
@@ -250,7 +246,6 @@ immediately when caught by a `++parse`.
 
 XX index.html?
 
-<span id="xeno"></span>
 ## A path not taken: foreign auth
 
 While this example details a login `/~/as/own`, it is possible to be
@@ -281,7 +276,6 @@ and sending `%g %nuke`.
 
 XX unmentioned arms: abet, add-poll, adit, ames-gram, anon, ares-to-json, bolo, cyst, doze, even, ford-kill, get-mean, gift, give-json, give-thou, gram, hapt, hasp, host-to-ship, ix, ixor, js, kiss, load, mean-json, move, note, pass-note, perk, perk-auth, pest, poke-test, print-subs, render-tang, resp, root-beak, scry, ses-authed, ses-ya, sign, silk, sine, stay, stem, teba, titl, to-oryx, urb, wait-era, wake, whir, wush, xml, ya, ye
 
-<span id="dns"></span>
 ### Appendix A: DNS
 
 The `*.urbit.org` domain can be used to access destroyers and cruisers. In the
@@ -350,7 +344,6 @@ When a new version of a page becomes available, it is useful to propagate it to 
 - `/~/on/[hash].json` retuns `true` when a page may require updating.
 - `/~/on/[hash].js` is a lightweight script that polls for the above. It is primarily used in error messages.
 
-<span id="auth"></span>
 ### 1.3 Authentication
 
 Authenticated requests are accomplished through sessions, tracked with cookies which are set on the first such request.
@@ -376,10 +369,8 @@ So far, all the paths specified have been GET requests. Authentication, however,
 - `POST {oryx, wire, xyro} /~/to/[app]/[mark].json`, where `xyro` is data that will be converted to the `mark`. In the simplest case, `/~/to/hello/json.json` will pass `xyro` through verbatim, sending `[%json xyro]` to the `++poke` arm of app `%hello`.
 - `POST {oryx, wire, xyro} /~/to/<ship>/[app]/[mark].json` is a foreign message send, as above.
 
-<span id="subs"></span>
 ### 1.5 Subscriptions
 
-<span id="of-ixor"></span>
 - `/~/of/[ixor]` is an `EventSource`: a conceptually infinite file containing a stream of events. By default, it sends a newline every 30 seconds serving to signal that the connection is alive to both the server and IP middleware.
   + `/~/of/[ixor]?poll={n}` is a long-polling fallback interface. Produces event number `{n}`, blocking until it occurs. Its contexts can be affected by `POST` requests with a body of `{oryx, wire}`, and a query string of `PUT` or `DELETE`. They return either `{mark}`(which may be `null`), or [`{fail, mess}`](#mean-json)
 - `/~/in/[hash].json` is a dual to [`/~/on`](#on-change). It binds `mod` events, which echo the requesting token.
@@ -387,14 +378,12 @@ So far, all the paths specified have been GET requests. Authentication, however,
 
 
 
-<span id="temp"></span>
 ### 1.6 Ablative
 
 These interfaces will temporarily exist to aid development, and are to be considered unstable.
 - `/~/debug/...` access normally inaccessible pages. For example, `/~/debug/as.html` will present the login page, regardless of current session status.
 
 
-<span id="client"></span>
 ## 2. Client state
 
 Some information is stored on, and provided to, browser clients
@@ -403,7 +392,6 @@ Some information is stored on, and provided to, browser clients
 
 Authenticated users receive a cookie on the domain of `*.urbit.org`. The cookie contains a client session token, keyed by the serving ship.
 
-<span id="auth-json"></span>
 ### 2.2 Authentication
 
 It is common(e.g. by the `%urb` mark) to set window.urb to the contents of `/~/auth.json`:
@@ -422,7 +410,6 @@ To this object, `/main/lib/urb.js` adds helpers:
 - `drop({path,app?=urb.app}, cb?)` pulls the subscription
 - `util` is an object containing methods for converting between JavaScript types and Hoon atom odors.
 
-<span id="kiss"></span>
 ## 3. Requests
 
 ## `[%born port=@ud]`, unix init
@@ -485,22 +472,17 @@ Sometimes, messages are received from other ships. They are expected to take the
 
 **Gifts given in response:** [`%nice` or `%mean`](#ack).
 
-<span id="gram"></span>
 #### 3.4.1 `gram`
 
-<span id="foreign"></span>
 There are three messages of note, all concerning authentication
-<span id="lon"></span>
 - `[/lon ses]` is a login request, which contains the session wishing to authenticate.
 - if the session is already authorized, a reply of `[/aut ses]` from (%eyre on) a foreign ship prescribes that the session is henceforth allowed to act on its behalf. All waiting `/~/as` are resolved as successful.
 - otherwise, `[/hat ses hart]` contains the ship's preferred hostname. This can then be used to redirect the client. All waiting `/~/as` are given `307 Redirect`s to `/~/am` on the provided host.
 
 **Gifts given in response:** nice?
 
-<span id="gift"></span>
 ## 4. Responses
 
-<span id="ack"></span>
 ### 4.1 `[%nice ~]`, `[%mean ares]`, network acknowledgement
 
 A `%nice` is given upon receiving an [ames message](#gram), indicating succesful receipt. `%mean` is currently unused directly, but reserved for error conditions.
@@ -516,30 +498,23 @@ Most requests are served with one coherent response, consisting of
 - `q=mess`, response headers
 - `r=(unit octs)`, an optional body
 
-<span id="that"></span>
 ### 4.3 `[%that httr]`, partial HTTP response
 
 [EventStream responses](#of-ixor) consist of multiple sequential chunks. Treated as `%thou`, except the request is kept open.
 
-<span id="thar"></span>
 ### 4.4 `[%thar (unit octs)]`, partial HTTP body
 
 Complementing `%that`, `%thar` is a body chunk, containing an event. An empty `%thar` signals for the connection to be closed.
 
 Body chunks, besides `[1 '\0a']`(a heartbeat newline), are encoded from `even` events. The stem becomes the [`event` field](#eventsource), and the content, `data` lines.
 
-<span id="even"></span>
 #### 4.4.1 `even`, event types
 
 There are three events that a [client subscription](#subs) will be given.
 
-<span id="even-news"></span>
 - `[%news hash]` is a `%f` update, and contains the relevant dependency token.
-<span id="even-rush"></span>
-- `[%rush [term path] wain]` is sourced subscription data.
 - `[%mean [term path] ares]` is a sourced subscription error.
 
-<span id="note"></span>
 ## 5. Vane requests
 
 ### 5.1 ``[%a %wont sock `[path *]`gram]``, outbound message
@@ -548,15 +523,12 @@ The `%a` interface provides conveyance of [messages](#gram) over UDP.
 
 Signs a `%woot` upon message arrival.
 
-<span id="wait"></span>
-### 5.2 `[%b ?(%wait %rest) time]`, timeout set/unset
 
 All open [subscriptions](#of-ixor) require a "heartbeat" newline every `~s30`. When this fails to arrive, a complementary timer is set for `~m1`, after which the client is considered to have departed.
 The `%b` timer interface is used to schedule the next such event, or cancel past scheduled ones when a connection closes.
 
 Signs a `%wake` upon timer activation.
 
-<span id="wasp"></span>
 ### 5.3 `[%f %wasp @uvI]`, dependency listen
 
 Knowledge of filesystem changes, requested by `/~/on` and `/~/in`, is requested the `%wasp` note. It contains the hash token which identifies a set of dependencies to query. Saved as a (live[live](#live)#live] request in case of cancellation when caused by `/~/on`.
@@ -578,7 +550,6 @@ The simplest functional request is the construction of a page. Saved as a [live]
 - A `beam`(path in `%clay`) is decoded from the request path.
 - A `/web/<nyp ced quy>` virtual path is appended, span-encoding method, auth, and query string.
 
-<span id="done"></span>
 ### `[%cast mark %done ~ cage]`, convert
 
 This is used when communicating with apps, in both directions.
@@ -589,14 +560,12 @@ This is used when communicating with apps, in both directions.
 
 The end goal of many a userspace `hymn.hook` is to provide UI for a `%gall` app. To accommodate this, various functionality needs to be interfaced with.
 
-<span id="mess"></span>
 ### `[%mess hapt ship cage]`, app message
 
 After a `/~/to` POST has been received, and possibly converted to the correct mark, it is sent to `%g` for processing. The `hapt` is the destination, the `ship` is the source, the `cage` is the marked message data.
 
 Signs a `%nice` or `%mean`, in userspace or upon crashing.
 
-<span id="show"></span>
 ### `[%show hapt ship path]`, app subscription
 
 An `/~/is` PUT, if not already registered, results in a new subscription. A request for such contains the destination `hapt`, requesting `ship`, and app-internal `path`.
@@ -615,17 +584,14 @@ An `/~/is` DELETE is used to remove a subscription, and is converted straightfor
 
 Signs an empty `%mean` for each open subscription that is closed.
 
-<span id="whir"></span>
 ## 6. In-flight metadata
 
 Various state can be associated with requests, but not necessarily be returned in responses to them.
 
-<span id="wire-drop"></span>
 ### 6.1 `~`, dropthrough
 
 If the response should be sent statelessly further up the duct, the `wire` is empty. This is used in `%f` pure functional page generation.
 
-<span id="wire-live"></span>
 ### 6.2 `[?(%y %n) ...]`, stability
 
 The first element of a [`%b` timer](#wait) path distinguishes between live(%y) and dying(%n) channels.
@@ -638,17 +604,14 @@ Designates which stream to act upon. Present on `%b` timer cards.
 
 Present on `%f` dependency news. Looked up in [the state](#bolo) to see if any response is necessary.
 
-<span id="wire-to"></span>
 ### 6.5 `/to/<hasp>/<ship>`, app
 
 Present on `%f` translations of message marks
 
-<span id="wire-is"></span>
 ### 6.6 `/is/[ixor]/{hasp path}`, subscription
 
 Subscription requests. Present on `%g` subscription requests, and `%f` translations of [`%rush` subscription data](#show).
 
-<span id="sign"></span>
 ## 7. Vane responses
 
 The goal of requests is to cause some manner of result. Specifically,
@@ -685,14 +648,12 @@ The former is [served](#mime) back to the requester(i.e. the remaining duct), an
 
 A `%rush` arrives on a [subscription wire](#wire-is), and is then sent [for conversion](#done) to the correct mark. An unexpected `%rush` is `%nuke`d.
 
-<span id="bolo"></span>
 ## 8. Server state
 
 There is a quantity of data that persists between events.
 
 ### 8.1 Global
 
-<span id="prefix"></span>
 - `path` the default path which is prepended to relative plain requests. Initialized to `/<our>`, the serving ship; this interprets the first element of requests as a desk, and injects a `case` of `0`.
 - `(jar ship hart)` remembered hostnames in order of preference, made accessible through `.^`
   + The default values(for self) are `http://<ship>.urbit.org:80` if not on a fake network, followed by `https://0.0.0.0:[port]`.
@@ -703,7 +664,6 @@ There is a quantity of data that persists between events.
 - `(map hole sink)`, session state.
 - `(map hole ,[ship ?])`, foreign session names, along with their origin ships and whether they are authorized to act on our behalf.
 
-<span id="live"></span>
 ### 8.2 `live`, per-request state
 
 To honor request cancellations, each unserved request must track which effect it is causing.
@@ -712,7 +672,6 @@ To honor request cancellations, each unserved request must track which effect it
 + `[%xeno ship]` if this is a proxied request
 + `[%poll ixor]` if this is a session long-poll
 
-<span id="sink"></span>
 ### 8.3 `sink`, per-session state
 
 Each `hole` has associated authentication state.
@@ -721,12 +680,10 @@ Each `hole` has associated authentication state.
 - `(jug ship ,[path duct])`, authentication `/~/as` requests waiting on foreign ships.
 - `(set oryx)`, views associated with this session. Dual of `hole` in `stem`.
 
-<span id="stem"></span>
 ### 8.4 `stem`, per-view state
 
 Each `oryx` has active subscription state.
 - `hole`, session in which this view resides. Dual of `(set oryx)` in `sink`.
-<span id="ixor"></span>
 - `ixor`, a cached hash of the `oryx` that is used as a subscription id, by the `/~/of` EventStream.
 - `[,@u (map ,@u even)]`, queued [events](#even). Has a maximum size.
 - `(unit ,[duct @u ?])`, http connection, its last received event, and whether it is a long-poll request.
@@ -737,14 +694,10 @@ Each `oryx` has active subscription state.
 ## Appendix A: Glossary
 
 - An `oryx` is a CSRF token used for [authenticated requests](#auth)
-<span id="mean-json"></span>
 - `mean.json` is a rendering of hoon `ares`: an error message formatted as `{fail:'type',mess:"Error message"}`
-<span id="urb-js"></span>
 - `urb.js` is the standard client-side implementation of the `%eyre` protocols, normally found in `/=main=/lib`
-<span id="mime"></span>
 - The act of "serving", refers to the wrapping of a `%mime` cage in an HTTP `200 Success` response, and errors or other marks being [sent to ford](#done) for conversion. Inside a `sign`, this conversion occurs along the same [`wire`](#wire); otherwise, the `wire` is [empty](#wire-drop).
 
-<span id="eventsource"></span>
 ## Appendix B: EventSource
 
 UNIMPLEMENTED

--- a/learn/arvo/hall.md
+++ b/learn/arvo/hall.md
@@ -11,11 +11,11 @@ Hall is the Urbit messaging and notifications protocol. This document details Ha
 
 ## Table of contents
 
-- #### [Hall Architecture](#architecture)
+- [Hall Architecture](#architecture)
 
-- #### [The Hall Interface](#interface)
+- [The Hall Interface](#interface)
 
-- #### [The New Gall Model](#new-gall)
+- [The New Gall Model](#new-gall)
 
 # Hall Architecture
 

--- a/learn/nock/implementations.md
+++ b/learn/nock/implementations.md
@@ -7,31 +7,31 @@ We use a C implementation for our Nock interpreter. But building a Nock interpre
 
 ## Table of Contents
 
-- #### [C](#C)
+- [C](#C)
 
-- #### [Clojure](#clojure)
+- [Clojure](#clojure)
 
-- #### [C#](#c-sharp)
+- [C#](#c-sharp)
 
-- #### [Groovy](#groovy)
+- [Groovy](#groovy)
 
-- #### [Haskell](#haskell)
+- [Haskell](#haskell)
 
-- #### [JavaScript](#javascript)
+- [JavaScript](#javascript)
 
-- #### [Python](#python)
+- [Python](#python)
 
-- #### [Ruby](#ruby)
+- [Ruby](#ruby)
 
-- #### [Scala](#scala)
+- [Scala](#scala)
 
-- #### [Scheme](#scheme)
+- [Scheme](#scheme)
 
-- #### [Swift](#swift)
+- [Swift](#swift)
 
 ## C Implementation
 
-The actual production Nock interpreter.  Note gotos for tail-call elimination,
+The actual production Nock interpreter. Note gotos for tail-call elimination,
 and manual reference counting.  More about the C environment can be found
 in the [runtime system documentation](./docs/learn/vere/runtime.md).
 ```
@@ -398,7 +398,6 @@ From [Matt Earnshaw](https://github.com/mattearnshaw/anock/blob/master/src/anock
 ```
 
 ## C#
-
 
 From [Julien Beasley](https://github.com/zass30/Nock5KCSharp):
 

--- a/reference/glossary.md
+++ b/reference/glossary.md
@@ -9,12 +9,10 @@ from the strange words within.
 As Dijkstra put it: "The purpose of abstraction is not to be vague, but
 to create a new semantic level in which one can be absolutely precise."
 
-<span id="application"></span>
 ### application
 
 Also known as an “app,” an _application_ is a Hoon program that can hold state.
 
-<span id="arm"></span>
 ### arm
 
 An _arm_ is a named, functionally-computed attribute of a [core](#core).
@@ -25,14 +23,14 @@ enclosing [core](#core) itself as the subject.
 There are two kinds of arms: _dry_ and _wet_. Most arms are
 dry.
 
-- ##### dry:
+##### dry
 
   normal, `++`, polymorphic by means of _variance_
 
   For a dry arm, we ask: is the new payload compatible with the old
   payload (against which the core was compiled)?
 
-- ##### wet:
+##### wet
 
   unusual, `+-`, polymorphic by means of _genericity_
 
@@ -43,7 +41,7 @@ dry.
 _See [advanced types](/docs/reference/hoon-expressions/advanced/)_.
 
 
-<span id="arvo"></span>
+
 ### Arvo
 
 The Urbit operating system and kernel. Arvo's state is a pure function of its
@@ -69,7 +67,7 @@ More in-depth information on Arvo can be found
 
 Below are Arvo modules, which are called "vanes".
 
-- ##### Ames
+##### Ames
 
   The networking vane. Ames handles all things UDP. Here live the protocols for
   discovering and interacting with other urbits. It’s also the name for the Urbit
@@ -80,7 +78,7 @@ Below are Arvo modules, which are called "vanes".
   More in-depth information on Ames can be found
   [`here`](.t/docs/learn/arvo/ames.md).
 
-- ##### Behn
+##### Behn
 
   The timing vane. Behn allows for applications to schedule events, which are
   managed in a simple priority queue. For example, Clay, the Urbit filesystem,
@@ -89,7 +87,7 @@ Below are Arvo modules, which are called "vanes".
 
   Behn is located in `/home/sys/vane/behn.hoon` within your urbit.
 
-- ##### Clay
+##### Clay
 
   The filesystem and typed revision-control vane. Think of Clay as a
   continuously synced git. It handles file-change events and maps them from Urbit
@@ -106,7 +104,7 @@ Below are Arvo modules, which are called "vanes".
   of the architecture can be found
   [`here`](./docs/learn/arvo/clay.md).
 
-- ##### Dill
+##### Dill
 
   The terminal-driver vane. You run your urbit in your Unix terminal, and
   Unix sends every event -- such as a keystroke or a change in the dimensions of
@@ -125,7 +123,7 @@ Below are Arvo modules, which are called "vanes".
   More in-depth information on Dill can be found
   [`here`](./docs/learn/arvo/dill.md).
 
-- ##### Eyre
+##### Eyre
 
   The web-server vane. Anything HTTP-related lives here. Unix sends HTTP messages
   though to Eyre, and Eyre produces HTTP messages in response.
@@ -139,7 +137,7 @@ Below are Arvo modules, which are called "vanes".
   More in-depth information on Eyre can be found
   [`here`](./docs/learn/arvo/eyre.md).
 
-- ##### Ford
+##### Ford
 
   The build-system vane. Ford is capable of sequencing generic asynchronous
   computations. Its uses include linking source files into programs, assembling
@@ -154,7 +152,7 @@ Below are Arvo modules, which are called "vanes".
   More in-depth information on Ford can be found
   [`here`](content/docs/learn/arvo/ford.md).
 
-- ##### Gall
+##### Gall
 
   The application-management vane. Userspace apps -- daemons, really -- are
   started, stopped, and sandboxed by Gall. Gall provides developers with a
@@ -179,17 +177,16 @@ optional constant.
 
 An atom type is _warm_ or _cold_ based on whether the constant exists.
 
-- ##### warm:
+##### warm
 
   If the constant is `~` (null), any atom is in the type.
 
-- ##### cold:
+##### cold
 
   If the constant is `[~ atom]`, its only legal value is `atom`.
 
 _See [basic types](./docs/reference/hoon-expressions/basic.md)_
 
-<span id="aura"></span>
 ### aura
 
 An aura is a soft atom type. They appear as strings beginning with `@`. Auras
@@ -293,7 +290,6 @@ least-significant bit first. Represented as the aura `@t`.
     'hello'
 ```
 
-<span id="core"></span>
 ### core
 
 A _core_ is a [cell](#nock-cell) of `[code data]`, where we call the
@@ -301,11 +297,11 @@ code head the _battery_ and the data tail the _payload_. All code-data
 structures in normal languages (functions, objects, modules, etc.)
 translate to cores in Hoon.
 
-- ##### battery
+##### battery
 
   The code-containing head of a core.
 
-- ##### payload
+##### payload
 
   The data-containing tail of a core.
 
@@ -361,7 +357,6 @@ _no_.
 Why? It's fresh, it's different, it's new. And it's annoying. And it
 keeps you on your toes. And it's also just intuitively right.
 
-<span id="gate"></span>
 ### gate
 
 A _gate_ is a [core](#core) with one [arm](#arm) -- Hoon's closest
@@ -371,11 +366,11 @@ in the core) with the argument, and then compute the arm.
 
 The payload of a gate has a shape of `[sample context]`.
 
-- ##### sample
+##### sample
 
   The argument tuple.
 
-- ##### context
+##### context
 
   The subject in which the gate was defined.
 
@@ -433,7 +428,7 @@ such app that uses Hall.
 
 _More information on Hall can be found [here](./docs/learn/arvo/hall.md)._
 
-- ##### circle
+##### circle
 
   A circle is the “audience” of your messages -- who can receive them. It can be
   thought of as a chat channel, but this is a little too narrow. More
@@ -447,7 +442,6 @@ _More information on Hall can be found [here](./docs/learn/arvo/hall.md)._
 _Hood_ orchestrates many of the Urbit initialization systems necessary
 for boot.
 
-<span id="hoon"></span>
 ### Hoon
 
 Hoon is a strict, higher-order typed functional language that compiles itself
@@ -457,8 +451,7 @@ The Hoon source file is located in `/home/sys/hoon.hoon` within your urbit.
 
 _More information can be found in the [hoon](./docs/learn/hoon/_index.md) section._
 
-<span id="mint"></span>
-- ##### Mint
+##### Mint
 
   _Mint_ is the Hoon compiler function. Mint takes the subject type and the
   expression source (a [hoon](#a-hoon), for example) and produces the product
@@ -550,7 +543,6 @@ you desire.
 15
 ```
 
-<span id="limb"></span>
 ### limb
 
 A _limb_ is an attribute or variable reference. A limb is an [arm](#arm) or a
@@ -561,71 +553,58 @@ head-first for either a face named "foo" or a core with an arm of
 "foo". If a face is found, the result is a leg, if a core is
 found, the result is the product of the arm.
 
-- ##### leg
+##### leg
 
   a subexpression, or subtree of the
   [subject](#nock-subject).
 
-- ##### wing
+##### wing
 
   a search path into the subject, composed of
   limbs. Search occurs from right to left (`a.b` means `b` within `a`).
 
 _See [Limbs and wings](./docs/reference/hoon-expressions/limb/_index.md)_
 
-
-<span id="move"></span>
 ### move
 
 A move is the [Arvo](#arvo) equivalent of a syscall.
 
-
-<span id="noun"></span>
 ### noun
 
 In [Nock](#nock) and [Hoon](#hoon), a _noun_ is an atom or a cell.
 
-
-<span id="nock"></span>
 ### Nock
 
 Nock is a Turing-complete, non-lambda combinator interpreter. It's
 Urbit's low-level programming language. Nock is functional and typeless.
 
-<span id="nock-noun"></span>
-- ##### noun
+##### noun
 
   an _atom_ or a _cell_.
 
-<span id="nock-atom"></span>
-- ##### atom
+##### atom
 
   any natural number, including zero.
 
-<span id="nock-cell"></span>
-- ##### cell
+##### cell
 
   any ordered pair of nouns.
 
-<span id="nock-subject"></span>
-- ##### subject
+
+##### subject
 
   a noun - the data against which a _formula_ is evaluated.
 
-<span id="nock-formula"></span>
-- ##### formula
+##### formula
 
   a noun - a function at the nock level.
 
-<span id="nock-product"></span>
-- ##### product
+##### product
 
   a noun - the result of evaluating a formula against a subject.
 
 _See the [Nock definition](./docs/learn/nock/definition.md)._
 
-
-<span id="mark"></span>
 ### mark
 
 A _mark_ is Urbit's version of a MIME type, if a MIME type was an
@@ -701,13 +680,11 @@ whose number is its bottom half. So the planet `~firbyr-napbes`,
 `48.879`, whose parent is `~mun`, `0xef`, `239`. The galaxy at the address of
 `0` is `~zod`.
 
-
-- ##### pier
+##### pier
 
   A ship's _pier_ is its Unix directory.  For planets, the name of the pier is
   usually the planet name.
 
-<span id="structure"></span>
 ### structure
 
 A _structure_ is an idempotent [gate](#gate) (function) that constructs and
@@ -718,7 +695,7 @@ validate untrusted network data.
 
 Here's some common structure terminology:
 
-- ##### bunt:
+##### bunt
 
   A bunt is the default value of a [structure](#structure). It's also a verb;
   to _bunt_ a structure is to produce the bunt of that structure. For example,
@@ -732,11 +709,10 @@ Here's some common structure terminology:
       ''
   ```
 
-- ##### icon: The type of the mold's range.
+##### icon: The type of the mold's range
 
 _See [mold hoons](/docs/reference/hoon-expressions/rune/buc/)._
 
-<span id="rune"></span>
 ### rune
 
 A Hoon _rune_ is a pair of ASCII symbols used to begin a
@@ -753,7 +729,7 @@ a [`hoon`](#a-hoon).
 
 Runes have two syntactic forms, _tall_ and _flat_:
 
-- ##### tall:
+##### tall
 
   multiple lines, no parentheses, two or more spaces between tokens
 
@@ -764,7 +740,7 @@ Runes have two syntactic forms, _tall_ and _flat_:
   4
   ```
 
-- ##### flat:
+##### flat
 
   one line, parentheses, one space between tokens
 
@@ -806,7 +782,6 @@ The head of `+n` is `+2n`, the tail is `+(2n+1)`.
 `+7` is a special address for gates, because the position is defined
 (by convention) as the context of a gate and of all cores.
 
-<span id="talk"></span>
 ### talk
 
 _Talk_ is Urbit's built-in chat app. It’s one example of an app that can be
@@ -826,7 +801,7 @@ All types are assembled out of base types defined in `++type`.
 does type-inference on a program, it assembles complex types out
 of the simpler built-in types.
 
-- ##### nest
+##### nest
 
   `nest` is an internal Hoon function on two types which performs a type
   compatibility test. `nest` produces yes if the
@@ -834,8 +809,7 @@ of the simpler built-in types.
   If `nest` produces no, the Hoon programmer will receive a `nest-fail`
   error. This is one of the most commons errors in Hoon programming.
 
-  _See [advanced types](./docs/reference/hoon-expressions/advanced.md)_.
-  _See [troubleshooting](./docs/reference/troubleshooting.md)_.
+  _See [advanced types](./docs/reference/hoon-expressions/advanced.md)_ and [troubleshooting](./docs/reference/troubleshooting.md).
 
 
 ### Unit

--- a/using/messaging.md
+++ b/using/messaging.md
@@ -125,7 +125,6 @@ Now you can tell your friends to `;join ~your-urbit/my-channel`.
 
 ---
 
-<span id="manual"></span>
 ## Manual
 
 Hall's design is similar in spirit to
@@ -306,7 +305,7 @@ For example:
 sampel-palnet:talk> ;depict %coolbox 'cool messages only. NO EXCEPTIONS.'
 ```
 
-<span id="filter"></span>
+
 #### Filter
 
 Syntax: `;filter %name [capitals] [unicode]`

--- a/using/sail-and-udon.md
+++ b/using/sail-and-udon.md
@@ -12,13 +12,13 @@ This document will be divided into two main sections: the Sail guide and the Udo
 
 ## Table of Contents
 
-- #### [Sail: A Guide](#sail)
+- [Sail: A Guide](#sail)
 
-- #### [Udon: A Guide](#udon)
+- [Udon: A Guide](#udon)
 
-- #### [Udon: A Simple  Blog](#blog)
+- [Udon: A Simple  Blog](#blog)
 
-- #### [Udon: A Static Site](#static)
+- [Udon: A Static Site](#static)
 
 ## Getting Started
 


### PR DESCRIPTION
Headers in lists are no longer supported by our styles. This PR changes a couple of tables of contents to standard lists.

Also includes deletion of a bunch of random <span> tags I came across and remove colons at the end of some headers in the Glossary.