### PR TITLE
Some mark conversion documentation

### DIFF
--- a/using/shell.md
+++ b/using/shell.md
@@ -287,11 +287,25 @@ Which outputs a new `urbit.pill` to `pier/.urb/put/urbit.pill`
 
 ##### `&` - Mark conversion
 
-Convert between marks using `&`:
+Convert between marks using `&`, with the destination mark first. You can stack multiple mark conversions together, and some marks can only be converted to specific other marks. In this example, [Udon](./docs/using/sail-and-udon/#udon) is converted to `&hymn` (a mark which supplies the `html`, `head`, `body` and closing tags) first, before being converted to HTML:
 
 ```
-~your-urbit:dojo> &html &md '# hello'
-'<html><head></head><body><div><h1 id="-hello">hello</h1></div></body></html>'
+~your-urbit:dojo>&html &hymn &udon ';h1#hello: hello'
+'<html><head></head><body><h1 id="hello">hello</h1></body></html>'
+```
+
+Performing a conversion straight from Udon to the `&hymn` mark reveals a bit more about its mark conversion:
+
+```
+~your-urbit:dojo>&hymn &udon ';h1#hello: hello'
+[[%html ~] [[%head ~] ~] [[%body ~] [g=[n=%h1 a=~[[n=%id v="hello"]]] c=~[[g=[n=%$ a=~[[n=%$ v="hello"]]] c=~]]] ~] ~]
+```
+
+As does converting straight from Udon to HTML:
+
+```
+~your-urbit:dojo>&html &udon ';h1#hello: hello'
+';h1#hello: hello'
 ```
 
 ##### `_` - Run a function


### PR DESCRIPTION
Marks are currently fairly undocumented (removed with the `layout` page if I recall), but seem like a not insignificant aspect of creating applications. ~~That said, I sense it's in a transition phase, but in this interim period, it should still have some representation somewhere.~~ It appears that `&cord` conversions are now gone, as are `&md` conversions, but we can still convert Udon and `&hymn` and stack those conversions, too.

This PR, then, explains that mark conversions are written destination-first; that they can be stacked together; that some marks only convert to other marks; and that some marks essentially wrap / prepare a mark for conversion to its final, destination mark, using Udon as the source mark.

Feel free to adjust and propose if anything I've written is, well, _off the mark_.