### PR TITLE
1.1: Removing redundant information, clarifying flow

### DIFF
--- a/getting-started/_index.md
+++ b/getting-started/_index.md
@@ -5,13 +5,13 @@ sort_by = "weight"
 template = "sections/docs/chapters.html"
 +++
 
-Welcome to Urbit, a personal server. Urbit isn't ready for serious use yet, but it's available to try out. If you have an Azimuth point, you can follow this step-by-step guide to get an Azimuth point, install Urbit, and join the community.
+Welcome to Urbit, a personal server. Urbit isn't ready for serious use yet, but it's available to try out. If you have an Azimuth point, you can follow this step-by-step guide to get your point's _keyfile_, which you need to boot your ship. Then you can install Urbit and join the community.
 
 If you don't have an Azimuth point, you can always [create a comet](./docs/using/creating-a-comet.md) to join the network before committing to a point, or [create a development ship](./docs/using/creating-a-development-ship.md) and start using Urbit offline first.
 
 ### [Step 1: Using Bridge](./docs/getting-started/using-bridge.md)
 
-In order to join the Urbit network, you need an Azimuth point, which acts like an identity and a password for your Urbit ship. Bridge is our client for managing Azimuth points. This guide tells you how to use Bridge to get your point's _keyfile_, which you need to boot your ship.
+In order to join the Urbit network, you need an Azimuth point, which acts like an identity and a password for your Urbit ship. Bridge is our client for managing Azimuth points, and lets you get your keyfile and claim the point.
 
 ### [Step 2: Installing Urbit](./docs/getting-started/installing-urbit.md)
 

--- a/getting-started/_index.md
+++ b/getting-started/_index.md
@@ -5,7 +5,9 @@ sort_by = "weight"
 template = "sections/docs/chapters.html"
 +++
 
-Welcome to Urbit, a personal server. Urbit isn't ready for serious use yet, but it's available to try out. Follow this step-by-step guide to get an Azimuth point, install Urbit, and join the community.
+Welcome to Urbit, a personal server. Urbit isn't ready for serious use yet, but it's available to try out. If you have an Azimuth point, you can follow this step-by-step guide to get an Azimuth point, install Urbit, and join the community.
+
+If you don't have an Azimuth point, you can always [create a comet](./docs/using/creating-a-comet.md) to join the network before committing to a point, or [create a development ship](./docs/using/creating-a-development-ship.md) and start using Urbit offline first.
 
 ### [Step 1: Using Bridge](./docs/getting-started/using-bridge.md)
 

--- a/learn/hoon/hoon-tutorial/setup.md
+++ b/learn/hoon/hoon-tutorial/setup.md
@@ -5,21 +5,21 @@ template = "doc.html"
 +++
 Before we begin working on Hoon, you should first (1) have Urbit installed and (2) boot a ship that you can use for trying out Hoon examples. Interactive learning is far superior to passive reading.
 
-## Installing Urbit
-
-You can install Urbit on any Mac or Unix machine; follow the steps for [creating a development ship](/docs/using/creating-a-development-ship).  On Windows, make a virtual Linux machine using VirtualBox or a similar tool.
-
-Once you're finished you can boot your very own ship.
-
 ## What is an urbit?
 
 An **urbit** is an Urbit virtual computer with persistent state that can connect to the Urbit network.  (Note the lowercase 'u' here.  'Urbit' is the entire software stack, whereas 'an urbit' is a local instance.)  Each urbit is associated with a unique number that plays three distinct roles: (1) it's an address on the Urbit network, (2) it's a cryptographic identity, and (3) it's (in principle) a human memorable name.  Normally an urbit's name is represented as a string starting with `~`, as in `~zod` or `~taglux-nidsep`.
 
 These may not look like numbers, but they are.  Each urbit name is written in a base-256 format, where each 'digit' is a syllable.  Imagine your phone number as a pronounceable string which sounds like a name in a foreign language.  An ordinary user-level urbit is a 'planet', and it's named by a 32-bit number.  The latter is represented as a four-syllable string; e.g., the planet name `~taglux-nidsep` is the number 6,095,360.
 
