### PR TITLE
Fix typo in setup.md

### DIFF
--- a/learn/hoon/hoon-tutorial/setup.md
+++ b/learn/hoon/hoon-tutorial/setup.md
@@ -65,7 +65,7 @@ You asked dojo to evaluate `17` and it echoed the number back at you.  This valu
 
 Generators are the most straightforward way to write Hoon programs. They are a concept in Arvo, and involve saving Hoon code in a `.hoon` text file. While they aren't strictly part of the Hoon language, we'll be dealing with generators throughout this tutorial.
 
-The simplest type of generator is the **naked generator**. All naked generators are `gates`: functions that take an argument and produce an output. So, to create a generator, all you need to do is write a `gate` and put it into a file in the `/home/gen` directory of your ship as a `.hoon` file. To run a generator named `mygen.hoon`, you would type `+myhoon <argument>` in your ship's Dojo.
+The simplest type of generator is the **naked generator**. All naked generators are `gates`: functions that take an argument and produce an output. So, to create a generator, all you need to do is write a `gate` and put it into a file in the `/home/gen` directory of your ship as a `.hoon` file. To run a generator named `mygen.hoon`, you would type `+mygen <argument>` in your ship's Dojo.
 
 If this doesn't make sense yet, that's okay. In the [next lesson](../list-of-numbers), we will walk you through an example `gate` that is run as a generator.
 


### PR DESCRIPTION
The docs say to run a generator `mygen.hoon` you need to type `+myhoon <argument>` in the Dojo, but if I'm not mistaken it should be `+mygen <argument>`