### PR TITLE
Fix broken link to next lesson in 2.2

### DIFF
--- a/learn/hoon/hoon-tutorial/type-checking-and-type-inference.md
+++ b/learn/hoon/hoon-tutorial/type-checking-and-type-inference.md
@@ -639,4 +639,4 @@ More subtly, the `=+`, `=/`, and `=|` runes modify the subject by pinning values
 
 In general, anything that modifies the subject modifies the type of the subject.  Type inference can work in subtle ways for various expressions.  However, we have covered enough that it should be relatively clear how to anticipate how type inference works for the vast majority of ordinary use cases.
 
-### [Next Up: Reading -- Insertion Sort](../insertion)
+### [Next Up: Reading -- Structures and Complex Types](../structures-and-complex-types)


### PR DESCRIPTION
The link at the bottom of 2.2 points to a missing page. I'm assuming the next link should point to 2.3