### PR TITLE
Remove reference to comets in Hoon tutorial

### DIFF
--- a/learn/hoon/hoon-tutorial/nouns.md
+++ b/learn/hoon/hoon-tutorial/nouns.md
@@ -451,7 +451,7 @@ Without using the dojo, for each fragment below provide the address relative to 
 5. 55
 ```
 
-That's it for our basic introduction to nouns.  Hit `ctrl-d` to exit your comet, or else move on to the next lesson.
+That's it for our basic introduction to nouns.  Hit `ctrl-d` to exit your ship, or else move on to the next lesson.
 
 ## Exercise Answers
 


### PR DESCRIPTION
Now that comets aren't the de facto introductory ship in the Hoon onboarding, referencing them is inconsistent. In my PR doing the former, I missed a reference to a comet — this PR smashes it back into dust. I love comets, but they have their place.