### PR TITLE
Update getting-started/installing-urbit for 0.8.0.

### DIFF
--- a/concepts/source-code-overview.md
+++ b/concepts/source-code-overview.md
@@ -15,6 +15,7 @@ This is the main Urbit repo. It contains the Urbit interpreter (all of the C cod
 
 It also contains Arvo, the Urbit operating system (written in Hoon), as a subtree. When you boot your Urbit, you get this over the air. The source code is kept here, and you'll need it if you want to do any heavy development work.
 
+## [`urbit/docs`](https://github.com/urbit/docs)
 
 Interesting in working on Urbit documentation? This repository is where all the collaboration happens. The docs themselves are just markdown files hosted on a live ship.
 

--- a/concepts/source-code-overview.md
+++ b/concepts/source-code-overview.md
@@ -13,9 +13,8 @@ important ones here:
 
 This is the main Urbit repo. It contains the Urbit interpreter (all of the C code) and is the main entry point if you're going to build from source.
 
-## [`urbit/arvo`](https://github.com/urbit/arvo)
+It also contains Arvo, the Urbit operating system (written in Hoon), as a subtree. When you boot your Urbit, you get this over the air. The source code is kept here, and you'll need it if you want to do any heavy development work.
 
-Arvo is the Urbit operating system (written in Hoon). When you boot your Urbit, you get this over the air. The source code is kept here, and you'll need it if you want to do any heavy development work.
 
 Interesting in working on Urbit documentation? This repository is where all the collaboration happens. The docs themselves are just markdown files hosted on a live ship.
 

--- a/getting-started/contributing.md
+++ b/getting-started/contributing.md
@@ -18,4 +18,4 @@ If you're just getting set up to work on the Urbit or Arvo code base for the fir
 
 ## Code style
 
-Before contributing Hoon code, you should familiarize yourself with the [Hoon style guide](@/docs/learn/hoon/style.md). For a good example of idiomatic Hoon, see [Ford](https://github.com/urbit/arvo/blob/master/sys/vane/ford.hoon).
+Before contributing Hoon code, you should familiarize yourself with the [Hoon style guide](@/docs/learn/hoon/style.md). For a good example of idiomatic Hoon, see [Ford](https://github.com/urbit/urbit/blob/master/pkg/arvo/sys/vane/ford.hoon).

--- a/getting-started/installing-urbit.md
+++ b/getting-started/installing-urbit.md
@@ -19,174 +19,32 @@ Urbit: a personal server operating function
 
 ## Instructions
 
-### MacOS
+### macOS (Darwin)
 
-We recommend using the Homebrew package manager to run Arvo on MacOS.
-
-```
-# Bash
-
-brew update
-brew install -v gcc git gmp libsigsegv libtool meson ninja pkg-config openssl
-git clone https://github.com/urbit/urbit
-cd urbit
-./scripts/bootstrap
-./scripts/build
-sudo ninja -C ./build/ meson-install
-urbit
-```
-
-### Ubuntu or Debian
+We provide static binaries for macOS.  You can grab the latest stable release as follows:
 
 ```
-# Bash
-
-sudo apt-get update
-sudo apt-get install g++ git libcurl4-gnutls-dev libgmp3-dev libncurses5-dev libsigsegv-dev libssl-dev make openssl pkg-config python python3 python3-pip python3-setuptools zlib1g-dev ninja-build
-sudo -H pip3 install --upgrade pip
-sudo -H pip3 install meson
-
-git clone https://github.com/urbit/urbit
-cd urbit
-./scripts/bootstrap
-./scripts/build
-sudo ninja -C ./build/ install
-urbit
+curl -O https://bootstrap.urbit.org/urbit-darwin-v0.8.0.tgz
+tar xzf urbit-darwin-v0.8.0.tgz
+./urbit
 ```
 
-To access your Urbit via HTTP on port 80, you may need to run the following:
+### Linux (64-bit)
+
+We also provide static binaries for 64-bit Linux distributions (Ubuntu, Debian, Fedora, Arch, etc.).  You can get the latest stable release similarly:
 
 ```
-sudo apt-get install libcap2-bin
-sudo setcap 'cap_net_bind_service=+ep' $(which urbit)
+curl -O https://bootstrap.urbit.org/urbit-linux64-v0.8.0.tgz
+tar xzf urbit-linux64-v0.8.0.tgz
+./urbit
 ```
 
-### Fedora 23 or earlier
+### Other
+
+We maintain a [Nix](https://nixos.org/nix) derivation for Urbit in [nixpkgs](https://github.com/NixOS/nixpkgs).  You can install and launch it like so:
 
 ```
-# Bash
-
-sudo yum upgrade
-sudo yum install autoconf automake cmake ctags gcc gcc-c++ git gmp-devel libcurl-devel libsigsegv-devel libtool ncurses-devel ninja-build openssl openssl-devel pkgconfig python3 re2c wget
-
-# meson requires python 3.5; RHEL supplies wrong version
-pushd /usr/src
-  sudo wget https://www.python.org/ftp/python/3.5.5/Python-3.5.5.tgz
-  sudo tar xzf Python-3.5.5.tgz
-  cd Python-3.5.5
-  sudo ./configure --enable--optimizations
-  sudo make altinstall
-  which python3.5
-  cd /usr/local/bin
-  sudo ln -s python3.5 python3
-  hash python3
-popd
-
-curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-sudo /usr/local/bin/python3 get-pip.py
-# downgrade meson to avoid dependencies that redhat can't meet
-sudo -H /usr/local/bin/pip3 install meson
-
-
-git clone git://github.com/ninja-build/ninja.git && cd ninja
-git checkout release
-./configure.py --bootstrap
-sudo cp ./ninja /usr/local/bin
-
-git clone https://github.com/urbit/urbit
-cd urbit
-./scripts/bootstrap
-./scripts/build
-sudo /usr/local/bin/ninja -C ./build/ install
-urbit
-```
-
-### Fedora 24 or later
-
-```
-# Bash
-
-sudo dnf upgrade
-sudo dnf install autoconf automake cmake ctags gcc gcc-c++ git gmp-devel libcurl-devel libsigsegv-devel libtool ncurses-devel meson ninja-build openssl openssl-devel pkgconfig python3 re2c wget
-
-git clone https://github.com/urbit/urbit
-cd urbit
-./scripts/bootstrap
-./scripts/build
-sudo ninja -C ./build/ install
-urbit
-```
-
-### Arch Linux
-
-```
-# Bash
-
-sudo pacman -Syyu
-sudo pacman -S --needed curl gcc git gmp libsigsegv ncurses ninja openssl python python-pip meson
-git clone https://github.com/urbit/urbit
-cd urbit
-./scripts/bootstrap
-./scripts/build
-cd build
-ninja
-sudo ninja meson-install
-urbit
-```
-
-### FreeBSD
-
-```
-# Bash or Sh
-
-pkg upgrade
-sudo pkg install curl gcc git gmake gmp libsigsegv python python3 ncurses openssl gmp
-curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-sudo python3 get-pip.py
-sudo -H pip install --upgrade pip
-sudo -H pip install meson
-sudo pkg install ninja
-git clone https://github.com/urbit/urbit
-cd urbit
-sh ./scripts/bootstrap
-sh ./scripts/build
-sudo ninja -C ./build/ meson-install
-urbit
-```
-
-### Amazon Web Services
-
-```
-# Bash
-
-sudo yum update
-sudo yum install gcc gcc-c++ git gmp-devel libcurl-devel libsigsegv-devel ncurses-devel openssl openssl-devel pkgconfig python3 python3-pip wget git
-sudo env "PATH=$PATH" pip3 install --upgrade pip
-sudo env "PATH=$PATH" pip3 install meson
-
-
-# we need libsigsegv
-#
-
-wget https://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/l/libsigsegv-2.11-7.fc30.x86_64.rpm
-wget https://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/Packages/l/libsigsegv-devel-2.11-7.fc30.x86_64.rpm
-sudo yum localinstall libsigsegv-2.11-7.fc30.x86_64.rpm
-sudo yum localinstall libsigsegv-devel-2.11-7.fc30.x86_64.rpm
-
-git clone git://github.com/ninja-build/ninja.git
-pushd ninja
-  git checkout release
-  ./configure.py --bootstrap
-  sudo cp ./ninja /usr/local/bin
-popd
-
-
-git clone https://github.com/urbit/urbit
-cd urbit
-./scripts/bootstrap
-./scripts/build
-sudo env "PATH=$PATH" ninja -C ./build/ install
-
+nix-env -i urbit
 urbit
 ```
 
@@ -195,8 +53,6 @@ urbit
 One you've completed your installation, you can continue on to the instructions for [booting your ship](@/docs/getting-started/booting-a-ship.md) to get on the Arvo network.
 
 Or, if you want to try testing and writing code, check out the guide to [getting an unnetworked development ship](/docs/using/creating-a-development-ship).
-
-
 
 ## Set Up Swap
 

--- a/learn/arvo/gall.md
+++ b/learn/arvo/gall.md
@@ -1711,7 +1711,7 @@ identity), and `eny` (512 bits of guaranteed-fresh entropy). For the full list
 of things in `++bowl`, search for `++  bowl` (note: two spaces) in
 `/arvo/zuse.hoon`.
 
-> This is, perhaps, the most common way to learn Hoon. The easiest way to learn about an identifier you see in code is to search in `/arvo/zuse.hoon` and `/arvo/hoon.hoon` for it.\\ Urbit's codebase is less than 30000 lines of code combined, including the hoon parser, the compiler, and the `/arvo` microkernel, so you can usually use the code and its comments as a reference doc. You can also read [zuse.hoon](https://github.com/urbit/arvo/blob/master/arvo/zuse.hoon) and [hoon.hoon](https://github.com/urbit/arvo/blob/master/arvo/hoon.hoon) in your browser.
+> This is, perhaps, the most common way to learn Hoon. The easiest way to learn about an identifier you see in code is to search in `/arvo/sys/zuse.hoon` and `/arvo/sys/hoon.hoon` for it.\\ Urbit's codebase is less than 30000 lines of code combined, including the hoon parser, the compiler, and the `/arvo` microkernel, so you can usually use the code and its comments as a reference doc. You can also read [zuse.hoon](https://github.com/urbit/urbit/blob/master/pkg/arvo/sys/zuse.hoon) and [hoon.hoon](https://github.com/urbit/urbit/blob/master/pkg/arvo/sys/hoon.hoon) in your browser.
 
 The second thing we should clear up is this: Urbit needs no "serialize to disk"
 step. Everything you produce in the app state is persistent across calls to the

--- a/learn/arvo/hall.md
+++ b/learn/arvo/hall.md
@@ -495,10 +495,10 @@ And, of course, there's a lot that the Talk client can improve on as well.
 ## Further reading
 
 To gain a more thorough understanding of Hall's inner workings, take a look at its source code. It comes with inline documentation.
-[On Github.](https://github.com/urbit/arvo/blob/master/app/hall.hoon)
+[On Github.](https://github.com/urbit/urbit/blob/master/pkg/arvo/app/hall.hoon)
 
 To see an expansive example of a Hall client, take a look at the code of Talk. It, too, comes with inline documentation.
-[On Github.](https://github.com/urbit/arvo/blob/master/app/talk.hoon)
+[On Github.](https://github.com/urbit/urbit/blob/master/pkg/arvo/app/talk.hoon)
 
 # The Hall Interface
 
@@ -864,7 +864,7 @@ When the user makes any changes to shared UI elements (elements that should pers
 
 # The New Gall Model
 
-This document is complemented by the source code of applications that use the new Gall model (like [Hall](https://github.com/urbit/arvo/blob/master/app/hall.hoon)), but doesn't require it. Code snippets will be provided where useful. Some knowledge of Hoon and the functioning of Hoon apps is assumed.
+This document is complemented by the source code of applications that use the new Gall model (like [Hall](https://github.com/urbit/urbit/blob/master/pkg/arvo/app/hall.hoon)), but doesn't require it. Code snippets will be provided where useful. Some knowledge of Hoon and the functioning of Hoon apps is assumed.
 
 New `%gall` has not yet fully solidified. As such, its structure and naming are tentative.
 

--- a/learn/hoon/hoon-tutorial/doors.md
+++ b/learn/hoon/hoon-tutorial/doors.md
@@ -194,7 +194,7 @@ Let's look once more at the parent core of the `add` arm in the Hoon standard li
 <74.dbd 1.qct $141>
 ```
 
-The battery of this core contains 74 arms, each of which evaluates to a gate in the standard library.  This 'library' is nothing more than a core containing useful basic functions that Hoon often makes available as part of the subject.  You can see the Hoon code defining these arms near the beginning of [hoon.hoon](https://github.com/urbit/arvo/blob/master/sys/hoon.hoon), starting with [`++  add`](https://github.com/urbit/arvo/blob/master/sys/hoon.hoon#L21).  (Yes, the Hoon standard library is written in Hoon.)
+The battery of this core contains 74 arms, each of which evaluates to a gate in the standard library.  This 'library' is nothing more than a core containing useful basic functions that Hoon often makes available as part of the subject.  You can see the Hoon code defining these arms near the beginning of [hoon.hoon](https://github.com/urbit/urbit/blob/master/pkg/arvo/sys/hoon.hoon), starting with [`++  add`](https://github.com/urbit/urbit/blob/master/pkg/arvo/sys/hoon.hoon#L21).  (Yes, the Hoon standard library is written in Hoon.)
 
 Here are some of the other gates that can be generated from this core in the Hoon standard library.  It should be fairly obvious what they do:
 


### PR DESCRIPTION
Describes how to download static binaries for macOS and 64-bit Linux, and replaces the instructions for other operating systems with a catch-all using Nix and nixpkgs.