### PR TITLE
Fix incorrect bucvat description

### DIFF
--- a/reference/hoon-expressions/rune/buc.md
+++ b/reference/hoon-expressions/rune/buc.md
@@ -283,8 +283,7 @@ Using `$~`:
 
 ###### Normalizes to
 
-Default, if the sample is an atom; `p`, if the head of the sample
-is an atom; `q` otherwise.
+`p`, if the sample is an atom; `q`, if the sample is a cell.
 
 ##### Defaults to
 


### PR DESCRIPTION
Looks like it got copied without modification from bucket.