### PR TITLE
Default port is 80

### DIFF
--- a/using/admin.md
+++ b/using/admin.md
@@ -108,13 +108,13 @@ Full coverage of the Urbit shell, the Dojo is covered in the
 
 ## Web
 
-On startup Urbit tries to bind to `localhost:8080`. If you're already
-running something on `8080` -- such as another urbit -- you'll find the urbit
-that you just started on `8081`, and so on. For planets only, we also proxy web
+On startup Urbit tries to bind to `localhost:80`. If you're already
+running something on port `80` -- such as any other HTTP server, or another urbit -- you'll find the urbit
+that you just started on `8080`, `8081`, and so on. For planets only, we also proxy web
 domains through Urbit's own servers. Any planet `~your-urbit` is also at
 `your-urbit.urbit.org`.
 
-Your urbit serves a simple homepage from `http://localhost:8080` or
+Your urbit serves a simple homepage from `http://localhost` or
 `https://your-urbit.urbit.org` that should be self-explanatory. Since
 our HTTPS isn't audited / battle tested, we just call it "secure" HTTPS.
 You can find that on `8443`. Or `8444` (and so on) if you're already


### PR DESCRIPTION
An Urbit instance doesn't default to port 8080 — it appears to try and get started on port 80 proper, first. On my first onboarding session with Urbit, this mixed me up, since if you're running this locally, without any other HTTP server on that port (something the docs essentially suggest is a normal environment) _nothing_ appears on port 8080. 

My second installation on AWS replicated this, also launching on port 80. Seems to fit more cases than not, unless you're running an HTTP server that the Urbit process coexists on.

There seems to be reference to the HTTP port behaviour [here](https://github.com/urbit/urbit/blob/a42f2cbe5ccc591c148464444264c8f6c92776e3/vere/http.c#L994) and [here](https://github.com/urbit/urbit/blob/a42f2cbe5ccc591c148464444264c8f6c92776e3/vere/http.c#L1420), though admittedly I'm not that familiar with the codebase in depth yet. 

Would welcome any changes that substantiate the actual behaviour in more detail.