### PR TITLE
list, inline code tic rendering, and zapgar output fixes

### DIFF
--- a/learn/hoon/hoon-tutorial/lists.md
+++ b/learn/hoon/hoon-tutorial/lists.md
@@ -13,7 +13,7 @@ So a list can be either null or non-null. When the list contains only `~` and no
 
 `[1 [2 [3 [4 ~]]]]`
 
-It's easy to see where the heads are and where the nesting tails are. The head of the above list is the atom `1` and the tail is the list `[2 [3 [4 ~]]]`, (or `[2 3 4]`). Recall that whenever cell brackets are omitted so that visually there appears to be more than two child nouns, it is implicitly understood that the right-most nouns constitute a cell.
+It's easy to see where the heads are and where the nesting tails are. The head of the above list is the atom `1` and the tail is the list `[2 [3 [4 ~]]]`, (or `[2 3 4 ~]`). Recall that whenever cell brackets are omitted so that visually there appears to be more than two child nouns, it is implicitly understood that the right-most nouns constitute a cell.
 
 To make a list, let's cast nouns to the `(list @)` ("list of atoms") type.
 

--- a/learn/hoon/hoon-tutorial/type-checking-and-type-inference.md
+++ b/learn/hoon/hoon-tutorial/type-checking-and-type-inference.md
@@ -167,7 +167,7 @@ Cast runes also shape how Hoon understands an expression type.  The inferred typ
 ^+([0x1b 0b11] [0x123 0b101])     [@ux @ub]
 ```
 
-You can also use the irregular `\` \`` syntax for casting in the same way as `^-`; e.g., `\`@\`123` for `^-(@ 123)`.
+You can also use the irregular `` ` `` syntax for casting in the same way as `^-`; e.g., `` `@`123 `` for `^-(@ 123)`.
 
 One thing to note about casts is that they can 'throw away' type information.  The second subexpression of `^-` and `^+` casts may be inferred to have a very specific type.  If the cast type is more general, then the more specific type information is lost.  Consider the literal `[12 14]`.  The inferred type of this expression is `[@ @]`, i.e., a cell of two atoms.  If we cast over `[12 14]` with `^-(^ [12 14])` then the inferred type is just `^`, the set of all cells.  The information about what kind of cell it is has been thrown away.  If we cast over `[12 14]` with `^-(* [12 14])` then the inferred type is `*`, the set of all nouns.  All interesting type information is thrown away on the latter cast.
 

--- a/reference/hoon-expressions/rune/zap.md
+++ b/reference/hoon-expressions/rune/zap.md
@@ -25,7 +25,7 @@ In Hoon, a dynamic type is a static type compiled at runtime.  This type-noun ce
 
 ```
 > !>(1)
-[p=#t/@ud q=1]
+[#t/@ud q=1]
 ```
 
 If you want just the type value, use a 'type spear'.  This is `-:!>`, i.e., the head of the cell produced by `!>`:

--- a/using/sail-and-udon.md
+++ b/using/sail-and-udon.md
@@ -1053,15 +1053,11 @@ bug.
 
 #### Inline Code Literal
 
-Enclosing some text in
-```
-`
-```
-characters will cause it to be displayed as code,
+Enclosing some text in `` ` `` characters will cause it to be displayed as code,
 inside a `<code>` HTML element with monospace font and highlighted with a
 different background color.
 
-Using `` ` \`` is useful when you want to designated only part of a line as code.
+Using `` ` `` is useful when you want to designated only part of a line as code.
 Since this page is written in Udon, we've been using this operation
 throughout this guide to `format text` to distinguish code from prose.
 
@@ -1097,16 +1093,14 @@ Most of our examples so far have used.
 **Example:**
 
 
-```
-  ```
-  (def Y (fn [f]
-         ((fn [x]
-            (x x))
-          (fn [x]
-            (f (fn [y]
-                 ((x x) y)))))))
-  ```
-```
+    ```
+    (def Y (fn [f]
+           ((fn [x]
+              (x x))
+            (fn [x]
+              (f (fn [y]
+                   ((x x) y)))))))
+    ```
 
 **Produces:**
 


### PR DESCRIPTION
https://meta.stackexchange.com/questions/82718/how-do-i-escape-a-backtick-within-in-line-code-in-markdown