### PR TITLE
Amending all mentions of Clay auto-sync to Unix

### DIFF
--- a/getting-started/booting-a-ship.md
+++ b/getting-started/booting-a-ship.md
@@ -84,7 +84,7 @@ This should produce:
 
 which indicates that the command was processed.
 
-`|mount %` will cause a `home/` directory to appear inside your _pier_ folder in Unix (the "pier" is our shorthand for the directory whose name corresponds to your Azimuth point). Changes to these files are automatically synced into your ship.
+`|mount %` will cause a `home/` directory to appear inside your _pier_ folder in Unix (the "pier" is our shorthand for the directory whose name corresponds to your Azimuth point). Once you've changed a file, `|commit %home` to synchronize changes to your pier.
 
 **Note: Do not, under any circumstances, delete your pier. If your pier is deleted, your ship cannot be recovered until the Arvo network is reset ("breached") -- a rare occasion.**
 

--- a/learn/arvo/clay.md
+++ b/learn/arvo/clay.md
@@ -325,7 +325,7 @@ and this will mount the given clay directory to the mount-point
 directory in Unix. Every file is converted to `%mime` before it's
 written to Unix, and converted back when read from Unix. The
 entire directory is watched (a la Dropbox), and every change is
-auto-committed to clay.
+committed once you run `|commit %mount-point`.
 
 ### Merging
 

--- a/reference/glossary.md
+++ b/reference/glossary.md
@@ -94,8 +94,7 @@ Below are Arvo modules, which are called "vanes".
   to Unix and vice versa.
 
   A common way to use it is to create a pier, a directory that exists in and is
-  visible in Unix. Changes are automatically recorded from Urbit to the Unix
-  directory, and vice versa. Just set it and forget it!
+  visible in Unix.
 
   Clay is located at `/home/sys/vane/clay.hoon` within your urbit.
 

--- a/using/creating-a-development-ship.md
+++ b/using/creating-a-development-ship.md
@@ -56,7 +56,7 @@ This should produce:
 
 which indicates that the command was processed.
 
-`|mount %` will cause a `home/` directory to appear inside your _pier_ folder in Unix (the "pier" is our shorthand for the directory whose name corresponds to your Azimuth point). Changes to these files are automatically synced into your ship.
+`|mount %` will cause a `home/` directory to appear inside your _pier_ folder in Unix (the "pier" is our shorthand for the directory whose name corresponds to your Azimuth point). Changes to these files can be committed to your pier by running `|commit %home` once you're done.
 
 ### Shutting Down and Restarting
 

--- a/using/filesystem.md
+++ b/using/filesystem.md
@@ -5,11 +5,9 @@ template = "doc.html"
 +++
 Urbit has its own revision-controlled filesystem, Clay. Clay is a typed, global,
 referentially transparent namespace. An easy way to think about it is like typed
-`git` with continuous sync.
+`git`.
 
-The most common way to use Clay is to mount a Clay node in a Unix directory. The
-Urbit process will watch this directory and automatically record edits as
-changes, Dropbox style. The mounted directory is always at the root of your
+The most common way to use Clay is to mount a Clay node in a Unix directory. The mounted directory is always at the root of your
 pier directory.
 
 ## Quickstart


### PR DESCRIPTION
We use `|commit %mount-point` now, so I found every mention of the Clay / Unix auto-sync that refers to 0.7.4 behaviour, and amended it with mentions of the current behaviour.