### PR TITLE
Fix links in 2.4

### DIFF
--- a/learn/hoon/hoon-tutorial/trees-sets-and-maps.md
+++ b/learn/hoon/hoon-tutorial/trees-sets-and-maps.md
@@ -87,7 +87,7 @@ $(hay r.hay)
 
 ## Sets
 
-Use `set` to create a data structure for a set of values, e.g., `(set @)` for a set of atoms.  The `in` core in the Hoon standard library contains the various functions for operating on sets.  See the standard library reference documentation for sets here (include link).
+Use `set` to create a data structure for a set of values, e.g., `(set @)` for a set of atoms.  The `in` core in the Hoon standard library contains the various functions for operating on sets.  See the standard library reference documentation for sets [here](/docs/reference/library/2h/).
 
 As with `list`s and `tree`s, there are two categories of sets: null `~`, and non-null.  Hoon implements sets using trees for the underlying noun.
 
@@ -236,7 +236,7 @@ Use `map` to create a set of key-value pairs, e.g., `(map @tas *)` for a set of 
 
 One example use case is for storing customer information as a set of pairs: `(map [employee-name employee-data])`.
 
-The `by` core in the Hoon standard library contains the various functions for operating on maps.  Many of these functions are similar to the set functions of the `in` core.  See the standard library reference documentation for maps here (include link).  As was the case with sets, the underlying noun of each map is a tree.
+The `by` core in the Hoon standard library contains the various functions for operating on maps.  Many of these functions are similar to the set functions of the `in` core.  See the standard library reference documentation for maps [here](/docs/reference/library/2i/).  As was the case with sets, the underlying noun of each map is a tree.
 
 Two common methods for populating a map include (1) creating it from a list of key-value cells using the `my` function, and (2) inserting items into a map using the `put` arm of the `by` core.
 
@@ -319,4 +319,4 @@ You can use `run` of `by` to apply a gate to each value in a map, producing a ma
 
 There are other map functions in the Hoon standard library that didn't cover here.
 
-### [Next Up: <placeholder>]
+### [Next Up: Reading -- Type Polymorphism](../type-polymorphism)


### PR DESCRIPTION
Adds links to standard library pages for Set Logic and Map Logic, along with link to next section, 2.5 Type Polymorphism