### PR TITLE
Remove extraneous 'has' from lists page

### DIFF
--- a/learn/hoon/hoon-tutorial/lists.md
+++ b/learn/hoon/hoon-tutorial/lists.md
@@ -9,7 +9,7 @@ template = "doc.html"
 
 A **list** is a type of noun that you'll frequently encounter when reading and writing Hoon. A list can be thought of as an ordered arrangement of zero or more elements terminated by a `~` (null).
 
-So a list can be either null or non-null. When the list contains only `~` and no items, it's the null list.  Most lists are, however, non-null lists, which have has items preceding the `~`. Non-null lists, called _lests_, are cells in which the head is the first list item, and the tail is the rest of the list. The tail is itself a list, and if such a list is also non-null, the head of this sub-list is the second item in the greater list, and so on. To illustrate, let's look at a list `[1 2 3 4 ~]` with the cell-delineating brackets left in:
+So a list can be either null or non-null. When the list contains only `~` and no items, it's the null list.  Most lists are, however, non-null lists, which have items preceding the `~`. Non-null lists, called _lests_, are cells in which the head is the first list item, and the tail is the rest of the list. The tail is itself a list, and if such a list is also non-null, the head of this sub-list is the second item in the greater list, and so on. To illustrate, let's look at a list `[1 2 3 4 ~]` with the cell-delineating brackets left in:
 
 `[1 [2 [3 [4 ~]]]]`
 


### PR DESCRIPTION
Fixes a small typo.

Changes " . . .which have has items preceding the `~`. "  to ". . .which have items preceding the `~`."