### PR TITLE
Update libsigsegv-2.11-7.fc30.x86_64 URL locations

### DIFF
--- a/getting-started/installing-urbit.md
+++ b/getting-started/installing-urbit.md
@@ -168,10 +168,10 @@ sudo env "PATH=$PATH" pip3 install meson
 # we need libsigsegv
 #
 
-wget http://dl.fedoraproject.org/pub/fedora/linux/releases/25/Everything/x86_64/os/Packages/l/libsigsegv-2.10-10.fc24.x86_64.rpm
-wget http://dl.fedoraproject.org/pub/fedora/linux/releases/25/Everything/x86_64/os/Packages/l/libsigsegv-devel-2.10-10.fc24.x86_64.rpm
-sudo yum localinstall libsigsegv-2.10-10.fc24.x86_64.rpm
-sudo yum localinstall libsigsegv-devel-2.10-10.fc24.x86_64.rpm
+wget https://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/l/libsigsegv-2.11-7.fc30.x86_64.rpm
+wget https://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/l/libsigsegv-devel-2.11-7.fc30.x86_64.rpm
+sudo yum localinstall libsigsegv-2.11-7.fc30.x86_64.rpm
+sudo yum localinstall libsigsegv-devel-2.11-7.fc30.x86_64.rpm
 
 git clone git://github.com/ninja-build/ninja.git
 pushd ninja


### PR DESCRIPTION
In the AWS installation instructions, the two `libsigsegv-2.11-7.fc30.x86_64` URLs no longer work — I've updated them with their current locations. The package version is newer, but urbit still compiles, so I am assuming no breaking errors.

## For future reference

It seems like Fedora will just change the URLs as the packages update, so you may want to establish a local (urbit.org) location for the packages to prevent future breaking links.