### PR TITLE
re-add learn/azimuth.md

### DIFF
--- a/learn/azimuth.md
+++ b/learn/azimuth.md
@@ -1,0 +1,11 @@
++++
+title = "Azimuth"
+weight = 2
+template = "doc.html"
++++
+
+Azimuth is a general-purpose public-key infrastructure (PKI) on the Ethereum blockchain, used as a decentralized ledger for Urbit identities that we call **points**. Having a point is necessary to use the Urbit network, which makes it important to have a neutral ledger to determine who owns what.
+
+Azimuth is not, however, part of the Arvo stack. Azimuth is a parallel system that be used as a generalized identity system for other projects. Azimuth "touches" the Urbit ecosystem when a point is used to boot a virtual computer on the Urbit network for the first time. When that happens, the point considered **linked** to Azimuth and the point’s full powers are available for use. Once a point is linked, it cannot be unlinked.
+
+A metaphor might make the relationship between these two systems easier to understand: Azimuth is the bank vault that stores the deed to your house. The Urbit network is the neighborhood that you live in.


### PR DESCRIPTION
`learn/azimuth.md` needs to be temporarily re-added because the docs sidebar code can't handle the case where `learn` has only folders as children (it then simply doesn't render them).