+## Installing Urbit
+
+You can install Urbit on any Mac or Unix machine; if you're just trying out Urbit or creating a development ship, you can follow the steps for creating a development ship [here](/docs/using/creating-a-development-ship).  On Windows, make a virtual Linux machine using VirtualBox or a similar tool.
+
+Once you're finished, you can [boot your very own ship](/docs/getting-started/booting-a-ship/#step-3-run-the-boot-command).
+
 ## Getting started 
 
-Once you've installed your development ship (or your own ship on the live network), let's try a basic command. Type `(add 2 2)` at the prompt and hit return.  Your screen now shows:
+Once you've created your development ship (or your own ship on the live network), let's try a basic command. Type `(add 2 2)` at the prompt and hit return.  Your screen now shows:
 
 ```
 ames: on localhost, UDP 31337.

--- a/learn/hoon/hoon-tutorial/setup.md
+++ b/learn/hoon/hoon-tutorial/setup.md
@@ -17,35 +17,9 @@ An **urbit** is an Urbit virtual computer with persistent state that can connect
 
 These may not look like numbers, but they are.  Each urbit name is written in a base-256 format, where each 'digit' is a syllable.  Imagine your phone number as a pronounceable string which sounds like a name in a foreign language.  An ordinary user-level urbit is a 'planet', and it's named by a 32-bit number.  The latter is represented as a four-syllable string; e.g., the planet name `~taglux-nidsep` is the number 6,095,360.
 
-For this tutorial you'll boot and run what we call a 'comet'.  **Comets** are urbits whose names are 128-bits or 16 syllables, such as:
+## Getting started 
 
-`~hillyn-pitwet-hasdur-paswer--miszod-rabpex-divrup-fogdur`
-
-Comet names aren't quite as memorable as others, but they're disposable identities that anyone can make for free to join the live network. Thus, comets make the ideal urbit for playing around with Hoon, asking for help from other Urbit devs in [Talk](./docs/using/messaging.md) if you need it, and showing off Urbit to your friends.
-
-## Booting a Comet
-
-To boot your comet, go into the command line and run the following command from the directory that was created during Urbit installation:
-
-```
-$ urbit -c mycomet
-```
-
-This will take a few minutes and will spin out a bunch of boot messages. Toward the end, you'll see something like:
-
-```
-ames: on localhost, UDP 31337.
-http: live (insecure, public) on 8080
-http: live ("secure", public) on 8443
-http: live (insecure, loopback) on 12321
-~palnul_nocser:dojo>
-```
-
-(There will likely be other messages as well.)
-
-Look at the prompt, `~palnul_nocser:dojo>`.  To the left of the `:` you'll see an abbreviation of the comet name you just booted, `~palnul_nocser` in this case.  To the right is the name of a local application, `dojo`.  **Dojo** is the Urbit command line app; it's also a Hoon [REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop) we'll use to run simple Hoon examples.
-
-To make sure everything is working, type `(add 2 2)` at the prompt and hit return.  Your screen now shows:
+Once you've installed your development ship (or your own ship on the live network), let's try a basic command. Type `(add 2 2)` at the prompt and hit return.  Your screen now shows:
 
 ```
 ames: on localhost, UDP 31337.
@@ -66,36 +40,15 @@ You just used a function from the Hoon standard library, `add`.  Next, quit Urbi
 $
 ```
 
-Your comet isn't running anymore and you're back at your computer's normal terminal prompt. You now have a `mycomet` directory for your Urbit comet; this directory is your comet's **pier** and it contains the entirety of your comet's state.
-
-Right now the only thing in your pier is your comet's system files:
+Your ship isn't running anymore and you're back at your computer's normal terminal prompt. If your ship is `~palnul_nocser`, then you can restart the ship by typing:
 
 ```
