### PR TITLE
Adding runes with col suffixes to /rune/ pages

### DIFF
--- a/reference/hoon-expressions/rune/bar.md
+++ b/reference/hoon-expressions/rune/bar.md
@@ -163,7 +163,7 @@ A trivial core:
 101
 ```
 
-### "barcol"
+### |: "barcol"
 
 Produce a gate with a custom sample.
 

--- a/reference/hoon-expressions/rune/buc.md
+++ b/reference/hoon-expressions/rune/buc.md
@@ -118,7 +118,7 @@ be an infinite loop!
 [%foo p=0 q=0]~
 ```
 
-### "buccol"
+### $: "buccol"
 
 `[%bscl p=(list spec)]`: form a cell type.
 

--- a/reference/hoon-expressions/rune/col.md
+++ b/reference/hoon-expressions/rune/col.md
@@ -28,7 +28,7 @@ Regular: **2-fixed**.
 [2 1]
 ```
 
-### "colcol"
+### :: "colcol"
 
 Code comment
 

--- a/reference/hoon-expressions/rune/ket.md
+++ b/reference/hoon-expressions/rune/ket.md
@@ -48,7 +48,7 @@ The prettyprinter shows the core metal (`.` gold, `|` iron):
 <1|gcq [@  @n <250.yur 41.wda 374.hzt 100.kzl 1.ypj %151>]>
 ```
 
-### "ketcol"
+### ^: "ketcol"
 
 `[%ktcl p=spec]`: 'factory' gate for type `p`.
 

--- a/reference/hoon-expressions/rune/mic.md
+++ b/reference/hoon-expressions/rune/mic.md
@@ -8,7 +8,7 @@ Miscellaneous useful macros.
 
 ## Runes
 
-### "miccol"
+### ;: "miccol"
 
 `[%mccl p=hoon q=(list hoon)]`: call a binary function as an n-ary function.
 

--- a/reference/hoon-expressions/rune/tis.md
+++ b/reference/hoon-expressions/rune/tis.md
@@ -77,7 +77,7 @@ Speaking more loosely, `=|` usually "declares a variable" which is "uninitialize
 7
 ```
 
-### "tiscol"
+### =: "tiscol"
 
 `[%tscl p=(list (pair wing hoon)) q=hoon]`: change multiple legs in the subject.
 

--- a/reference/hoon-expressions/rune/wut.md
+++ b/reference/hoon-expressions/rune/wut.md
@@ -106,7 +106,7 @@ Irregular: `|(foo bar baz)` is `?|(foo bar baz)`.
 %.n
 ```
 
-### "wutcol"
+### ?: "wutcol"
 
 `[%wtcl p=hoon q=hoon r=hoon]`: branch on a boolean test.
 

--- a/reference/hoon-expressions/rune/zap.md
+++ b/reference/hoon-expressions/rune/zap.md
@@ -35,7 +35,7 @@ If you want just the type value, use a 'type spear'.  This is `-:!>`, i.e., the 
 #t/@ud
 ```
 
-### "zapcol"
+### !: "zapcol"
 
 `[%dbug p=hoon]`: turn on stack trace
 


### PR DESCRIPTION
I kept running into this, so I checked them all, and they were each missing the col suffix rune — eg. `tiscol`, `barcol`, `buccol`, `colcol` et al. I added them.

I was wondering if this meant col suffix runes had rendering issues in the past. In my commit earlier today adding `cencol`, it rendered fine, so I checked the commit history, and it looks the col suffix runes were just a casualty of [this commit](https://github.com/urbit/docs/commit/f1229c17b955540fd2cbc760a26506f7b549406d#diff-8b4bfeb59044a1736c1846009587b102) during the transition from Udon to Markdown. In any case, this PR adds them back.