-$ ls -a /path/to/mycomet
-./  ../ .urb/
-```
-
-Restarting your already-created comet from the terminal is like creating a new one, but without the `-c` flag.  (The `-c` is for "create".)
-
-```
-$ urbit mycomet
-```
-
-Because the comet has already been booted it won't take very long to get it running again.  There are also fewer startup messages:
-
-```
-$ urbit mycomet
-[...]
-ames: on localhost, UDP 31337.
-http: live (insecure, public) on 8080
-http: live ("secure", public) on 8443
-http: live (insecure, loopback) on 12321
-~palnul_nocser:dojo>
+urbit palnul_nocser
 ```
 
 ## Another Noun
 
-You've already used a standard library function to produce one value, in the dojo.  Now that your comet is running again, let's try another.  Enter the number `17`.
+You've already used a standard library function to produce one value, in the dojo.  Now that your ship is running again, let's try another.  Enter the number `17`.
 
 > We won't show the `~palnul_nocser:dojo> ` prompt from here on out.  We'll just show the echoed command along with its result.
 
@@ -106,7 +59,7 @@ You'll see:
 17
 ```
 
-You asked dojo to evaluate `17` and it echoed the number back at you.  This value is a 'noun'.  But what is a noun?  Move on to lesson 1.2 for the answer.
+You asked dojo to evaluate `17` and it echoed the number back at you.  This value is a 'noun'.  We'll talk more about nouns in [Chapter 1.2](docs/learn/hoon/hoon-tutorial/nouns/), but first let's write a very basic program.
 
 ## Generators
 

--- a/learn/hoon/hoon-tutorial/setup.md
+++ b/learn/hoon/hoon-tutorial/setup.md
@@ -22,13 +22,13 @@ Once you're finished, you can [boot your very own ship](/docs/getting-started/bo
 Once you've created your development ship, let's try a basic command. Type `(add 2 2)` at the prompt and hit return.  Your screen now shows:
 
 ```
-ames: on localhost, UDP 31337.
-http: live (insecure, public) on 8080
-http: live ("secure", public) on 8443
+fake: ~zod
+ames: czar: ~zod on 31337 (localhost only)
+http: live (insecure, public) on 80
 http: live (insecure, loopback) on 12321
 > (add 2 2)
 4
-~palnul_nocser:dojo>
+~zod:dojo>
 ```
 
 You just used a function from the Hoon standard library, `add`.  Next, quit Urbit with `ctrl-d`:
@@ -36,21 +36,21 @@ You just used a function from the Hoon standard library, `add`.  Next, quit Urbi
 ```
 > (add 2 2)
 4
-~palnul_nocser:dojo>
+~zod:dojo>
 $
 ```
 
-Your ship isn't running anymore and you're back at your computer's normal terminal prompt. If your ship is `~palnul_nocser`, then you can restart the ship by typing:
+Your ship isn't running anymore and you're back at your computer's normal terminal prompt. If your ship is `~zod`, then you can restart the ship by typing:
 
 ```
-urbit palnul_nocser
+urbit zod
 ```
 
 ## Another Noun
 
 You've already used a standard library function to produce one value, in the dojo.  Now that your ship is running again, let's try another.  Enter the number `17`.
 
-> We won't show the `~palnul_nocser:dojo> ` prompt from here on out.  We'll just show the echoed command along with its result.
+> We won't show the `~zod:dojo> ` prompt from here on out.  We'll just show the echoed command along with its result.
 
 You'll see:
 

--- a/learn/hoon/hoon-tutorial/setup.md
+++ b/learn/hoon/hoon-tutorial/setup.md
@@ -15,11 +15,11 @@ These may not look like numbers, but they are.  Each urbit name is written in a 
 
 You can install Urbit on any Mac or Unix machine; if you're just trying out Urbit or creating a development ship, you can follow the steps for creating a development ship [here](/docs/using/creating-a-development-ship).  On Windows, make a virtual Linux machine using VirtualBox or a similar tool.
 
-Once you're finished, you can [boot your very own ship](/docs/getting-started/booting-a-ship/#step-3-run-the-boot-command).
+Once you're finished, you can [boot your very own ship](/docs/getting-started/booting-a-ship/#step-3-run-the-boot-command). While you can develop in Hoon on your own ship on the live network, we strongly suggest developing on a development ship first.
 
 ## Getting started 
 
-Once you've created your development ship (or your own ship on the live network), let's try a basic command. Type `(add 2 2)` at the prompt and hit return.  Your screen now shows:
+Once you've created your development ship, let's try a basic command. Type `(add 2 2)` at the prompt and hit return.  Your screen now shows:
 
 ```
 ames: on localhost, UDP 31337.

--- a/using/_index.md
+++ b/using/_index.md
@@ -7,6 +7,7 @@ template = "sections/docs/chapters.html"
 This section contains guides to using your urbit.
 
 - [Creating a Development Ship](creating-a-development-ship) will show you how to set up the environment for coding on Urbit.
+- [Creating a Comet](creating-a-comet) will show you how to create a comet: quick, disposable 128-bit identities on the Urbit network.
 - [Admin and Operation](admin) is a guide to the basic commands used to interact with your ship.
 - [Messaging](messaging) tells you how to use Talk, our chat system.
 - [Shell](shell) is a guide to using Dojo, our command-line interface.

--- a/using/creating-a-comet.md
+++ b/using/creating-a-comet.md
@@ -6,7 +6,7 @@ template = "doc.html"
 
 **Comets** are urbits whose names are 128-bits or 16 syllables, such as:
 
-`~hillyn-pitwet-hasdur-paswer--miszod-rabpex-divrup-fogdur`
+`~dasres-ragnep-lislyt-ribpyl--mosnyx-bisdem-nidful-marzod`
 
 Comet names aren't quite as memorable as others, but they're disposable identities that anyone can make for free to join the live network.
 
@@ -25,5 +25,5 @@ ames: on localhost, UDP 31337.
 http: live (insecure, public) on 8080
 http: live ("secure", public) on 8443
 http: live (insecure, loopback) on 12321
-~hillyn-pitwet-hasdur-paswer--miszod-rabpex-divrup-fogdur:dojo>
+~dasres_marzod:dojo>
 ```

--- a/using/creating-a-comet.md
+++ b/using/creating-a-comet.md
@@ -1,0 +1,29 @@
++++
+title = "Creating a Comet"
+weight = 0
+template = "doc.html"
++++
+
+**Comets** are urbits whose names are 128-bits or 16 syllables, such as:
+
+`~hillyn-pitwet-hasdur-paswer--miszod-rabpex-divrup-fogdur`
+
+Comet names aren't quite as memorable as others, but they're disposable identities that anyone can make for free to join the live network.
+
+## Booting a Comet
+
+To boot your comet, go into the command line and run the following command from the directory that was created during Urbit installation:
+
+```
+$ urbit -c mycomet
+```
+
+This will take a few minutes and will spin out a bunch of boot messages. Toward the end, you'll see something like:
+
+```
+ames: on localhost, UDP 31337.
+http: live (insecure, public) on 8080
+http: live ("secure", public) on 8443
+http: live (insecure, loopback) on 12321
+~hillyn-pitwet-hasdur-paswer--miszod-rabpex-divrup-fogdur:dojo>
+```


### PR DESCRIPTION
Perhaps a more controversial PR? The first part of the tutorial series repeats information found elsewhere in the documentation — and it even links to those parts at the start. It would be much clearer to just continue from those posts as a starting point. 

In addition the usage of 'ship' and 'comet' is inconsistent (and refers to a planet as a 'comet,' potentially confusing a new user after instructing that a comet has a long address), so I've made it consistently a *ship*.

Finally the last part talks as if the 'noun' section is immediately following, but then goes into generators, which is jarring for the onboarding flow. I've clarified that what's coming *first* is a simple program, and afterward we will discuss what nouns are.

Edit: PR in sum

- Eliminates comet setup information from the start of the Hoon tutorial
- Makes the wording consistently 'ship' in that section
- Changes flow into the generators paragraph by amending the "Noun" paragraph in 1.1 to better clarify the onboarding flow.
- Mentions the three paths to creating an urbit on Getting Started
- Migrates the comet information to "Using" section, beside the fakezod setup information
- Keeps the Hoon tutorial clean and recommend users use a fakezod to develop.