### PR TITLE
Add summaries and metadata to the entire standard library list

### DIFF
--- a/reference/library/_index.md
+++ b/reference/library/_index.md
@@ -13,1718 +13,1718 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### a
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ab' title="Primitive parser engine"><code>++ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#abs-fl' title="Absolute value"><code>++abs:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#abs-si' title="Absolute value (signed integer)"><code>++abs:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#abel' title="Compiler alias"><code>++abel</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ace' title="Parse space"><code>++ace</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#add' title="Add"><code>++add</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-ff' title="Add (floating point)"><code>++add:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-fl' title="Add (with exact/rounded flag)"><code>++add:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#add-ja' title="Prepend to list"><code>+-add:ja</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rd' title="Add (double-precision float)"><code>++add:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rh' title="Add (half-precision float)"><code>++add:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rs' title="Add (single-precision float)"><code>++add:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rq' title="Add (quad-precision float)"><code>++add:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ag' title="Top-level atom parser engine"><code>++ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#alf' title="Parse alphabetic characters"><code>++alf</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#all-by' title="Logical AND (map and wet gate)"><code>+-all:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#all-in' title="Logical AND (set and wet gate)"><code>+-all:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#aln' title="Parse alphanumeric characters"><code>++aln</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#alp' title="Parse alphanumeric characters and -"><code>++alp</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#any-by' title="Logical OR (map and wet gate)"><code>+-any:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#any-in' title="Logical OR (set and gate)"><code>+-any:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#aor' title="Alphabetical order"><code>++aor</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ape-ag' title="Parse 0 or rule"><code>++ape:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#apt-by' title="Check correctness (map)"><code>+-apt:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#apt-in' title="Check correctness (set)"><code>+-apt:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#at' title="(Undocumented)"><code>++at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#aura' title="'Type' of atom"><code>++aura</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#axis' title="Nock axis"><code>++axis</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#ab' title="Primitive parser engine"><code>++ab</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#abs-fl' title="Absolute value"><code>++abs:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#abs-si' title="Absolute value (signed integer)"><code>++abs:si</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#abel' title="Compiler alias"><code>++abel</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#ace' title="Parse space"><code>++ace</code></a>
+<a class="tooltip" href='/docs/reference/library/1a/#add' title="Add"><code>++add</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#add-ff' title="Add (floating point)"><code>++add:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#add-fl' title="Add (with exact/rounded flag)"><code>++add:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/2j/#add-ja' title="Prepend to list"><code>+-add:ja</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#add-rd' title="Add (double-precision float)"><code>++add:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#add-rh' title="Add (half-precision float)"><code>++add:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#add-rs' title="Add (single-precision float)"><code>++add:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#add-rq' title="Add (quad-precision float)"><code>++add:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#ag' title="Top-level atom parser engine"><code>++ag</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#alf' title="Parse alphabetic characters"><code>++alf</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#all-by' title="Logical AND (map and wet gate)"><code>+-all:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#all-in' title="Logical AND (set and wet gate)"><code>+-all:in</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#aln' title="Parse alphanumeric characters"><code>++aln</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#alp' title="Parse alphanumeric characters and -"><code>++alp</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#any-by' title="Logical OR (map and wet gate)"><code>+-any:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#any-in' title="Logical OR (set and gate)"><code>+-any:in</code></a>
+<a class="tooltip" href='/docs/reference/library/2f/#aor' title="Alphabetical order"><code>++aor</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#ape-ag' title="Parse 0 or rule"><code>++ape:ag</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#apt-by' title="Check correctness (map)"><code>+-apt:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#apt-in' title="Check correctness (set)"><code>+-apt:in</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#at' title="(Undocumented)"><code>++at</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#aura' title="'Type' of atom"><code>++aura</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#axis' title="Nock axis"><code>++axis</code></a>
 
 ### b
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#bal-to' title="Balance queue"><code>+-bal:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#bar' title="Parse | (bar)"><code>++bar</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#bas' title="Parse \ (bas)"><code>++bas</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#base' title="Base type"><code>++base</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#bass' title="Parser modifier (LSB-ordered ++list as atom of ++base)"><code>++bass</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#bay-ag' title="Parses binary number"><code>++bay:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#bean' title="Boolean"><code>++bean</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#beer' title="Tape builder"><code>++beer</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#beet' title="XML interpolation cases"><code>++beet</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#bend' title="Conditional composer"><code>++bend</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#bet' title="Parse hep and lus axis syntax"><code>++bet</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#bex' title="Binary exponent"><code>++bex</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bif-ff' title="Converts from fn to @r"><code>++bif:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#bif-by' title="Bifurcate map"><code>+-bif:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#bif-in' title="Bifurcate set"><code>+-bif:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#biff' title="Unit as argument"><code>++biff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#bin' title="Binary to atom"><code>++bin</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#bind' title="Non-unit function to unit, producing unit"><code>++bind</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#bip-ag' title="Parse IPv6"><code>++bip:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-ff' title="fn to @r with rounding"><code>++bit:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rd' title="fn to double-precision binary float"><code>++bit:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rh' title="fn to half-precision float"><code>++bit:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rs' title="fn to single-precision float"><code>++bit:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rq' title="fn to quad-precision float"><code>++bit:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#bix-ab' title="Parse hex pair"><code>++bix:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#bisk-so' title="Parse odor-atom pair"><code>++bisk:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#bloq' title="Blocksize"><code>++bloq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#bond' title="Replace null"><code>++bond</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#boss' title="Parser modifier: LSB"><code>++boss</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#both' title="Group unit values into pair"><code>++both</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#buc' title="Parse $ (buc)"><code>++buc</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#but' title="Parse binary digit"><code>++but</code></a>
+<a class="tooltip" href='/docs/reference/library/2k/#bal-to' title="Balance queue"><code>+-bal:to</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#bar' title="Parse | (bar)"><code>++bar</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#bas' title="Parse \ (bas)"><code>++bas</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#base' title="Base type"><code>++base</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#bass' title="Parser modifier (LSB-ordered ++list as atom of ++base)"><code>++bass</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#bay-ag' title="Parses binary number"><code>++bay:ag</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#bean' title="Boolean"><code>++bean</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#beer' title="Tape builder"><code>++beer</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#beet' title="XML interpolation cases"><code>++beet</code></a>
+<a class="tooltip" href='/docs/reference/library/4e/#bend' title="Conditional composer"><code>++bend</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#bet' title="Parse hep and lus axis syntax"><code>++bet</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#bex' title="Binary exponent"><code>++bex</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#bif-ff' title="Converts from fn to @r"><code>++bif:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#bif-by' title="Bifurcate map"><code>+-bif:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#bif-in' title="Bifurcate set"><code>+-bif:in</code></a>
+<a class="tooltip" href='/docs/reference/library/2a/#biff' title="Unit as argument"><code>++biff</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#bin' title="Binary to atom"><code>++bin</code></a>
+<a class="tooltip" href='/docs/reference/library/2a/#bind' title="Non-unit function to unit, producing unit"><code>++bind</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#bip-ag' title="Parse IPv6"><code>++bip:ag</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#bit-ff' title="fn to @r with rounding"><code>++bit:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#bit-rd' title="fn to double-precision binary float"><code>++bit:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#bit-rh' title="fn to half-precision float"><code>++bit:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#bit-rs' title="fn to single-precision float"><code>++bit:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#bit-rq' title="fn to quad-precision float"><code>++bit:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#bix-ab' title="Parse hex pair"><code>++bix:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#bisk-so' title="Parse odor-atom pair"><code>++bisk:so</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#bloq' title="Blocksize"><code>++bloq</code></a>
+<a class="tooltip" href='/docs/reference/library/2a/#bond' title="Replace null"><code>++bond</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#boss' title="Parser modifier: LSB"><code>++boss</code></a>
+<a class="tooltip" href='/docs/reference/library/2a/#both' title="Group unit values into pair"><code>++both</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#buc' title="Parse $ (buc)"><code>++buc</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#but' title="Parse binary digit"><code>++but</code></a>
 
 ### c
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#cab' title="Parse _ (cab)"><code>++cab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#can' title="Assemble"><code>++can</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#cap' title="Tree head"><code>++cap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#cass' title="To lowercase"><code>++cass</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#cat' title="Concatenate"><code>++cat</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#cen' title="Parse % (cen)"><code>++cen</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#cet-yo' title="Days in a century"><code>++cet:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#char' title="Character"><code>++char</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#chum' title="Jet hint information"><code>++chum</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#cit' title="Octal digit"><code>++cit</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#clap' title="Apply function to two units"><code>++clap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#cmp-si' title="Compare (signed integer)"><code>++cmp:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#co' title="Literal rendering engine"><code>++co</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#coil' title="Tuple of core information"><code>++coil</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#coin' title="Noun-literal syntax cases"><code>++coin</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#col' title="Parse : (col)"><code>++col</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#cold' title="Replace with constant"><code>++cold</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#com' title="Parse , (com)"><code>++com</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#comp' title="Arbitrary compose"><code>++comp</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#con' title="Binary OR"><code>++con</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#cook' title="Apply gate"><code>++cook</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#cord' title="UTF-8 text"><code>++cord</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#cork' title="Compose forward"><code>++cork</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#corl' title="Compose backward"><code>++corl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#crip' title="Tape to cord"><code>++crip</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#crub-so' title="Parse @da, @dr, @p, @t"><code>++crub:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#cue' title="Unpack atom to noun"><code>++cue</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#curr' title="Right-curry a gate"><code>++curr</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#cury' title="Curry left a gate"><code>++cury</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#cuss' title="To uppercase"><code>++cuss</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#cut' title="Slice"><code>++cut</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#cab' title="Parse _ (cab)"><code>++cab</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#can' title="Assemble"><code>++can</code></a>
+<a class="tooltip" href='/docs/reference/library/1b/#cap' title="Tree head"><code>++cap</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#cass' title="To lowercase"><code>++cass</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#cat' title="Concatenate"><code>++cat</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#cen' title="Parse % (cen)"><code>++cen</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#cet-yo' title="Days in a century"><code>++cet:yo</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#char' title="Character"><code>++char</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#chum' title="Jet hint information"><code>++chum</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#cit' title="Octal digit"><code>++cit</code></a>
+<a class="tooltip" href='/docs/reference/library/2a/#clap' title="Apply function to two units"><code>++clap</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#cmp-si' title="Compare (signed integer)"><code>++cmp:si</code></a>
+<a class="tooltip" href='/docs/reference/library/4k/#co' title="Literal rendering engine"><code>++co</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#coil' title="Tuple of core information"><code>++coil</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#coin' title="Noun-literal syntax cases"><code>++coin</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#col' title="Parse : (col)"><code>++col</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#cold' title="Replace with constant"><code>++cold</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#com' title="Parse , (com)"><code>++com</code></a>
+<a class="tooltip" href='/docs/reference/library/4e/#comp' title="Arbitrary compose"><code>++comp</code></a>
+<a class="tooltip" href='/docs/reference/library/2d/#con' title="Binary OR"><code>++con</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#cook' title="Apply gate"><code>++cook</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#cord' title="UTF-8 text"><code>++cord</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#cork' title="Compose forward"><code>++cork</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#corl' title="Compose backward"><code>++corl</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#crip' title="Tape to cord"><code>++crip</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#crub-so' title="Parse @da, @dr, @p, @t"><code>++crub:so</code></a>
+<a class="tooltip" href='/docs/reference/library/2p/#cue' title="Unpack atom to noun"><code>++cue</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#curr' title="Right-curry a gate"><code>++curr</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#cury' title="Curry left a gate"><code>++cury</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#cuss' title="To uppercase"><code>++cuss</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#cut' title="Slice"><code>++cut</code></a>
 
 ### d
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#d-ne' title="Render decimal"><code>++d:ne</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#date' title="Point in time"><code>++date</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#day-yo' title="Seconds in day"><code>++day:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#dec' title="Decrement"><code>++dec</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#def-by' title="Difference (map)"><code>+-def:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#del-by' title="Delete (map)"><code>+-del:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#del-in' title="Delete (set)"><code>+-del:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#del-ju' title="Delete (jug)"><code>+-del:ju</code></a>
-    <a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dem' title="Decimal to atom"><code>++dem</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dem-ag' title="Parse decmal with dots"><code>++dem:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#den-fl' title="Denormalizes (floating point)"><code>++den:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#dep-by' title="Difference as patch (map)"><code>+-dep:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#dep-to' title="Maximum depth (queue)"><code>+-dep:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#dif-fe' title="Difference between atoms (modular basis)"><code>++dif:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dif-fo' title='Subtraction (modular base)'><code>++dif:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#dif-in' title='Difference (set)'><code>+-dif:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dif-si' title="Subtraction (signed integer)"><code>++dif:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#dig-by' title="Address of key (map)"><code>+-dig:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#dig-in' title="Address of a in set"><code>+-dig:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dim-ag' title="Parse decimal number"><code>++dim:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#dime' title="Aura-atom pair"><code>++dime</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#din-re' title="(Undocumented)"><code>++din:re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#dis' title="Binary AND (atoms)"><code>++dis</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dit' title="Decimal digit"><code>++dit</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#div' title="Divide"><code>++div</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-ff' title="Divide (IEEE float)"><code>++div:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-fl' title="Divide (signed and unsigned integer cell)"><code>++div:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rd' title="Double precision float"><code>++div:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rh' title="Divide (half-precision float)"><code>++div:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rs' title="Divide (single-precision float)"><code>++div:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rq' title="Divide (quad-precision float)"><code>++div:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dog' title="Optional gap"><code>++dog</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#doh' title="@p separator"><code>++doh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#doq' title="Parse double quote"><code>++doq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#dor' title="Numeric order"><code>++dor</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#dot' title="Parse period"><code>++dot</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-ff' title="@r to decimal float"><code>++drg:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-fl' title="Get printable decimal (signed and unsigned integer cell)"><code>++drg:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rd' title="@rd to decimal float"><code>++drg:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rh' title="@rh to decimal float"><code>++drg:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rs' title="@rs to decimal float"><code>++drg:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rq' title="@rq to decimal float"><code>++drg:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#drop' title="Unit to list"><code>++drop</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dul-si' title="Modulus (signed integer)"><code>++dul:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dum-ag' title="Parse decimal with leading zero"><code>++dum:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dun' title="-- to ~"><code>++dun</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#duz' title="== to ~"><code>++duz</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#dvr' title="Divide (with remainder)"><code>++dvr</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#d-ne' title="Render decimal"><code>++d:ne</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#date' title="Point in time"><code>++date</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#day-yo' title="Seconds in day"><code>++day:yo</code></a>
+<a class="tooltip" href='/docs/reference/library/1a/#dec' title="Decrement"><code>++dec</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#def-by' title="Difference (map)"><code>+-def:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#del-by' title="Delete (map)"><code>+-del:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#del-in' title="Delete (set)"><code>+-del:in</code></a>
+<a class="tooltip" href='/docs/reference/library/2j/#del-ju' title="Delete (jug)"><code>+-del:ju</code></a>
+    <a class="tooltip" href='/docs/reference/library/4i/#dem' title="Decimal to atom"><code>++dem</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#dem-ag' title="Parse decmal with dots"><code>++dem:ag</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#den-fl' title="Denormalizes (floating point)"><code>++den:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#dep-by' title="Difference as patch (map)"><code>+-dep:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2k/#dep-to' title="Maximum depth (queue)"><code>+-dep:to</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#dif-fe' title="Difference between atoms (modular basis)"><code>++dif:fe</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#dif-fo' title='Subtraction (modular base)'><code>++dif:fo</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#dif-in' title='Difference (set)'><code>+-dif:in</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#dif-si' title="Subtraction (signed integer)"><code>++dif:si</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#dig-by' title="Address of key (map)"><code>+-dig:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#dig-in' title="Address of a in set"><code>+-dig:in</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#dim-ag' title="Parse decimal number"><code>++dim:ag</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#dime' title="Aura-atom pair"><code>++dime</code></a>
+<a class="tooltip" href='/docs/reference/library/4c/#din-re' title="(Undocumented)"><code>++din:re</code></a>
+<a class="tooltip" href='/docs/reference/library/2d/#dis' title="Binary AND (atoms)"><code>++dis</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#dit' title="Decimal digit"><code>++dit</code></a>
+<a class="tooltip" href='/docs/reference/library/1a/#div' title="Divide"><code>++div</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#div-ff' title="Divide (IEEE float)"><code>++div:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#div-fl' title="Divide (signed and unsigned integer cell)"><code>++div:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#div-rd' title="Double precision float"><code>++div:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#div-rh' title="Divide (half-precision float)"><code>++div:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#div-rs' title="Divide (single-precision float)"><code>++div:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#div-rq' title="Divide (quad-precision float)"><code>++div:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#dog' title="Optional gap"><code>++dog</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#doh' title="@p separator"><code>++doh</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#doq' title="Parse double quote"><code>++doq</code></a>
+<a class="tooltip" href='/docs/reference/library/2f/#dor' title="Numeric order"><code>++dor</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#dot' title="Parse period"><code>++dot</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#drg-ff' title="@r to decimal float"><code>++drg:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#drg-fl' title="Get printable decimal (signed and unsigned integer cell)"><code>++drg:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#drg-rd' title="@rd to decimal float"><code>++drg:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#drg-rh' title="@rh to decimal float"><code>++drg:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#drg-rs' title="@rs to decimal float"><code>++drg:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#drg-rq' title="@rq to decimal float"><code>++drg:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/2a/#drop' title="Unit to list"><code>++drop</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#dul-si' title="Modulus (signed integer)"><code>++dul:si</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#dum-ag' title="Parse decimal with leading zero"><code>++dum:ag</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#dun' title="-- to ~"><code>++dun</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#duz' title="== to ~"><code>++duz</code></a>
+<a class="tooltip" href='/docs/reference/library/1a/#dvr' title="Divide (with remainder)"><code>++dvr</code></a>
 
 ### e
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ead-fl' title="Exact add"><code>++ead:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#each' title="Mold of fork between two types"><code>++each</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#easy' title="Always parse"><code>++easy</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#edge' title="Parsing location metadata"><code>++edge</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#egcd' title="Extended Euclidean algorithm"><code>++egcd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emn-fl' title="Minimum exponent"><code>++emn:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emu-fl' title="Exact multiply"><code>++emu:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emx-fl' title="Maximum exponent"><code>++emx:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#end' title="Tail"><code>++end</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-ff' title="Equals (IEEE float)"><code>++equ:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-fl' title="Equals (signed and unsigned integer cell)"><code>++equ:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rd' title="Equals (double-precision float)"><code>++equ:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rh' title="Equals (half-precision float)"><code>++equ:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rs' title="Equals (single-precision float)"><code>++equ:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rq' title="Equals (quad-precision float)"><code>++equ:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#era-yo' title="Leap-year period"><code>++era:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-ff' title="Get exponent (IEEE float)"><code>++exp:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#exp-fo' title="Exponent (modular base)"><code>++exp:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rd' title="Exponent (@rd)"><code>++exp:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rh' title="Exponent (half-precision float)"><code>++exp:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rs' title="Exponent (@rs)"><code>++exp:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rq' title="Exponent (quad-precision float)"><code>++exp:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#ead-fl' title="Exact add"><code>++ead:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#each' title="Mold of fork between two types"><code>++each</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#easy' title="Always parse"><code>++easy</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#edge' title="Parsing location metadata"><code>++edge</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#egcd' title="Extended Euclidean algorithm"><code>++egcd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#emn-fl' title="Minimum exponent"><code>++emn:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#emu-fl' title="Exact multiply"><code>++emu:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#emx-fl' title="Maximum exponent"><code>++emx:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#end' title="Tail"><code>++end</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#equ-ff' title="Equals (IEEE float)"><code>++equ:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#equ-fl' title="Equals (signed and unsigned integer cell)"><code>++equ:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#equ-rd' title="Equals (double-precision float)"><code>++equ:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#equ-rh' title="Equals (half-precision float)"><code>++equ:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#equ-rs' title="Equals (single-precision float)"><code>++equ:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#equ-rq' title="Equals (quad-precision float)"><code>++equ:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#era-yo' title="Leap-year period"><code>++era:yo</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#exp-ff' title="Get exponent (IEEE float)"><code>++exp:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#exp-fo' title="Exponent (modular base)"><code>++exp:fo</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#exp-rd' title="Exponent (@rd)"><code>++exp:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#exp-rh' title="Exponent (half-precision float)"><code>++exp:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#exp-rs' title="Exponent (@rs)"><code>++exp:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#exp-rq' title="Exponent (quad-precision float)"><code>++exp:rq</code></a>
 
 ### f
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#fail' title="Never parse"><code>++fail</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#fall' title="Give unit a default value"><code>++fall</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#fand' title="All indices in list"><code>++fand</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#fas' title="Parse / (fas)"><code>++fas</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#fe' title="Modulo bloq"><code>++fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#fed-ag' title="Parse @p"><code>++fed:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#feen-ob' title="Conceal structure v2"><code>++feen:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#fend-ob' title="Restore structure v2"><code>++fend:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#fice-ob' title="Feistel-like cipher"><code>++fice:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#fil' title="Fill bloqstream"><code>++fil</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#find' title="First index in list"><code>++find</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#fit-re' title="Fit on one line test"><code>++fit:re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fli-fl' title="Flip sign"><code>++fli:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#flop' title="Reverse list"><code>++flop</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-ff' title="Fused multiply-add (IEEE float)"><code>++fma:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-fl' title="Fused multiply-add"><code>++fma:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rd' title="Fused multiply-add (@rd)"><code>++fma:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rh' title="Fused multiply-add (half-precision float)"><code>++fma:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rs' title="Fused multiply-add (single-precision float)"><code>++fma:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rq' title="Fused multiply-add (quad-precision float)"><code>++fma:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#fnv' title="FNV scrambler"><code>++fnv</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fo' title="Modulo prime"><code>++fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#foot' title="Cases of arms by variance model"><code>++foot</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fos-rh' title="@rs to @rh"><code>++fos:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fra-fo' title="Divide (modular base)"><code>++fra:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fra-si' title="Divide (signed integer)"><code>++fra:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#full' title="Parse to end"><code>++full</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#funk' title="Add to tape"><code>++funk</code></a>
+<a class="tooltip" href='/docs/reference/library/4e/#fail' title="Never parse"><code>++fail</code></a>
+<a class="tooltip" href='/docs/reference/library/2a/#fall' title="Give unit a default value"><code>++fall</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#fand' title="All indices in list"><code>++fand</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#fas' title="Parse / (fas)"><code>++fas</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#fe' title="Modulo bloq"><code>++fe</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#fed-ag' title="Parse @p"><code>++fed:ag</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#feen-ob' title="Conceal structure v2"><code>++feen:ob</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#fend-ob' title="Restore structure v2"><code>++fend:ob</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#fice-ob' title="Feistel-like cipher"><code>++fice:ob</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#fil' title="Fill bloqstream"><code>++fil</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#find' title="First index in list"><code>++find</code></a>
+<a class="tooltip" href='/docs/reference/library/4c/#fit-re' title="Fit on one line test"><code>++fit:re</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#fli-fl' title="Flip sign"><code>++fli:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#flop' title="Reverse list"><code>++flop</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#fma-ff' title="Fused multiply-add (IEEE float)"><code>++fma:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#fma-fl' title="Fused multiply-add"><code>++fma:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#fma-rd' title="Fused multiply-add (@rd)"><code>++fma:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#fma-rh' title="Fused multiply-add (half-precision float)"><code>++fma:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#fma-rs' title="Fused multiply-add (single-precision float)"><code>++fma:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#fma-rq' title="Fused multiply-add (quad-precision float)"><code>++fma:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/2e/#fnv' title="FNV scrambler"><code>++fnv</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#fo' title="Modulo prime"><code>++fo</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#foot' title="Cases of arms by variance model"><code>++foot</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#fos-rh' title="@rs to @rh"><code>++fos:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#fra-fo' title="Divide (modular base)"><code>++fra:fo</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#fra-si' title="Divide (signed integer)"><code>++fra:si</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#full' title="Parse to end"><code>++full</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#funk' title="Add to tape"><code>++funk</code></a>
 
 ### g
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gah' title="New line or ''"><code>++gah</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#gal' title="Parse < (gal)"><code>++gal</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gap' title="Plural whitespace"><code>++gap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gaq' title="End of line"><code>++gaq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#gar' title="Parse > (gar)"><code>++gar</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#gas-by' title="Concatenate (map)"><code>+-gas:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#gas-in' title="Concatenate (set)"><code>+-gas:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#gas-to' title="Push list into queue"><code>+-gas:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#gate' title="Function"><code>++gate</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gaw' title="Classic whitespace"><code>++gaw</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gay' title="Optional gap"><code>++gay</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#get-by' title="Grab unit value"><code>+-get:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#get-ja' title="Grab value by key"><code>+-get:ja</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#get-ju' title="Retrieve set"><code>+-get:ju</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#get-to' title="Head-tail pair"><code>+-get:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#glue' title="Skip delimiter"><code>++glue</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gon' title="Parse long numbers"><code>++gon</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#gor' title="Hash order"><code>++gor</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#got-by' title="Assert for value (map)"><code>+-got:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-ff' title="Decimal float to @r"><code>++grd:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-fl' title="Decimal to float"><code>++grd:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rd' title="Decimal float to @rd"><code>++grd:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rh' title="Decimal float to @rh"><code>++grd:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rs' title="Decimal float to @rs"><code>++grd:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rq' title="Decimal float to @rq"><code>++grd:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#gte' title="Greater than / equal"><code>++gte</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-ff' title="Greater than / equal (IEEE float)"><code>++gte:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-fl' title="Greater than / equal (producing flag)"><code>++gte:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rd' title="Greater than / equal (double-precision float)"><code>++gte:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rh' title="Greater than / equal (half-precision float)"><code>++gte:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rs' title="Greater than / equal (single-precision float)"><code>++gte:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rq' title="Greater than / equal (quad-precision float)"><code>++gte:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#gth' title="Greater than"><code>++gth</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-ff' title="Greater than (IEEE float)"><code>++gth:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-fl' title="Greater than (producing flag)"><code>++gth:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rd' title="Greater than (double-precision float)"><code>++gth:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rh' title="Greater than (half-precision float)"><code>++gth:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rs' title="Greater than (single-precision float)"><code>++gth:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rq' title="Greater than (quad-precision float)"><code>++gth:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gul' title="Axis syntax < or >"><code>++gul</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#gulf' title="List from range"><code>++gulf</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#gah' title="New line or ''"><code>++gah</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#gal' title="Parse < (gal)"><code>++gal</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#gap' title="Plural whitespace"><code>++gap</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#gaq' title="End of line"><code>++gaq</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#gar' title="Parse > (gar)"><code>++gar</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#gas-by' title="Concatenate (map)"><code>+-gas:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#gas-in' title="Concatenate (set)"><code>+-gas:in</code></a>
+<a class="tooltip" href='/docs/reference/library/2k/#gas-to' title="Push list into queue"><code>+-gas:to</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#gate' title="Function"><code>++gate</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#gaw' title="Classic whitespace"><code>++gaw</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#gay' title="Optional gap"><code>++gay</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#get-by' title="Grab unit value"><code>+-get:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2j/#get-ja' title="Grab value by key"><code>+-get:ja</code></a>
+<a class="tooltip" href='/docs/reference/library/2j/#get-ju' title="Retrieve set"><code>+-get:ju</code></a>
+<a class="tooltip" href='/docs/reference/library/2k/#get-to' title="Head-tail pair"><code>+-get:to</code></a>
+<a class="tooltip" href='/docs/reference/library/4e/#glue' title="Skip delimiter"><code>++glue</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#gon' title="Parse long numbers"><code>++gon</code></a>
+<a class="tooltip" href='/docs/reference/library/2f/#gor' title="Hash order"><code>++gor</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#got-by' title="Assert for value (map)"><code>+-got:by</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#grd-ff' title="Decimal float to @r"><code>++grd:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#grd-fl' title="Decimal to float"><code>++grd:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#grd-rd' title="Decimal float to @rd"><code>++grd:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#grd-rh' title="Decimal float to @rh"><code>++grd:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#grd-rs' title="Decimal float to @rs"><code>++grd:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#grd-rq' title="Decimal float to @rq"><code>++grd:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/1a/#gte' title="Greater than / equal"><code>++gte</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#gte-ff' title="Greater than / equal (IEEE float)"><code>++gte:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#gte-fl' title="Greater than / equal (producing flag)"><code>++gte:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#gte-rd' title="Greater than / equal (double-precision float)"><code>++gte:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#gte-rh' title="Greater than / equal (half-precision float)"><code>++gte:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#gte-rs' title="Greater than / equal (single-precision float)"><code>++gte:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#gte-rq' title="Greater than / equal (quad-precision float)"><code>++gte:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/1a/#gth' title="Greater than"><code>++gth</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#gth-ff' title="Greater than (IEEE float)"><code>++gth:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#gth-fl' title="Greater than (producing flag)"><code>++gth:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#gth-rd' title="Greater than (double-precision float)"><code>++gth:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#gth-rh' title="Greater than (half-precision float)"><code>++gth:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#gth-rs' title="Greater than (single-precision float)"><code>++gth:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#gth-rq' title="Greater than (quad-precision float)"><code>++gth:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#gul' title="Axis syntax < or >"><code>++gul</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#gulf' title="List from range"><code>++gulf</code></a>
 
 ### h
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#hair' title="Parsing line and column"><code>++hair</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#hard' title="Force remold"><code>++hard</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#has-by' title="Key existence check (map)"><code>+-has:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#has-in' title="Key existence check (set)"><code>+-has:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#has-ju' title="Check contents (jug)"><code>+-has:ju</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#hax' title="Parse # (hax)"><code>++hax</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#head' title="Get head of cell"><code>++head</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#here' title="Place-based apply"><code>++here</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#hep' title="Parse - (hep)"><code>++hep</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hex' title="Hexadecimal to atom"><code>++hex</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hex-ag' title="Parse hexadecimal number"><code>++hex:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hif-ab' title="Parse phonetic pair"><code>++hif:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hig' title="Parse single uppercase letter"><code>++hig</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hit' title="Parse single hexadecimal digit"><code>++hit</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#homo' title="Homogenize list"><code>++homo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#hor' title="Horizontal hash order"><code>++hor</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#hor-yo' title="Seconds in hour"><code>++hor:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#huf-ab' title="Parse two phonetic pairs"><code>++huf:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hyf-ab' title="Parse 8 phonetic bytes"><code>++hyf:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#hair' title="Parsing line and column"><code>++hair</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#hard' title="Force remold"><code>++hard</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#has-by' title="Key existence check (map)"><code>+-has:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#has-in' title="Key existence check (set)"><code>+-has:in</code></a>
+<a class="tooltip" href='/docs/reference/library/2j/#has-ju' title="Check contents (jug)"><code>+-has:ju</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#hax' title="Parse # (hax)"><code>++hax</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#head' title="Get head of cell"><code>++head</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#here' title="Place-based apply"><code>++here</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#hep' title="Parse - (hep)"><code>++hep</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#hex' title="Hexadecimal to atom"><code>++hex</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#hex-ag' title="Parse hexadecimal number"><code>++hex:ag</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#hif-ab' title="Parse phonetic pair"><code>++hif:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#hig' title="Parse single uppercase letter"><code>++hig</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#hit' title="Parse single hexadecimal digit"><code>++hit</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#homo' title="Homogenize list"><code>++homo</code></a>
+<a class="tooltip" href='/docs/reference/library/2f/#hor' title="Horizontal hash order"><code>++hor</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#hor-yo' title="Seconds in hour"><code>++hor:yo</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#huf-ab' title="Parse two phonetic pairs"><code>++huf:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#hyf-ab' title="Parse 8 phonetic bytes"><code>++hyf:ab</code></a>
 
 ### i
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ibl-fl' title="Integer binary logarithm"><code>++ibl:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#ifix' title="Infix"><code>++ifix</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#ind-po' title="Parse suffix"><code>++ind:po</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#ins-po' title="Parse prefix"><code>++ins:po</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#int-by' title="Intersection (map)"><code>+-int:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#int-in' title="Intersection (set)"><code>+-int:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#inv-fe' title="Inverse order of modular field"><code>++inv:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#inv-fl' title="Inverse"><code>++inv:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#inv-fo' title="Inverse (signed modulus)"><code>++inv:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#iny' title="Indentation block"><code>++iny</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#ibl-fl' title="Integer binary logarithm"><code>++ibl:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#ifix' title="Infix"><code>++ifix</code></a>
+<a class="tooltip" href='/docs/reference/library/4a/#ind-po' title="Parse suffix"><code>++ind:po</code></a>
+<a class="tooltip" href='/docs/reference/library/4a/#ins-po' title="Parse prefix"><code>++ins:po</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#int-by' title="Intersection (map)"><code>+-int:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#int-in' title="Intersection (set)"><code>+-int:in</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#inv-fe' title="Inverse order of modular field"><code>++inv:fe</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#inv-fl' title="Inverse"><code>++inv:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#inv-fo' title="Inverse (signed modulus)"><code>++inv:fo</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#iny' title="Indentation block"><code>++iny</code></a>
 
 ### j
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#ja' title="Jar engine"><code>++ja</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#jam' title="Pack noun to atom"><code>++jam</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#jar' title="Mold generator (jar)"><code>++jar</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#jes-yo' title="Maximum 64-bit timestamp"><code>++jes:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#jest' title="Match a cord"><code>++jest</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#ju' title="Jug operations"><code>++ju</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#jug' title="Mold generator (jug)"><code>++jug</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#just' title="Match a single character"><code>++just</code></a>
+<a class="tooltip" href='/docs/reference/library/2j/#ja' title="Jar engine"><code>++ja</code></a>
+<a class="tooltip" href='/docs/reference/library/2p/#jam' title="Pack noun to atom"><code>++jam</code></a>
+<a class="tooltip" href='/docs/reference/library/2o/#jar' title="Mold generator (jar)"><code>++jar</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#jes-yo' title="Maximum 64-bit timestamp"><code>++jes:yo</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#jest' title="Match a cord"><code>++jest</code></a>
+<a class="tooltip" href='/docs/reference/library/2j/#ju' title="Jug operations"><code>++ju</code></a>
+<a class="tooltip" href='/docs/reference/library/2o/#jug' title="Mold generator (jug)"><code>++jug</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#just' title="Match a single character"><code>++just</code></a>
 
 ### k
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#kel' title="Parse { (kel)"><code>++kel</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ker' title="Parse } (ker)"><code>++ker</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ket' title="Parse ^ (ket)"><code>++ket</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#knee' title="Recursive parsers"><code>++knee</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#knot' title="Atom type of ASCII characters"><code>++knot</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#kel' title="Parse { (kel)"><code>++kel</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#ker' title="Parse } (ker)"><code>++ker</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#ket' title="Parse ^ (ket)"><code>++ket</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#knee' title="Recursive parsers"><code>++knee</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#knot' title="Atom type of ASCII characters"><code>++knot</code></a>
 
 ### l
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4d/#last' title="Further trace"><code>++last</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#le-nl' title="Construct list from null-terminated noun"><code>++le:nl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#lent' title="List length"><code>++lent</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#levy' title="Logical AND on list"><code>++levy</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lfe-fl' title="Maximum"><code>++lfe:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lfn-fl' title="Largest normal float"><code>++lfn:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#lien' title="Logical OR on list"><code>++lien</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#lift' title="Curried bind"><code>++lift</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#like' title="Generic edge"><code>++like</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#limb' title="Reference into subject by name/axis"><code>++limb</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#limo' title="Construct list from null-terminated tuple"><code>++limo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#line' title="(Undocumented)"><code>++line</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#lip-ag' title="Parse IPv4 address"><code>++lip:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#list' title="Mold constructor (list)"><code>++list</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#lone' title="Mold generator (face on mold)"><code>++lone</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#lor' title="Leg order"><code>++lor</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#low' title="Parse lowercase letter"><code>++low</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#lsh' title="Left-shift"><code>++lsh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#lte' title="Less than / equal (atom)"><code>++lte</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-ff' title="Less than / equal (IEEE float)"><code>++lte:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-fl' title="Less than / equal (producing flag)"><code>++lte:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rd' title="Less than / equal (double-precision float)"><code>++lte:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rh' title="Less than / equal (half-precision float)"><code>++lte:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rs' title="Less than / equal (single-precision float)"><code>++lte:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rq' title="Less than / equal (quad-precision float)"><code>++lte:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#lth' title="Less than (atom)"><code>++lth</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-ff' title="Less than (IEEE float)"><code>++lth:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-fl' title="Less than (signed and unsigned integer cell)"><code>++lth:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rd' title="Less than (double-precision float)"><code>++lth:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rh' title="Less than (half-precision float)"><code>++lth:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rs' title="Less than (single-precision float)"><code>++lth:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rq' title="Less than (quad-precision float)"><code>++lth:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lug-fl' title="Central rounding mechanism"><code>++lug:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#lus' title="Parse + (lus)"><code>++lus</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4d/#lust' title="Detect new line"><code>++lust</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#less' title="Parse unless"><code>++less</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#ly' title="List from raw noun"><code>++ly</code></a>
+<a class="tooltip" href='/docs/reference/library/4d/#last' title="Further trace"><code>++last</code></a>
+<a class="tooltip" href='/docs/reference/library/2m/#le-nl' title="Construct list from null-terminated noun"><code>++le:nl</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#lent' title="List length"><code>++lent</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#levy' title="Logical AND on list"><code>++levy</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#lfe-fl' title="Maximum"><code>++lfe:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#lfn-fl' title="Largest normal float"><code>++lfn:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#lien' title="Logical OR on list"><code>++lien</code></a>
+<a class="tooltip" href='/docs/reference/library/2a/#lift' title="Curried bind"><code>++lift</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#like' title="Generic edge"><code>++like</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#limb' title="Reference into subject by name/axis"><code>++limb</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#limo' title="Construct list from null-terminated tuple"><code>++limo</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#line' title="(Undocumented)"><code>++line</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#lip-ag' title="Parse IPv4 address"><code>++lip:ag</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#list' title="Mold constructor (list)"><code>++list</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#lone' title="Mold generator (face on mold)"><code>++lone</code></a>
+<a class="tooltip" href='/docs/reference/library/2f/#lor' title="Leg order"><code>++lor</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#low' title="Parse lowercase letter"><code>++low</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#lsh' title="Left-shift"><code>++lsh</code></a>
+<a class="tooltip" href='/docs/reference/library/1a/#lte' title="Less than / equal (atom)"><code>++lte</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#lte-ff' title="Less than / equal (IEEE float)"><code>++lte:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#lte-fl' title="Less than / equal (producing flag)"><code>++lte:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#lte-rd' title="Less than / equal (double-precision float)"><code>++lte:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#lte-rh' title="Less than / equal (half-precision float)"><code>++lte:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#lte-rs' title="Less than / equal (single-precision float)"><code>++lte:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#lte-rq' title="Less than / equal (quad-precision float)"><code>++lte:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/1a/#lth' title="Less than (atom)"><code>++lth</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#lth-ff' title="Less than (IEEE float)"><code>++lth:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#lth-fl' title="Less than (signed and unsigned integer cell)"><code>++lth:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#lth-rd' title="Less than (double-precision float)"><code>++lth:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#lth-rh' title="Less than (half-precision float)"><code>++lth:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#lth-rs' title="Less than (single-precision float)"><code>++lth:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#lth-rq' title="Less than (quad-precision float)"><code>++lth:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#lug-fl' title="Central rounding mechanism"><code>++lug:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#lus' title="Parse + (lus)"><code>++lus</code></a>
+<a class="tooltip" href='/docs/reference/library/4d/#lust' title="Detect new line"><code>++lust</code></a>
+<a class="tooltip" href='/docs/reference/library/4e/#less' title="Parse unless"><code>++less</code></a>
+<a class="tooltip" href='/docs/reference/library/2m/#ly' title="List from raw noun"><code>++ly</code></a>
 
 ### m
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rd' title="Initialize ff (rd core)"><code>++ma:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rh' title="Initialize ff (rh core)"><code>++ma:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rs' title="Initialize ff (rs core)"><code>++ma:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rq' title="Initialize ff (rq core)"><code>++ma:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mack' title="Nock subject to unit"><code>++mack</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2l/#malt' title="Map from list"><code>++malt</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#map' title="Mold generator (map)"><code>++map</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#mar-by' title="Assert and add (map)"><code>+-mar:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#mas' title="Address within head/tail"><code>++mas</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#mask' title="Match character"><code>++mask</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#mat' title="Length-encode"><code>++mat</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#mate' title="Choose"><code>++mate</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#max' title="Maximum"><code>++max</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#me-ff' title="Minimum exponent of ff"><code>++me:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#mean' title="Crash and printf"><code>++mean</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#mes' title="Parse hexabyte"><code>++mes</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#mesc' title="Escape special characters"><code>++mesc</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#met' title="Measure"><code>++met</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#metl' title="(Undocumented)"><code>++metl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#min' title="Minimum (atom)"><code>++min</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mink' title="Mock (virtual Nock) interpreter"><code>++mink</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#mit-yo' title="Seconds in minute"><code>++mit:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#mix' title="Binary XOR (atom)"><code>++mix</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mock' title="Compute formula on subject with hint"><code>++mock</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#mod' title="Modulus (atom)"><code>++mod</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#moh-yo' title="Days in month"><code>++moh:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2l/#molt' title="Map from pair list"><code>++molt</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mong' title="Slam gate with sample"><code>++mong</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mook' title="Intelligently render crash annotation"><code>++mook</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#more' title="Parse list with delimiter"><code>++more</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#most' title="Parse list of at least one match"><code>++most</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#moy-yo' title="Days in months of leap-year"><code>++moy:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#mu' title="Core used to scramble 16-bit atoms"><code>++mu</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#mug' title="FNV-1a scrambler"><code>++mug</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#muk' title="Standard MurmurHash3"><code>++muk</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#mul' title="Multiply (atom)"><code>++mul</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-ff' title="Multiply (IEEE float)"><code>++mul:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-fl' title="Multiply (signed and unsigned integer cell)"><code>++mul:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rd' title="Multiply (double-precision float)"><code>++mul:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rh' title="Multiply (quad-precision float)"><code>++mul:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rs' title="Multiply (single-precision float)"><code>++mul:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rq' title="Multiply (quad-precision float)"><code>++mul:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mule' title="Typed virtual"><code>++mule</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mute' title="Untyped virtual"><code>++mute</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#mum' title="31-bit MurmurHash3 scrambler"><code>++mum</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#murn' title="Maybe transform"><code>++murn</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#my' title="Map from raw noun"><code>++my</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#my-nl' title="Construct map from null-terminated noun"><code>++my:nl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#ma-rd' title="Initialize ff (rd core)"><code>++ma:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#ma-rh' title="Initialize ff (rh core)"><code>++ma:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#ma-rs' title="Initialize ff (rs core)"><code>++ma:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#ma-rq' title="Initialize ff (rq core)"><code>++ma:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/4n/#mack' title="Nock subject to unit"><code>++mack</code></a>
+<a class="tooltip" href='/docs/reference/library/2l/#malt' title="Map from list"><code>++malt</code></a>
+<a class="tooltip" href='/docs/reference/library/2o/#map' title="Mold generator (map)"><code>++map</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#mar-by' title="Assert and add (map)"><code>+-mar:by</code></a>
+<a class="tooltip" href='/docs/reference/library/1b/#mas' title="Address within head/tail"><code>++mas</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#mask' title="Match character"><code>++mask</code></a>
+<a class="tooltip" href='/docs/reference/library/2p/#mat' title="Length-encode"><code>++mat</code></a>
+<a class="tooltip" href='/docs/reference/library/2a/#mate' title="Choose"><code>++mate</code></a>
+<a class="tooltip" href='/docs/reference/library/1a/#max' title="Maximum"><code>++max</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#me-ff' title="Minimum exponent of ff"><code>++me:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#mean' title="Crash and printf"><code>++mean</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#mes' title="Parse hexabyte"><code>++mes</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#mesc' title="Escape special characters"><code>++mesc</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#met' title="Measure"><code>++met</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#metl' title="(Undocumented)"><code>++metl</code></a>
+<a class="tooltip" href='/docs/reference/library/1a/#min' title="Minimum (atom)"><code>++min</code></a>
+<a class="tooltip" href='/docs/reference/library/4n/#mink' title="Mock (virtual Nock) interpreter"><code>++mink</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#mit-yo' title="Seconds in minute"><code>++mit:yo</code></a>
+<a class="tooltip" href='/docs/reference/library/2d/#mix' title="Binary XOR (atom)"><code>++mix</code></a>
+<a class="tooltip" href='/docs/reference/library/4n/#mock' title="Compute formula on subject with hint"><code>++mock</code></a>
+<a class="tooltip" href='/docs/reference/library/1a/#mod' title="Modulus (atom)"><code>++mod</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#moh-yo' title="Days in month"><code>++moh:yo</code></a>
+<a class="tooltip" href='/docs/reference/library/2l/#molt' title="Map from pair list"><code>++molt</code></a>
+<a class="tooltip" href='/docs/reference/library/4n/#mong' title="Slam gate with sample"><code>++mong</code></a>
+<a class="tooltip" href='/docs/reference/library/4n/#mook' title="Intelligently render crash annotation"><code>++mook</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#more' title="Parse list with delimiter"><code>++more</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#most' title="Parse list of at least one match"><code>++most</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#moy-yo' title="Days in months of leap-year"><code>++moy:yo</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#mu' title="Core used to scramble 16-bit atoms"><code>++mu</code></a>
+<a class="tooltip" href='/docs/reference/library/2e/#mug' title="FNV-1a scrambler"><code>++mug</code></a>
+<a class="tooltip" href='/docs/reference/library/2e/#muk' title="Standard MurmurHash3"><code>++muk</code></a>
+<a class="tooltip" href='/docs/reference/library/1a/#mul' title="Multiply (atom)"><code>++mul</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#mul-ff' title="Multiply (IEEE float)"><code>++mul:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#mul-fl' title="Multiply (signed and unsigned integer cell)"><code>++mul:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#mul-rd' title="Multiply (double-precision float)"><code>++mul:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#mul-rh' title="Multiply (quad-precision float)"><code>++mul:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#mul-rs' title="Multiply (single-precision float)"><code>++mul:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#mul-rq' title="Multiply (quad-precision float)"><code>++mul:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/4n/#mule' title="Typed virtual"><code>++mule</code></a>
+<a class="tooltip" href='/docs/reference/library/4n/#mute' title="Untyped virtual"><code>++mute</code></a>
+<a class="tooltip" href='/docs/reference/library/2e/#mum' title="31-bit MurmurHash3 scrambler"><code>++mum</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#murn' title="Maybe transform"><code>++murn</code></a>
+<a class="tooltip" href='/docs/reference/library/2m/#my' title="Map from raw noun"><code>++my</code></a>
+<a class="tooltip" href='/docs/reference/library/2m/#my-nl' title="Construct map from null-terminated noun"><code>++my:nl</code></a>
 
 ### n
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#nail' title="Location, remainder of parsed text"><code>++nail</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#nap-to' title="Remove head of queue"><code>+-nap:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ne' title="Digit rendering engine"><code>++ne</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ned-fl' title="Require float"><code>++ned:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#need' title="Unwrap unit"><code>++need</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#net-fe' title="Flip endianness"><code>++net:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#new-si' title="Atom to @s"><code>++new:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#next' title="Consume character"><code>++next</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#nip-to' title="Remove root of queue"><code>+-nip:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#nix' title="Parse letters and -"><code>++nix</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#nl' title="Noun to container operations"><code>++nl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#nock' title="Virtual machine (see Nock)"><code>++nock</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#not' title="Binary NOT (atom)"><code>++not</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#noun' title="(Undocumented)"><code>++noun</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#nuck-so' title="Top-level coin parser"><code>++nuck:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#nud' title="Parse numeric character"><code>++nud</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#null' title="(Undocumented)"><code>++null</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#nusk-so' title="Parse coin literal with escapes"><code>++nusk:so</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#nail' title="Location, remainder of parsed text"><code>++nail</code></a>
+<a class="tooltip" href='/docs/reference/library/2k/#nap-to' title="Remove head of queue"><code>+-nap:to</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#ne' title="Digit rendering engine"><code>++ne</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#ned-fl' title="Require float"><code>++ned:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/2a/#need' title="Unwrap unit"><code>++need</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#net-fe' title="Flip endianness"><code>++net:fe</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#new-si' title="Atom to @s"><code>++new:si</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#next' title="Consume character"><code>++next</code></a>
+<a class="tooltip" href='/docs/reference/library/2k/#nip-to' title="Remove root of queue"><code>+-nip:to</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#nix' title="Parse letters and -"><code>++nix</code></a>
+<a class="tooltip" href='/docs/reference/library/2m/#nl' title="Noun to container operations"><code>++nl</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#nock' title="Virtual machine (see Nock)"><code>++nock</code></a>
+<a class="tooltip" href='/docs/reference/library/2d/#not' title="Binary NOT (atom)"><code>++not</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#noun' title="(Undocumented)"><code>++noun</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#nuck-so' title="Top-level coin parser"><code>++nuck:so</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#nud' title="Parse numeric character"><code>++nud</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#null' title="(Undocumented)"><code>++null</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#nusk-so' title="Parse coin literal with escapes"><code>++nusk:so</code></a>
 
 ### o
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#ob' title="Reversible scrambling v2"><code>++ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#og' title="Container arm for SHA-256 powered RNG"><code>++og</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#old-si' title="Sign and absolute value"><code>++old:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#oust' title="Remove from list"><code>++oust</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#out-fe' title="Maximum integer value"><code>++out:fe</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#ob' title="Reversible scrambling v2"><code>++ob</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#og' title="Container arm for SHA-256 powered RNG"><code>++og</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#old-si' title="Sign and absolute value"><code>++old:si</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#oust' title="Remove from list"><code>++oust</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#out-fe' title="Maximum integer value"><code>++out:fe</code></a>
 
 ### p
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#pa-ff' title="Initialize fl from ff core"><code>++pa:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#pair' title="Mold of pair of types"><code>++pair</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pam' title="Parse & (pam)"><code>++pam</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pat' title="Parse @ (pat)"><code>++pat</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#path' title="Filesystem path"><code>++path</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#peg' title="Address within address"><code>++peg</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pel' title="Parse ( (pel)"><code>++pel</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#per' title="Parse ) (per)"><code>++per</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#perd-so' title="Parses dime/tiple without standard prefixes"><code>++perd:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#pev-ab' title="Parse <=5 in base 32"><code>++pev:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#pew-ab' title="Parse <= 5 in base 64"><code>++pew:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#pfix' title="Discard first rule"><code>++pfix</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#pint' title="Parsing range"><code>++pint</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#piv-ab' title="Parse 5 digits in base 32"><code>++piv:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#piw-ab' title="Parse 5 digits in base 64"><code>++piw:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#plug' title="Parse to tuple"><code>++plug</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#plus' title="List of at least one match"><code>++plus</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#po' title="Phonetic base"><code>++po</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#pole' title="Mold generator of faceless list"><code>++pole</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#port' title="(Undocumented)"><code>++port</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#pose' title="Parse options"><code>++pose</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2g/#pow' title="Computes a to the power of b"><code>++pow</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#prc-fl' title="Force precision of 2 or greater (floating point)"><code>++prc:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#prn' title="Parse any printable character"><code>++prn</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#pro-fo' title="Multiplies b and c modulo a"><code>++pro:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#pro-si' title="Multiply to signed integer"><code>++pro:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#put-by' title="Add key-value pair (map)"><code>+-put:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#put-in' title="Put b in a (set)"><code>+-put:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#put-ju' title="Add key-set pair (jar)"><code>+-put:ju</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#put-to' title="Insert into queue"><code>+-put:to</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#pa-ff' title="Initialize fl from ff core"><code>++pa:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#pair' title="Mold of pair of types"><code>++pair</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#pam' title="Parse & (pam)"><code>++pam</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#pat' title="Parse @ (pat)"><code>++pat</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#path' title="Filesystem path"><code>++path</code></a>
+<a class="tooltip" href='/docs/reference/library/1b/#peg' title="Address within address"><code>++peg</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#pel' title="Parse ( (pel)"><code>++pel</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#per' title="Parse ) (per)"><code>++per</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#perd-so' title="Parses dime/tiple without standard prefixes"><code>++perd:so</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#pev-ab' title="Parse <=5 in base 32"><code>++pev:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#pew-ab' title="Parse <= 5 in base 64"><code>++pew:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4e/#pfix' title="Discard first rule"><code>++pfix</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#pint' title="Parsing range"><code>++pint</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#piv-ab' title="Parse 5 digits in base 32"><code>++piv:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#piw-ab' title="Parse 5 digits in base 64"><code>++piw:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4e/#plug' title="Parse to tuple"><code>++plug</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#plus' title="List of at least one match"><code>++plus</code></a>
+<a class="tooltip" href='/docs/reference/library/4a/#po' title="Phonetic base"><code>++po</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#pole' title="Mold generator of faceless list"><code>++pole</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#port' title="(Undocumented)"><code>++port</code></a>
+<a class="tooltip" href='/docs/reference/library/4e/#pose' title="Parse options"><code>++pose</code></a>
+<a class="tooltip" href='/docs/reference/library/2g/#pow' title="Computes a to the power of b"><code>++pow</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#prc-fl' title="Force precision of 2 or greater (floating point)"><code>++prc:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#prn' title="Parse any printable character"><code>++prn</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#pro-fo' title="Multiplies b and c modulo a"><code>++pro:fo</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#pro-si' title="Multiply to signed integer"><code>++pro:si</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#put-by' title="Add key-value pair (map)"><code>+-put:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#put-in' title="Put b in a (set)"><code>+-put:in</code></a>
+<a class="tooltip" href='/docs/reference/library/2j/#put-ju' title="Add key-set pair (jar)"><code>+-put:ju</code></a>
+<a class="tooltip" href='/docs/reference/library/2k/#put-to' title="Insert into queue"><code>+-put:to</code></a>
 
 ### q
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#qad-yo' title="Seconds in 4 years"><code>++qad:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qeb-ab' title="Parse <=4 binary digits"><code>++qeb:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#qeu' title="Mold generator (queue)"><code>++qeu</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qex-ab' title="Parse <=4 hexadecimal digits"><code>++qex:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qib-ab' title="Parse 4 binary digits"><code>++qib:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#qit' title="Parse character to cord atom"><code>++qit</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qix-ab' title="Parse 4 hexadecimal digits"><code>++qix:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#quip' title="Mold generator (tuple of list and type)"><code>++quip</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#qut' title="Parse cord"><code>++qut</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#qad-yo' title="Seconds in 4 years"><code>++qad:yo</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#qeb-ab' title="Parse <=4 binary digits"><code>++qeb:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/2o/#qeu' title="Mold generator (queue)"><code>++qeu</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#qex-ab' title="Parse <=4 hexadecimal digits"><code>++qex:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#qib-ab' title="Parse 4 binary digits"><code>++qib:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#qit' title="Parse character to cord atom"><code>++qit</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#qix-ab' title="Parse 4 hexadecimal digits"><code>++qix:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#quip' title="Mold generator (tuple of list and type)"><code>++quip</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#qut' title="Parse cord"><code>++qut</code></a>
 
 ### r
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#r-at' title="(Undocumented)"><code>++r:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#rad-og' title="Random in range"><code>++rad:og</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#rads-og' title="Random continuation"><code>++rads:og</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#raku-ob' title="Key list"><code>++raku:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#ram-re' title="Flatten tank to tape"><code>++ram:re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rap' title="Assemble non-zero"><code>++rap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rash' title="Parse or crash"><code>++rash</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rau-fl' title="Various roundings (floating point)"><code>++rau:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#raw-og' title="Random bits"><code>++raw:og</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#raws-og' title="Random bits continuation"><code>++raws:og</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#re' title="Pretty-printing engine (tank)"><code>++re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rear-co' title="Prepend and render atom as tape"><code>++rear:co</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#reap' title="Replicate (list)"><code>++reap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#reel' title="Right fold (list)"><code>++reel</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#rem-si' title="Remainder (signed integer)"><code>++rem:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rend-co' title="Render coin lot as tape"><code>++rend:co</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rent-co' title="Render coin lot as span"><code>++rent:co</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rep' title="Assemble single"><code>++rep</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rep-by' title="Replace by product (map)"><code>+-rep:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#rep-in' title="Accumulate elements (set)"><code>+-rep:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rf-at' title="(Undocumented)"><code>++rf:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rib-by' title="Replace values with accumulator (map)"><code>+-rib:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#rig-re' title="Wrap tape in / (tank)"><code>++rig:re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rip' title="Disassemble"><code>++rip</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rn-at' title="(Undocumented)"><code>++rn:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rol-fe' title="Roll left"><code>++rol:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#roll' title="Left fold (list)"><code>++roll</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#r-at' title="(Undocumented)"><code>++r:at</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#rad-og' title="Random in range"><code>++rad:og</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#rads-og' title="Random continuation"><code>++rads:og</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#raku-ob' title="Key list"><code>++raku:ob</code></a>
+<a class="tooltip" href='/docs/reference/library/4c/#ram-re' title="Flatten tank to tape"><code>++ram:re</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#rap' title="Assemble non-zero"><code>++rap</code></a>
+<a class="tooltip" href='/docs/reference/library/4g/#rash' title="Parse or crash"><code>++rash</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#rau-fl' title="Various roundings (floating point)"><code>++rau:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#raw-og' title="Random bits"><code>++raw:og</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#raws-og' title="Random bits continuation"><code>++raws:og</code></a>
+<a class="tooltip" href='/docs/reference/library/4c/#re' title="Pretty-printing engine (tank)"><code>++re</code></a>
+<a class="tooltip" href='/docs/reference/library/4k/#rear-co' title="Prepend and render atom as tape"><code>++rear:co</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#reap' title="Replicate (list)"><code>++reap</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#reel' title="Right fold (list)"><code>++reel</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#rem-si' title="Remainder (signed integer)"><code>++rem:si</code></a>
+<a class="tooltip" href='/docs/reference/library/4k/#rend-co' title="Render coin lot as tape"><code>++rend:co</code></a>
+<a class="tooltip" href='/docs/reference/library/4k/#rent-co' title="Render coin lot as span"><code>++rent:co</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#rep' title="Assemble single"><code>++rep</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#rep-by' title="Replace by product (map)"><code>+-rep:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#rep-in' title="Accumulate elements (set)"><code>+-rep:in</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#rf-at' title="(Undocumented)"><code>++rf:at</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#rib-by' title="Replace values with accumulator (map)"><code>+-rib:by</code></a>
+<a class="tooltip" href='/docs/reference/library/4c/#rig-re' title="Wrap tape in / (tank)"><code>++rig:re</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#rip' title="Disassemble"><code>++rip</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#rn-at' title="(Undocumented)"><code>++rn:at</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#rol-fe' title="Roll left"><code>++rol:fe</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#roll' title="Left fold (list)"><code>++roll</code></a>
 <code>++rood</code>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#ror-fe' title="Roll right"><code>++ror:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rou-fl' title="Round to nearest float with 113-bit significand"><code>++rou:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#royl-so' title="Parse dime float"><code>++royl:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#royl-cell-so' title="(Undocumented)"><code>++royl-cell:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rsh' title="Right-shift"><code>++rsh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rt-at' title="(Undocumented)"><code>++rt:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rta-at' title="(Undocumented)"><code>++rta:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rtam-at' title="(Undocumented)"><code>++rtam:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#rub' title="Length-decode"><code>++rub</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rub-at' title="(Undocumented)"><code>++rub:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rud-at' title="(Undocumented)"><code>++rud:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#rule' title="Parsing rule (match this with _)"><code>++rule</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rum-at' title="(Undocumented)"><code>++rum:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#run-by' title="Transform values (map)"><code>+-run:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#run-in' title="Apply gate to set"><code>+-run:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#rund-ob' title="Reverse single Feistel-like"><code>++rund:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#runt' title="Prepend n times"><code>++runt</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rup-at' title="(Undocumented)"><code>++rup:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rush' title="Parse or null"><code>++rush</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rust' title="Parse tape or null"><code>++rust</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rut-by' title="Transform nodes (map)"><code>+-rut:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#ruv-at' title="(Undocumented)"><code>++ruv:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rux-at' title="(Undocumented)"><code>++rux:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#rynd-ob' title="Reverse Feistel-like cipher"><code>++rynd:ob</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#ror-fe' title="Roll right"><code>++ror:fe</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#rou-fl' title="Round to nearest float with 113-bit significand"><code>++rou:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#royl-so' title="Parse dime float"><code>++royl:so</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#royl-cell-so' title="(Undocumented)"><code>++royl-cell:so</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#rsh' title="Right-shift"><code>++rsh</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#rt-at' title="(Undocumented)"><code>++rt:at</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#rta-at' title="(Undocumented)"><code>++rta:at</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#rtam-at' title="(Undocumented)"><code>++rtam:at</code></a>
+<a class="tooltip" href='/docs/reference/library/2p/#rub' title="Length-decode"><code>++rub</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#rub-at' title="(Undocumented)"><code>++rub:at</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#rud-at' title="(Undocumented)"><code>++rud:at</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#rule' title="Parsing rule (match this with _)"><code>++rule</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#rum-at' title="(Undocumented)"><code>++rum:at</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#run-by' title="Transform values (map)"><code>+-run:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#run-in' title="Apply gate to set"><code>+-run:in</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#rund-ob' title="Reverse single Feistel-like"><code>++rund:ob</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#runt' title="Prepend n times"><code>++runt</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#rup-at' title="(Undocumented)"><code>++rup:at</code></a>
+<a class="tooltip" href='/docs/reference/library/4g/#rush' title="Parse or null"><code>++rush</code></a>
+<a class="tooltip" href='/docs/reference/library/4g/#rust' title="Parse tape or null"><code>++rust</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#rut-by' title="Transform nodes (map)"><code>+-rut:by</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#ruv-at' title="(Undocumented)"><code>++ruv:at</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#rux-at' title="(Undocumented)"><code>++rux:at</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#rynd-ob' title="Reverse Feistel-like cipher"><code>++rynd:ob</code></a>
 
 ### s
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#same'><code>++same</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-ff'><code>++san:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-fl'><code>++san:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-rd'><code>++san:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-rh'><code>++san:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-rs'><code>++san:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-rq'><code>++san:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#sand'><code>++sand</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#sane'><code>++sane</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sb-ff'><code>++sb:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#scag'><code>++scag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#scan'><code>++scan</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#scot'><code>++scot</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#scow'><code>++scow</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sea-ff'><code>++sea:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sea-rd'><code>++sea:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sea-rh'><code>++sea:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sea-rs'><code>++sea:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sea-rq'><code>++sea:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#sear'><code>++sear</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#seb-ab'><code>++seb:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sed-ab'><code>++sed:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#sel'><code>++sel</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#sem'><code>++sem</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ser'><code>++ser</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#set'><code>++set</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sev-ab'><code>++sev:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sew-ab'><code>++sew:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sex-ab'><code>++sex:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#sfix'><code>++sfix</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shad'><code>++shad</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shaf'><code>++shaf</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shal'><code>++shal</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#sham'><code>++sham</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shan'><code>++shan</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shas'><code>++shas</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shaw'><code>++shaw</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shax'><code>++shax</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shay'><code>++shay</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shaz'><code>++shaz</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#shep'><code>++shep</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#shf-fl'><code>++shf:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#shim'><code>++shim</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#shop'><code>++shop</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#show'><code>++show</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#si'><code>++si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#si-nl'><code>++si:nl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sib-ab'><code>++sib:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sid-ab'><code>++sid:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#sig'><code>++sig</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sig-ff'><code>++sig:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sig-rd'><code>++sig:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sig-rh'><code>++sig:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sig-rs'><code>++sig:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sig-rq'><code>++sig:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2l/#silt'><code>++silt</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#simu'><code>++simu</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#sit-fe'><code>++sit:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#sit-fo'><code>++sit:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#siv-ab'><code>++siv:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#siw-ab'><code>++siw:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#six-ab'><code>++six:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#skid'><code>++skid</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#skim'><code>++skim</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#skip'><code>++skip</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#slag'><code>++slag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#slat'><code>++slat</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#slav'><code>++slav</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#slaw'><code>++slaw</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#slay'><code>++slay</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#slog'><code>++slog</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#slug'><code>++slug</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#smyt'><code>++smyt</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#snag'><code>++snag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#snag-nl'><code>++snag:nl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#snoc'><code>++snoc</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#so'><code>++so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#soft'><code>++soft</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#some'><code>++some</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#soq'><code>++soq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#sort'><code>++sort</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sov-ab'><code>++sov:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sow-ab'><code>++sow:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sox-ab'><code>++sox:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#soz'><code>++soz</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#span'><code>++span</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#spat'><code>++spat</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#spd-fl'><code>++spd:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#spin'><code>++spin</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#spn-fl'><code>++spn:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#spot'><code>++spot</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#spud'><code>++spud</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#spun'><code>++spun</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2g/#sqt'><code>++sqt</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sqt-ff'><code>++sqt:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sqt-fl'><code>++sqt:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sqt-rd'><code>++sqt:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sqt-rh'><code>++sqt:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sqt-rs'><code>++sqt:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sqt-rq'><code>++sqt:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#stab'><code>++stab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#stag'><code>++stag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#star'><code>++star</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#stet'><code>++stet</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#stew'><code>++stew</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#stir'><code>++stir</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#stun'><code>++stun</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#sub'><code>++sub</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sub-ff'><code>++sub:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sub-fl'><code>++sub:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sub-rd'><code>++sub:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sub-rh'><code>++sub:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sub-rs'><code>++sub:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sub-rq'><code>++sub:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#sum-fe'><code>++sum:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#sum-fo'><code>++sum:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#sum-si'><code>++sum:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sun-ff'><code>++sun:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sun-fl'><code>++sun:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sun-rd'><code>++sun:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sun-rh'><code>++sun:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sun-rs'><code>++sun:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sun-rq'><code>++sun:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#sun-si'><code>++sun:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#swag'><code>++swag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#swp'><code>++swp</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#swr-fl'><code>++swr:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#sy'><code>++sy</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#sym'><code>++sym</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#syn-fl'><code>++syn:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#syn-si'><code>++syn:si</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#same'><code>++same</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#san-ff'><code>++san:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#san-fl'><code>++san:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#san-rd'><code>++san:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#san-rh'><code>++san:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#san-rs'><code>++san:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#san-rq'><code>++san:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#sand'><code>++sand</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#sane'><code>++sane</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sb-ff'><code>++sb:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#scag'><code>++scag</code></a>
+<a class="tooltip" href='/docs/reference/library/4g/#scan'><code>++scan</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#scot'><code>++scot</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#scow'><code>++scow</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sea-ff'><code>++sea:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sea-rd'><code>++sea:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sea-rh'><code>++sea:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sea-rs'><code>++sea:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sea-rq'><code>++sea:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#sear'><code>++sear</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#seb-ab'><code>++seb:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sed-ab'><code>++sed:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#sel'><code>++sel</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#sem'><code>++sem</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#ser'><code>++ser</code></a>
+<a class="tooltip" href='/docs/reference/library/2o/#set'><code>++set</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sev-ab'><code>++sev:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sew-ab'><code>++sew:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sex-ab'><code>++sex:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4e/#sfix'><code>++sfix</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shad'><code>++shad</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shaf'><code>++shaf</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shal'><code>++shal</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#sham'><code>++sham</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shan'><code>++shan</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shas'><code>++shas</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shaw'><code>++shaw</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shax'><code>++shax</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shay'><code>++shay</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shaz'><code>++shaz</code></a>
+<a class="tooltip" href='/docs/reference/library/4c/#shep'><code>++shep</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#shf-fl'><code>++shf:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#shim'><code>++shim</code></a>
+<a class="tooltip" href='/docs/reference/library/4c/#shop'><code>++shop</code></a>
+<a class="tooltip" href='/docs/reference/library/4c/#show'><code>++show</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#si'><code>++si</code></a>
+<a class="tooltip" href='/docs/reference/library/2m/#si-nl'><code>++si:nl</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sib-ab'><code>++sib:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sid-ab'><code>++sid:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#sig'><code>++sig</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sig-ff'><code>++sig:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sig-rd'><code>++sig:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sig-rh'><code>++sig:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sig-rs'><code>++sig:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sig-rq'><code>++sig:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/2l/#silt'><code>++silt</code></a>
+<a class="tooltip" href='/docs/reference/library/4e/#simu'><code>++simu</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#sit-fe'><code>++sit:fe</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#sit-fo'><code>++sit:fo</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#siv-ab'><code>++siv:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#siw-ab'><code>++siw:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#six-ab'><code>++six:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#skid'><code>++skid</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#skim'><code>++skim</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#skip'><code>++skip</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#slag'><code>++slag</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#slat'><code>++slat</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#slav'><code>++slav</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#slaw'><code>++slaw</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#slay'><code>++slay</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#slog'><code>++slog</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#slug'><code>++slug</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#smyt'><code>++smyt</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#snag'><code>++snag</code></a>
+<a class="tooltip" href='/docs/reference/library/2m/#snag-nl'><code>++snag:nl</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#snoc'><code>++snoc</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#so'><code>++so</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#soft'><code>++soft</code></a>
+<a class="tooltip" href='/docs/reference/library/2a/#some'><code>++some</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#soq'><code>++soq</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#sort'><code>++sort</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sov-ab'><code>++sov:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sow-ab'><code>++sow:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sox-ab'><code>++sox:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#soz'><code>++soz</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#span'><code>++span</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#spat'><code>++spat</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#spd-fl'><code>++spd:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#spin'><code>++spin</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#spn-fl'><code>++spn:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#spot'><code>++spot</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#spud'><code>++spud</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#spun'><code>++spun</code></a>
+<a class="tooltip" href='/docs/reference/library/2g/#sqt'><code>++sqt</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sqt-ff'><code>++sqt:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sqt-fl'><code>++sqt:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sqt-rd'><code>++sqt:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sqt-rh'><code>++sqt:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sqt-rs'><code>++sqt:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sqt-rq'><code>++sqt:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#stab'><code>++stab</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#stag'><code>++stag</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#star'><code>++star</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#stet'><code>++stet</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#stew'><code>++stew</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#stir'><code>++stir</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#stun'><code>++stun</code></a>
+<a class="tooltip" href='/docs/reference/library/1a/#sub'><code>++sub</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sub-ff'><code>++sub:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sub-fl'><code>++sub:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sub-rd'><code>++sub:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sub-rh'><code>++sub:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sub-rs'><code>++sub:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sub-rq'><code>++sub:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#sum-fe'><code>++sum:fe</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#sum-fo'><code>++sum:fo</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#sum-si'><code>++sum:si</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sun-ff'><code>++sun:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sun-fl'><code>++sun:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sun-rd'><code>++sun:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sun-rh'><code>++sun:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sun-rs'><code>++sun:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sun-rq'><code>++sun:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#sun-si'><code>++sun:si</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#swag'><code>++swag</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#swp'><code>++swp</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#swr-fl'><code>++swr:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/2m/#sy'><code>++sy</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#sym'><code>++sym</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#syn-fl'><code>++syn:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#syn-si'><code>++syn:si</code></a>
 
 ### t
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#tail'><code>++tail</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#tap-to'><code>+-tap:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#tar'><code>++tar</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#tang'><code>++tang</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#tank'><code>++tank</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#tap-by'><code>+-tap:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#tap-in'><code>+-tap:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#tape'><code>++tape</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#tarp'><code>++tarp</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#tash-so'><code>++tash:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#tec'><code>++tec</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ted-ab'><code>++ted:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#teff'><code>++teff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#teil-ob'><code>++teil:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#term'><code>++term</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#test'><code>++test</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#tid-ab'><code>++tid:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#tiki'><code>++tiki</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#til-ab'><code>++til:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#tip-ab'><code>++tip:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#tiq-ab'><code>++tiq:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#tis'><code>++tis</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#to'><code>++to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#tod-po'><code>++tod:po</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#toga'><code>++toga</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toi-ff'><code>++toi:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toi-fl'><code>++toi:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toi-rd'><code>++toi:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toi-rh'><code>++toi:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toi-rs'><code>++toi:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toi-rq'><code>++toi:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toj-fl'><code>++toj:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#tone'><code>++tone</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#toon'><code>++toon</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#top-to'><code>+-top:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#tos-po'><code>++tos:po</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#tos-rh'><code>++tos:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#trap'><code>++trap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#tree'><code>++tree</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#trel'><code>++trel</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#trim'><code>++trim</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#trip'><code>++trip</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#tuba'><code>++tuba</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#tufa'><code>++tufa</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#tuna'><code>++tuna</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#tuft'><code>++tuft</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#turf'><code>++turf</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#turn'><code>++turn</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#tusk'><code>++tusk</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#twid-so'><code>++twid:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#tyke'><code>++tyke</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#typo'><code>++typo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#tyre'><code>++tyre</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#tail'><code>++tail</code></a>
+<a class="tooltip" href='/docs/reference/library/2k/#tap-to'><code>+-tap:to</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#tar'><code>++tar</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#tang'><code>++tang</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#tank'><code>++tank</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#tap-by'><code>+-tap:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#tap-in'><code>+-tap:in</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#tape'><code>++tape</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#tarp'><code>++tarp</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#tash-so'><code>++tash:so</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#tec'><code>++tec</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#ted-ab'><code>++ted:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#teff'><code>++teff</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#teil-ob'><code>++teil:ob</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#term'><code>++term</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#test'><code>++test</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#tid-ab'><code>++tid:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#tiki'><code>++tiki</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#til-ab'><code>++til:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#tip-ab'><code>++tip:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#tiq-ab'><code>++tiq:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#tis'><code>++tis</code></a>
+<a class="tooltip" href='/docs/reference/library/2k/#to'><code>++to</code></a>
+<a class="tooltip" href='/docs/reference/library/4a/#tod-po'><code>++tod:po</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#toga'><code>++toga</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#toi-ff'><code>++toi:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#toi-fl'><code>++toi:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#toi-rd'><code>++toi:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#toi-rh'><code>++toi:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#toi-rs'><code>++toi:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#toi-rq'><code>++toi:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#toj-fl'><code>++toj:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#tone'><code>++tone</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#toon'><code>++toon</code></a>
+<a class="tooltip" href='/docs/reference/library/2k/#top-to'><code>+-top:to</code></a>
+<a class="tooltip" href='/docs/reference/library/4a/#tos-po'><code>++tos:po</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#tos-rh'><code>++tos:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#trap'><code>++trap</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#tree'><code>++tree</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#trel'><code>++trel</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#trim'><code>++trim</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#trip'><code>++trip</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#tuba'><code>++tuba</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#tufa'><code>++tufa</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#tuna'><code>++tuna</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#tuft'><code>++tuft</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#turf'><code>++turf</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#turn'><code>++turn</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#tusk'><code>++tusk</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#twid-so'><code>++twid:so</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#tyke'><code>++tyke</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#typo'><code>++typo</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#tyre'><code>++tyre</code></a>
 
 ### u
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#un'><code>++un</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#uni-by'><code>+-uni:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#uni-fl'><code>++uni:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#uni-in'><code>+-uni:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#unit'><code>++unit</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#urn-by'><code>+-urn:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#urs-ab'><code>++urs:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#urt-ab'><code>++urt:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#un'><code>++un</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#uni-by'><code>+-uni:by</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#uni-fl'><code>++uni:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#uni-in'><code>+-uni:in</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#unit'><code>++unit</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#urn-by'><code>+-urn:by</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#urs-ab'><code>++urs:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#urt-ab'><code>++urt:ab</code></a>
 
 ### v
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#v-ne'><code>++v:ne</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#v-ne'><code>++v:ne</code></a>
 <code>++vang</code>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#vase'><code>++vase</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#vase'><code>++vase</code></a>
 <code>++vast</code>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#ven'><code>++ven</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#vise'><code>++vise</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#vit'><code>++vit</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#viz-ag'><code>++viz:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#vor'><code>++vor</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#voy-ab'><code>++voy:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#vul'><code>++vul</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#vum-ag'><code>++vum:ag</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#ven'><code>++ven</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#vise'><code>++vise</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#vit'><code>++vit</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#viz-ag'><code>++viz:ag</code></a>
+<a class="tooltip" href='/docs/reference/library/2f/#vor'><code>++vor</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#voy-ab'><code>++voy:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#vul'><code>++vul</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#vum-ag'><code>++vum:ag</code></a>
 
 ### w
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#w-ne'><code>++w:ne</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#wack'><code>++wack</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#wain'><code>++wain</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#wall'><code>++wall</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#weld'><code>++weld</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#weld-nl'><code>++weld:nl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#welp'><code>++welp</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#wick'><code>++wick</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#wig-re'><code>++wig:re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#win-re'><code>++win:re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#wing'><code>++wing</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#wiz-ag'><code>++wiz:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#woad'><code>++woad</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#wood'><code>++wood</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#wonk'><code>++wonk</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#wred-un'><code>++wred:un</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#wren-un'><code>++wren:un</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#wut'><code>++wut</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#wyt-by'><code>+-wyt:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#wyt-in'><code>+-wyt:in</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#w-ne'><code>++w:ne</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#wack'><code>++wack</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#wain'><code>++wain</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#wall'><code>++wall</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#weld'><code>++weld</code></a>
+<a class="tooltip" href='/docs/reference/library/2m/#weld-nl'><code>++weld:nl</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#welp'><code>++welp</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#wick'><code>++wick</code></a>
+<a class="tooltip" href='/docs/reference/library/4c/#wig-re'><code>++wig:re</code></a>
+<a class="tooltip" href='/docs/reference/library/4c/#win-re'><code>++win:re</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#wing'><code>++wing</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#wiz-ag'><code>++wiz:ag</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#woad'><code>++woad</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#wood'><code>++wood</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#wonk'><code>++wonk</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#wred-un'><code>++wred:un</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#wren-un'><code>++wren:un</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#wut'><code>++wut</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#wyt-by'><code>+-wyt:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#wyt-in'><code>+-wyt:in</code></a>
 
 ### x
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#x-ne'><code>++x:ne</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#xeb'><code>++xeb</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#xpd-fl'><code>++xpd:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#x-ne'><code>++x:ne</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#xeb'><code>++xeb</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#xpd-fl'><code>++xpd:fl</code></a>
 
 ### y
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yall'><code>++yall</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yawn'><code>++yawn</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#year'><code>++year</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yell'><code>++yell</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yelp'><code>++yelp</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yer-yo'><code>++yer:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yo'><code>++yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yore'><code>++yore</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yule'><code>++yule</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yall'><code>++yall</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yawn'><code>++yawn</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#year'><code>++year</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yell'><code>++yell</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yelp'><code>++yelp</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yer-yo'><code>++yer:yo</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yo'><code>++yo</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yore'><code>++yore</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yule'><code>++yule</code></a>
 
 ### z
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#zaft-un'><code>++zaft:un</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#zag-mu'><code>++zag:mu</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#zap'><code>++zap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#zart-un'><code>++zart:un</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#zer-fl'><code>++zer:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#zig-mu'><code>++zig:mu</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#zing'><code>++zing</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#zug-mu'><code>++zug:mu</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#zust-so'><code>++zust:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#zyft-un'><code>++zyft:un</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#zyrt-un'><code>++zyrt:un</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#zaft-un'><code>++zaft:un</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#zag-mu'><code>++zag:mu</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#zap'><code>++zap</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#zart-un'><code>++zart:un</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#zer-fl'><code>++zer:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#zig-mu'><code>++zig:mu</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#zing'><code>++zing</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#zug-mu'><code>++zug:mu</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#zust-so'><code>++zust:so</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#zyft-un'><code>++zyft:un</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#zyrt-un'><code>++zyrt:un</code></a>
 
 ## By Section
 
 ### 1a: basic arithmetic
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#add' title="Add"><code>++add</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#dec' title="Decrement"><code>++dec</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#div' title="Divide"><code>++div</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#dvr' title="Divide (with remainder)"><code>++dvr</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#gte' title="Greater than / equal"><code>++gte</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#gth' title="Greater than"><code>++gth</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#lte' title="Less than / equal (atom)"><code>++lte</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#lth' title="Less than (atom)"><code>++lth</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#max' title="Maximum"><code>++max</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#min' title="Minimum (atom)"><code>++min</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#mod' title="Modulus (atom)"><code>++mod</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#mul' title="Multiply (atom)"><code>++mul</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#sub'><code>++sub</code></a>
+<a class="tooltip" href='/docs/reference/library/1a/#add' title="Add"><code>++add</code></a>
+<a class="tooltip" href='/docs/reference/library/1a/#dec' title="Decrement"><code>++dec</code></a>
+<a class="tooltip" href='/docs/reference/library/1a/#div' title="Divide"><code>++div</code></a>
+<a class="tooltip" href='/docs/reference/library/1a/#dvr' title="Divide (with remainder)"><code>++dvr</code></a>
+<a class="tooltip" href='/docs/reference/library/1a/#gte' title="Greater than / equal"><code>++gte</code></a>
+<a class="tooltip" href='/docs/reference/library/1a/#gth' title="Greater than"><code>++gth</code></a>
+<a class="tooltip" href='/docs/reference/library/1a/#lte' title="Less than / equal (atom)"><code>++lte</code></a>
+<a class="tooltip" href='/docs/reference/library/1a/#lth' title="Less than (atom)"><code>++lth</code></a>
+<a class="tooltip" href='/docs/reference/library/1a/#max' title="Maximum"><code>++max</code></a>
+<a class="tooltip" href='/docs/reference/library/1a/#min' title="Minimum (atom)"><code>++min</code></a>
+<a class="tooltip" href='/docs/reference/library/1a/#mod' title="Modulus (atom)"><code>++mod</code></a>
+<a class="tooltip" href='/docs/reference/library/1a/#mul' title="Multiply (atom)"><code>++mul</code></a>
+<a class="tooltip" href='/docs/reference/library/1a/#sub'><code>++sub</code></a>
 
 ### 1b: tree addressing
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#cap' title="Tree head"><code>++cap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#mas' title="Address within head/tail"><code>++mas</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#peg' title="Address within address"><code>++peg</code></a>
+<a class="tooltip" href='/docs/reference/library/1b/#cap' title="Tree head"><code>++cap</code></a>
+<a class="tooltip" href='/docs/reference/library/1b/#mas' title="Address within head/tail"><code>++mas</code></a>
+<a class="tooltip" href='/docs/reference/library/1b/#peg' title="Address within address"><code>++peg</code></a>
 
 ### 1c: molds and mold builders
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#bloq' title="Blocksize"><code>++bloq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#each' title="Mold of fork between two types"><code>++each</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#gate' title="Function"><code>++gate</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#list' title="Mold constructor (list)"><code>++list</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#lone' title="Mold generator (face on mold)"><code>++lone</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#pair' title="Mold of pair of types"><code>++pair</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#pole' title="Mold generator of faceless list"><code>++pole</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#quip' title="Mold generator (tuple of list and type)"><code>++quip</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#trap'><code>++trap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#tree'><code>++tree</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#trel'><code>++trel</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#unit'><code>++unit</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#bloq' title="Blocksize"><code>++bloq</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#each' title="Mold of fork between two types"><code>++each</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#gate' title="Function"><code>++gate</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#list' title="Mold constructor (list)"><code>++list</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#lone' title="Mold generator (face on mold)"><code>++lone</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#pair' title="Mold of pair of types"><code>++pair</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#pole' title="Mold generator of faceless list"><code>++pole</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#quip' title="Mold generator (tuple of list and type)"><code>++quip</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#trap'><code>++trap</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#tree'><code>++tree</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#trel'><code>++trel</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#unit'><code>++unit</code></a>
 
 ### 2a: unit logic
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#biff' title="Unit as argument"><code>++biff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#bind' title="Non-unit function to unit, producing unit"><code>++bind</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#bond' title="Replace null"><code>++bond</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#both' title="Group unit values into pair"><code>++both</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#clap' title="Apply function to two units"><code>++clap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#drop' title="Unit to list"><code>++drop</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#fall' title="Give unit a default value"><code>++fall</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#lift' title="Curried bind"><code>++lift</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#mate' title="Choose"><code>++mate</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#need' title="Unwrap unit"><code>++need</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#some'><code>++some</code></a>
+<a class="tooltip" href='/docs/reference/library/2a/#biff' title="Unit as argument"><code>++biff</code></a>
+<a class="tooltip" href='/docs/reference/library/2a/#bind' title="Non-unit function to unit, producing unit"><code>++bind</code></a>
+<a class="tooltip" href='/docs/reference/library/2a/#bond' title="Replace null"><code>++bond</code></a>
+<a class="tooltip" href='/docs/reference/library/2a/#both' title="Group unit values into pair"><code>++both</code></a>
+<a class="tooltip" href='/docs/reference/library/2a/#clap' title="Apply function to two units"><code>++clap</code></a>
+<a class="tooltip" href='/docs/reference/library/2a/#drop' title="Unit to list"><code>++drop</code></a>
+<a class="tooltip" href='/docs/reference/library/2a/#fall' title="Give unit a default value"><code>++fall</code></a>
+<a class="tooltip" href='/docs/reference/library/2a/#lift' title="Curried bind"><code>++lift</code></a>
+<a class="tooltip" href='/docs/reference/library/2a/#mate' title="Choose"><code>++mate</code></a>
+<a class="tooltip" href='/docs/reference/library/2a/#need' title="Unwrap unit"><code>++need</code></a>
+<a class="tooltip" href='/docs/reference/library/2a/#some'><code>++some</code></a>
 
 ### 2b: list logic
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#fand' title="All indices in list"><code>++fand</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#find' title="First index in list"><code>++find</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#flop' title="Reverse list"><code>++flop</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#gulf' title="List from range"><code>++gulf</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#homo' title="Homogenize list"><code>++homo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#lent' title="List length"><code>++lent</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#levy' title="Logical AND on list"><code>++levy</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#lien' title="Logical OR on list"><code>++lien</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#limo' title="Construct list from null-terminated tuple"><code>++limo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#murn' title="Maybe transform"><code>++murn</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#oust' title="Remove from list"><code>++oust</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#reap' title="Replicate (list)"><code>++reap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#reel' title="Right fold (list)"><code>++reel</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#roll' title="Left fold (list)"><code>++roll</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#scag'><code>++scag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#skid'><code>++skid</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#skim'><code>++skim</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#skip'><code>++skip</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#slag'><code>++slag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#snag'><code>++snag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#snoc'><code>++snoc</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#sort'><code>++sort</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#spin'><code>++spin</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#spun'><code>++spun</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#swag'><code>++swag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#turn'><code>++turn</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#weld'><code>++weld</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#welp'><code>++welp</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#zing'><code>++zing</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#fand' title="All indices in list"><code>++fand</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#find' title="First index in list"><code>++find</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#flop' title="Reverse list"><code>++flop</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#gulf' title="List from range"><code>++gulf</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#homo' title="Homogenize list"><code>++homo</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#lent' title="List length"><code>++lent</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#levy' title="Logical AND on list"><code>++levy</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#lien' title="Logical OR on list"><code>++lien</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#limo' title="Construct list from null-terminated tuple"><code>++limo</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#murn' title="Maybe transform"><code>++murn</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#oust' title="Remove from list"><code>++oust</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#reap' title="Replicate (list)"><code>++reap</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#reel' title="Right fold (list)"><code>++reel</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#roll' title="Left fold (list)"><code>++roll</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#scag'><code>++scag</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#skid'><code>++skid</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#skim'><code>++skim</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#skip'><code>++skip</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#slag'><code>++slag</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#snag'><code>++snag</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#snoc'><code>++snoc</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#sort'><code>++sort</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#spin'><code>++spin</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#spun'><code>++spun</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#swag'><code>++swag</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#turn'><code>++turn</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#weld'><code>++weld</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#welp'><code>++welp</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#zing'><code>++zing</code></a>
 
 ### 2c: bit arithmetic
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#fe' title="Modulo bloq"><code>++fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#dif-fe' title="Difference between atoms (modular basis)"><code>++dif:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#inv-fe' title="Inverse order of modular field"><code>++inv:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#net-fe' title="Flip endianness"><code>++net:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#out-fe' title="Maximum integer value"><code>++out:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rol-fe' title="Roll left"><code>++rol:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#ror-fe' title="Roll right"><code>++ror:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#sit-fe'><code>++sit:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#sum-fe'><code>++sum:fe</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#fe' title="Modulo bloq"><code>++fe</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#dif-fe' title="Difference between atoms (modular basis)"><code>++dif:fe</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#inv-fe' title="Inverse order of modular field"><code>++inv:fe</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#net-fe' title="Flip endianness"><code>++net:fe</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#out-fe' title="Maximum integer value"><code>++out:fe</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#rol-fe' title="Roll left"><code>++rol:fe</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#ror-fe' title="Roll right"><code>++ror:fe</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#sit-fe'><code>++sit:fe</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#sum-fe'><code>++sum:fe</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#bex' title="Binary exponent"><code>++bex</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#can' title="Assemble"><code>++can</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#cat' title="Concatenate"><code>++cat</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#cut' title="Slice"><code>++cut</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#end' title="Tail"><code>++end</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#fil' title="Fill bloqstream"><code>++fil</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#lsh' title="Left-shift"><code>++lsh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#met' title="Measure"><code>++met</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rap' title="Assemble non-zero"><code>++rap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rep' title="Assemble single"><code>++rep</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rip' title="Disassemble"><code>++rip</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rsh' title="Right-shift"><code>++rsh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#swp'><code>++swp</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#xeb'><code>++xeb</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#bex' title="Binary exponent"><code>++bex</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#can' title="Assemble"><code>++can</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#cat' title="Concatenate"><code>++cat</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#cut' title="Slice"><code>++cut</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#end' title="Tail"><code>++end</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#fil' title="Fill bloqstream"><code>++fil</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#lsh' title="Left-shift"><code>++lsh</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#met' title="Measure"><code>++met</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#rap' title="Assemble non-zero"><code>++rap</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#rep' title="Assemble single"><code>++rep</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#rip' title="Disassemble"><code>++rip</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#rsh' title="Right-shift"><code>++rsh</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#swp'><code>++swp</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#xeb'><code>++xeb</code></a>
 
 ### 2d: bit logic
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#con' title="Binary OR"><code>++con</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#dis' title="Binary AND (atoms)"><code>++dis</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#mix' title="Binary XOR (atom)"><code>++mix</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#not' title="Binary NOT (atom)"><code>++not</code></a>
+<a class="tooltip" href='/docs/reference/library/2d/#con' title="Binary OR"><code>++con</code></a>
+<a class="tooltip" href='/docs/reference/library/2d/#dis' title="Binary AND (atoms)"><code>++dis</code></a>
+<a class="tooltip" href='/docs/reference/library/2d/#mix' title="Binary XOR (atom)"><code>++mix</code></a>
+<a class="tooltip" href='/docs/reference/library/2d/#not' title="Binary NOT (atom)"><code>++not</code></a>
 
 ### 2e: insecure hashing
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#fnv' title="FNV scrambler"><code>++fnv</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#mug' title="FNV-1a scrambler"><code>++mug</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#muk' title="Standard MurmurHash3"><code>++muk</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#mum' title="31-bit MurmurHash3 scrambler"><code>++mum</code></a>
+<a class="tooltip" href='/docs/reference/library/2e/#fnv' title="FNV scrambler"><code>++fnv</code></a>
+<a class="tooltip" href='/docs/reference/library/2e/#mug' title="FNV-1a scrambler"><code>++mug</code></a>
+<a class="tooltip" href='/docs/reference/library/2e/#muk' title="Standard MurmurHash3"><code>++muk</code></a>
+<a class="tooltip" href='/docs/reference/library/2e/#mum' title="31-bit MurmurHash3 scrambler"><code>++mum</code></a>
 
 ### 2f: noun ordering
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#aor' title="Alphabetical order"><code>++aor</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#dor' title="Numeric order"><code>++dor</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#gor' title="Hash order"><code>++gor</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#hor' title="Horizontal hash order"><code>++hor</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#lor' title="Leg order"><code>++lor</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#vor'><code>++vor</code></a>
+<a class="tooltip" href='/docs/reference/library/2f/#aor' title="Alphabetical order"><code>++aor</code></a>
+<a class="tooltip" href='/docs/reference/library/2f/#dor' title="Numeric order"><code>++dor</code></a>
+<a class="tooltip" href='/docs/reference/library/2f/#gor' title="Hash order"><code>++gor</code></a>
+<a class="tooltip" href='/docs/reference/library/2f/#hor' title="Horizontal hash order"><code>++hor</code></a>
+<a class="tooltip" href='/docs/reference/library/2f/#lor' title="Leg order"><code>++lor</code></a>
+<a class="tooltip" href='/docs/reference/library/2f/#vor'><code>++vor</code></a>
 
 ### 2g: unsigned powers
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2g/#pow' title="Computes a to the power of b"><code>++pow</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2g/#sqt'><code>++sqt</code></a>
+<a class="tooltip" href='/docs/reference/library/2g/#pow' title="Computes a to the power of b"><code>++pow</code></a>
+<a class="tooltip" href='/docs/reference/library/2g/#sqt'><code>++sqt</code></a>
 
 ### 2h: set logic
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#in'><code>++in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#all-in' title="Logical AND (set and wet gate)"><code>+-all:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#any-in' title="Logical OR (set and gate)"><code>+-any:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#apt-in' title="Check correctness (set)"><code>+-apt:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#bif-in' title="Bifurcate set"><code>+-bif:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#del-in' title="Delete (set)"><code>+-del:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#dif-in' title='Difference (set)'><code>+-dif:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#dig-in' title="Address of a in set"><code>+-dig:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#gas-in' title="Concatenate (set)"><code>+-gas:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#has-in' title="Key existence check (set)"><code>+-has:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#int-in' title="Intersection (set)"><code>+-int:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#put-in' title="Put b in a (set)"><code>+-put:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#rep-in' title="Accumulate elements (set)"><code>+-rep:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#run-in' title="Apply gate to set"><code>+-run:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#tap-in'><code>+-tap:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#uni-in'><code>+-uni:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#wyt-in'><code>+-wyt:in</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#in'><code>++in</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#all-in' title="Logical AND (set and wet gate)"><code>+-all:in</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#any-in' title="Logical OR (set and gate)"><code>+-any:in</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#apt-in' title="Check correctness (set)"><code>+-apt:in</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#bif-in' title="Bifurcate set"><code>+-bif:in</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#del-in' title="Delete (set)"><code>+-del:in</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#dif-in' title='Difference (set)'><code>+-dif:in</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#dig-in' title="Address of a in set"><code>+-dig:in</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#gas-in' title="Concatenate (set)"><code>+-gas:in</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#has-in' title="Key existence check (set)"><code>+-has:in</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#int-in' title="Intersection (set)"><code>+-int:in</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#put-in' title="Put b in a (set)"><code>+-put:in</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#rep-in' title="Accumulate elements (set)"><code>+-rep:in</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#run-in' title="Apply gate to set"><code>+-run:in</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#tap-in'><code>+-tap:in</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#uni-in'><code>+-uni:in</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#wyt-in'><code>+-wyt:in</code></a>
 
 ### 2i: map logic
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#by'><code>++by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#all-by' title="Logical AND (map and wet gate)"><code>+-all:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#any-by' title="Logical OR (map and wet gate)"><code>+-any:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#apt-by' title="Check correctness (map)"><code>+-apt:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#bif-by' title="Bifurcate map"><code>+-bif:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#def-by' title="Difference (map)"><code>+-def:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#del-by' title="Delete (map)"><code>+-del:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#dep-by' title="Difference as patch (map)"><code>+-dep:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#dig-by' title="Address of key (map)"><code>+-dig:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#gas-by' title="Concatenate (map)"><code>+-gas:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#get-by' title="Grab unit value"><code>+-get:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#got-by' title="Assert for value (map)"><code>+-got:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#has-by' title="Key existence check (map)"><code>+-has:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#int-by' title="Intersection (map)"><code>+-int:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#mar-by' title="Assert and add (map)"><code>+-mar:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#put-by' title="Add key-value pair (map)"><code>+-put:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rep-by' title="Replace by product (map)"><code>+-rep:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rib-by' title="Replace values with accumulator (map)"><code>+-rib:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#run-by' title="Transform values (map)"><code>+-run:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rut-by' title="Transform nodes (map)"><code>+-rut:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#tap-by'><code>+-tap:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#uni-by'><code>+-uni:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#urn-by'><code>+-urn:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#wyt-by'><code>+-wyt:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#by' title="Map operations"><code>++by</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#all-by' title="Logical AND (map and wet gate)"><code>+-all:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#any-by' title="Logical OR (map and wet gate)"><code>+-any:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#apt-by' title="Check correctness (map)"><code>+-apt:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#bif-by' title="Bifurcate map"><code>+-bif:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#def-by' title="Difference (map)"><code>+-def:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#del-by' title="Delete (map)"><code>+-del:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#dep-by' title="Difference as patch (map)"><code>+-dep:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#dig-by' title="Address of key (map)"><code>+-dig:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#gas-by' title="Concatenate (map)"><code>+-gas:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#get-by' title="Grab unit value"><code>+-get:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#got-by' title="Assert for value (map)"><code>+-got:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#has-by' title="Key existence check (map)"><code>+-has:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#int-by' title="Intersection (map)"><code>+-int:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#mar-by' title="Assert and add (map)"><code>+-mar:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#put-by' title="Add key-value pair (map)"><code>+-put:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#rep-by' title="Replace by product (map)"><code>+-rep:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#rib-by' title="Replace values with accumulator (map)"><code>+-rib:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#run-by' title="Transform values (map)"><code>+-run:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#rut-by' title="Transform nodes (map)"><code>+-rut:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#tap-by'><code>+-tap:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#uni-by'><code>+-uni:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#urn-by'><code>+-urn:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#wyt-by'><code>+-wyt:by</code></a>
 
 ### 2j: jar and jug logic
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#ja' title="Jar engine"><code>++ja</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#add-ja' title="Prepend to list"><code>+-add:ja</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#get-ja' title="Grab value by key"><code>+-get:ja</code></a>
+<a class="tooltip" href='/docs/reference/library/2j/#ja' title="Jar engine"><code>++ja</code></a>
+<a class="tooltip" href='/docs/reference/library/2j/#add-ja' title="Prepend to list"><code>+-add:ja</code></a>
+<a class="tooltip" href='/docs/reference/library/2j/#get-ja' title="Grab value by key"><code>+-get:ja</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#ju' title="Jug operations"><code>++ju</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#del-ju' title="Delete (jug)"><code>+-del:ju</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#get-ju' title="Retrieve set"><code>+-get:ju</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#has-ju' title="Check contents (jug)"><code>+-has:ju</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#put-ju' title="Add key-set pair (jar)"><code>+-put:ju</code></a>
+<a class="tooltip" href='/docs/reference/library/2j/#ju' title="Jug operations"><code>++ju</code></a>
+<a class="tooltip" href='/docs/reference/library/2j/#del-ju' title="Delete (jug)"><code>+-del:ju</code></a>
+<a class="tooltip" href='/docs/reference/library/2j/#get-ju' title="Retrieve set"><code>+-get:ju</code></a>
+<a class="tooltip" href='/docs/reference/library/2j/#has-ju' title="Check contents (jug)"><code>+-has:ju</code></a>
+<a class="tooltip" href='/docs/reference/library/2j/#put-ju' title="Add key-set pair (jar)"><code>+-put:ju</code></a>
 
 ### 2k: queue logic
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#to'><code>++to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#bal-to' title="Balance queue"><code>+-bal:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#dep-to' title="Maximum depth (queue)"><code>+-dep:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#gas-to' title="Push list into queue"><code>+-gas:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#get-to' title="Head-tail pair"><code>+-get:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#nap-to' title="Remove head of queue"><code>+-nap:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#nip-to' title="Remove root of queue"><code>+-nip:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#put-to' title="Insert into queue"><code>+-put:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#tap-to'><code>+-tap:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#top-to'><code>+-top:to</code></a>
+<a class="tooltip" href='/docs/reference/library/2k/#to'><code>++to</code></a>
+<a class="tooltip" href='/docs/reference/library/2k/#bal-to' title="Balance queue"><code>+-bal:to</code></a>
+<a class="tooltip" href='/docs/reference/library/2k/#dep-to' title="Maximum depth (queue)"><code>+-dep:to</code></a>
+<a class="tooltip" href='/docs/reference/library/2k/#gas-to' title="Push list into queue"><code>+-gas:to</code></a>
+<a class="tooltip" href='/docs/reference/library/2k/#get-to' title="Head-tail pair"><code>+-get:to</code></a>
+<a class="tooltip" href='/docs/reference/library/2k/#nap-to' title="Remove head of queue"><code>+-nap:to</code></a>
+<a class="tooltip" href='/docs/reference/library/2k/#nip-to' title="Remove root of queue"><code>+-nip:to</code></a>
+<a class="tooltip" href='/docs/reference/library/2k/#put-to' title="Insert into queue"><code>+-put:to</code></a>
+<a class="tooltip" href='/docs/reference/library/2k/#tap-to'><code>+-tap:to</code></a>
+<a class="tooltip" href='/docs/reference/library/2k/#top-to'><code>+-top:to</code></a>
 
 ### 2l: container from container
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2l/#malt' title="Map from list"><code>++malt</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2l/#molt' title="Map from pair list"><code>++molt</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2l/#silt'><code>++silt</code></a>
+<a class="tooltip" href='/docs/reference/library/2l/#malt' title="Map from list"><code>++malt</code></a>
+<a class="tooltip" href='/docs/reference/library/2l/#molt' title="Map from pair list"><code>++molt</code></a>
+<a class="tooltip" href='/docs/reference/library/2l/#silt'><code>++silt</code></a>
 
 ### 2m: container from noun
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#nl' title="Noun to container operations"><code>++nl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#le-nl' title="Construct list from null-terminated noun"><code>++le:nl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#my-nl' title="Construct map from null-terminated noun"><code>++my:nl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#si-nl'><code>++si:nl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#snag-nl'><code>++snag:nl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#weld-nl'><code>++weld:nl</code></a>
+<a class="tooltip" href='/docs/reference/library/2m/#nl' title="Noun to container operations"><code>++nl</code></a>
+<a class="tooltip" href='/docs/reference/library/2m/#le-nl' title="Construct list from null-terminated noun"><code>++le:nl</code></a>
+<a class="tooltip" href='/docs/reference/library/2m/#my-nl' title="Construct map from null-terminated noun"><code>++my:nl</code></a>
+<a class="tooltip" href='/docs/reference/library/2m/#si-nl'><code>++si:nl</code></a>
+<a class="tooltip" href='/docs/reference/library/2m/#snag-nl'><code>++snag:nl</code></a>
+<a class="tooltip" href='/docs/reference/library/2m/#weld-nl'><code>++weld:nl</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#ly' title="List from raw noun"><code>++ly</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#my' title="Map from raw noun"><code>++my</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#sy'><code>++sy</code></a>
+<a class="tooltip" href='/docs/reference/library/2m/#ly' title="List from raw noun"><code>++ly</code></a>
+<a class="tooltip" href='/docs/reference/library/2m/#my' title="Map from raw noun"><code>++my</code></a>
+<a class="tooltip" href='/docs/reference/library/2m/#sy'><code>++sy</code></a>
 
 ### 2n: functional hacks
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#cork' title="Compose forward"><code>++cork</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#corl' title="Compose backward"><code>++corl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#curr' title="Right-curry a gate"><code>++curr</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#cury' title="Curry left a gate"><code>++cury</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#hard' title="Force remold"><code>++hard</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#head' title="Get head of cell"><code>++head</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#mean' title="Crash and printf"><code>++mean</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#same'><code>++same</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#slog'><code>++slog</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#soft'><code>++soft</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#tail'><code>++tail</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#test'><code>++test</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#cork' title="Compose forward"><code>++cork</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#corl' title="Compose backward"><code>++corl</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#curr' title="Right-curry a gate"><code>++curr</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#cury' title="Curry left a gate"><code>++cury</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#hard' title="Force remold"><code>++hard</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#head' title="Get head of cell"><code>++head</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#mean' title="Crash and printf"><code>++mean</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#same'><code>++same</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#slog'><code>++slog</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#soft'><code>++soft</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#tail'><code>++tail</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#test'><code>++test</code></a>
 
 ### 2o: normalizing containers
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#jar' title="Mold generator (jar)"><code>++jar</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#jug' title="Mold generator (jug)"><code>++jug</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#map' title="Mold generator (map)"><code>++map</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#qeu' title="Mold generator (queue)"><code>++qeu</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#set'><code>++set</code></a>
+<a class="tooltip" href='/docs/reference/library/2o/#jar' title="Mold generator (jar)"><code>++jar</code></a>
+<a class="tooltip" href='/docs/reference/library/2o/#jug' title="Mold generator (jug)"><code>++jug</code></a>
+<a class="tooltip" href='/docs/reference/library/2o/#map' title="Mold generator (map)"><code>++map</code></a>
+<a class="tooltip" href='/docs/reference/library/2o/#qeu' title="Mold generator (queue)"><code>++qeu</code></a>
+<a class="tooltip" href='/docs/reference/library/2o/#set'><code>++set</code></a>
 
 ### 2p: serialization
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#cue' title="Unpack atom to noun"><code>++cue</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#jam' title="Pack noun to atom"><code>++jam</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#mat' title="Length-encode"><code>++mat</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#rub' title="Length-decode"><code>++rub</code></a>
+<a class="tooltip" href='/docs/reference/library/2p/#cue' title="Unpack atom to noun"><code>++cue</code></a>
+<a class="tooltip" href='/docs/reference/library/2p/#jam' title="Pack noun to atom"><code>++jam</code></a>
+<a class="tooltip" href='/docs/reference/library/2p/#mat' title="Length-encode"><code>++mat</code></a>
+<a class="tooltip" href='/docs/reference/library/2p/#rub' title="Length-decode"><code>++rub</code></a>
 
 ### 2q: molds and mold builders
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#char' title="Character"><code>++char</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#cord' title="UTF-8 text"><code>++cord</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#date' title="Point in time"><code>++date</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#knot' title="Atom type of ASCII characters"><code>++knot</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#tang'><code>++tang</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#tank'><code>++tank</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#tape'><code>++tape</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#tarp'><code>++tarp</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#term'><code>++term</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#wain'><code>++wain</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#wall'><code>++wall</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#char' title="Character"><code>++char</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#cord' title="UTF-8 text"><code>++cord</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#date' title="Point in time"><code>++date</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#knot' title="Atom type of ASCII characters"><code>++knot</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#tang'><code>++tang</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#tank'><code>++tank</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#tape'><code>++tape</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#tarp'><code>++tarp</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#term'><code>++term</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#wain'><code>++wain</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#wall'><code>++wall</code></a>
 
 ### 3a: modular and signed ints
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fo' title="Modulo prime"><code>++fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dif-fo' title='Subtraction (modular base)'><code>++dif:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#exp-fo' title="Exponent (modular base)"><code>++exp:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fra-fo' title="Divide (modular base)"><code>++fra:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#inv-fo' title="Inverse (signed modulus)"><code>++inv:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#pro-fo' title="Multiplies b and c modulo a"><code>++pro:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#sit-fo'><code>++sit:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#sum-fo'><code>++sum:fo</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#fo' title="Modulo prime"><code>++fo</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#dif-fo' title='Subtraction (modular base)'><code>++dif:fo</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#exp-fo' title="Exponent (modular base)"><code>++exp:fo</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#fra-fo' title="Divide (modular base)"><code>++fra:fo</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#inv-fo' title="Inverse (signed modulus)"><code>++inv:fo</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#pro-fo' title="Multiplies b and c modulo a"><code>++pro:fo</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#sit-fo'><code>++sit:fo</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#sum-fo'><code>++sum:fo</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#si'><code>++si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#abs-si' title="Absolute value (signed integer)"><code>++abs:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#cmp-si' title="Compare (signed integer)"><code>++cmp:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dif-si' title="Subtraction (signed integer)"><code>++dif:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dul-si' title="Modulus (signed integer)"><code>++dul:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fra-si' title="Divide (signed integer)"><code>++fra:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#new-si' title="Atom to @s"><code>++new:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#old-si' title="Sign and absolute value"><code>++old:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#pro-si' title="Multiply to signed integer"><code>++pro:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#rem-si' title="Remainder (signed integer)"><code>++rem:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#sum-si'><code>++sum:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#sun-si'><code>++sun:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#syn-si'><code>++syn:si</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#si'><code>++si</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#abs-si' title="Absolute value (signed integer)"><code>++abs:si</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#cmp-si' title="Compare (signed integer)"><code>++cmp:si</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#dif-si' title="Subtraction (signed integer)"><code>++dif:si</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#dul-si' title="Modulus (signed integer)"><code>++dul:si</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#fra-si' title="Divide (signed integer)"><code>++fra:si</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#new-si' title="Atom to @s"><code>++new:si</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#old-si' title="Sign and absolute value"><code>++old:si</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#pro-si' title="Multiply to signed integer"><code>++pro:si</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#rem-si' title="Remainder (signed integer)"><code>++rem:si</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#sum-si'><code>++sum:si</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#sun-si'><code>++sun:si</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#syn-si'><code>++syn:si</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#egcd' title="Extended Euclidean algorithm"><code>++egcd</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#egcd' title="Extended Euclidean algorithm"><code>++egcd</code></a>
 
 ### 3b: floating point
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#dn'><code>++dn</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fn'><code>++fn</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rn'><code>++rn</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#dn'><code>++dn</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#fn'><code>++fn</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#rn'><code>++rn</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ff'><code>++ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-ff' title="Add (floating point)"><code>++add:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bif-ff' title="Converts from fn to @r"><code>++bif:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-ff' title="fn to @r with rounding"><code>++bit:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-ff' title="Divide (IEEE float)"><code>++div:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-ff' title="@r to decimal float"><code>++drg:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-ff' title="Equals (IEEE float)"><code>++equ:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-ff' title="Get exponent (IEEE float)"><code>++exp:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-ff' title="Fused multiply-add (IEEE float)"><code>++fma:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-ff' title="Decimal float to @r"><code>++grd:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-ff' title="Greater than / equal (IEEE float)"><code>++gte:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-ff' title="Greater than (IEEE float)"><code>++gth:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-ff' title="Less than / equal (IEEE float)"><code>++lte:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-ff' title="Less than (IEEE float)"><code>++lth:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#me-ff' title="Minimum exponent of ff"><code>++me:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-ff' title="Multiply (IEEE float)"><code>++mul:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#pa-ff' title="Initialize fl from ff core"><code>++pa:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-ff'><code>++san:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sb-ff'><code>++sb:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sea-ff'><code>++sea:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sig-ff'><code>++sig:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sqt-ff'><code>++sqt:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sub-ff'><code>++sub:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sun-ff'><code>++sun:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toi-ff'><code>++toi:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#ff'><code>++ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#add-ff' title="Add (floating point)"><code>++add:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#bif-ff' title="Converts from fn to @r"><code>++bif:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#bit-ff' title="fn to @r with rounding"><code>++bit:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#div-ff' title="Divide (IEEE float)"><code>++div:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#drg-ff' title="@r to decimal float"><code>++drg:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#equ-ff' title="Equals (IEEE float)"><code>++equ:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#exp-ff' title="Get exponent (IEEE float)"><code>++exp:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#fma-ff' title="Fused multiply-add (IEEE float)"><code>++fma:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#grd-ff' title="Decimal float to @r"><code>++grd:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#gte-ff' title="Greater than / equal (IEEE float)"><code>++gte:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#gth-ff' title="Greater than (IEEE float)"><code>++gth:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#lte-ff' title="Less than / equal (IEEE float)"><code>++lte:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#lth-ff' title="Less than (IEEE float)"><code>++lth:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#me-ff' title="Minimum exponent of ff"><code>++me:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#mul-ff' title="Multiply (IEEE float)"><code>++mul:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#pa-ff' title="Initialize fl from ff core"><code>++pa:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#san-ff'><code>++san:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sb-ff'><code>++sb:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sea-ff'><code>++sea:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sig-ff'><code>++sig:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sqt-ff'><code>++sqt:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sub-ff'><code>++sub:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sun-ff'><code>++sun:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#toi-ff'><code>++toi:ff</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fl'><code>++fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#abs-fl' title="Absolute value"><code>++abs:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-fl' title="Add (with exact/rounded flag)"><code>++add:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#den-fl' title="Denormalizes (floating point)"><code>++den:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-fl' title="Divide (signed and unsigned integer cell)"><code>++div:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-fl' title="Get printable decimal (signed and unsigned integer cell)"><code>++drg:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ead-fl' title="Exact add"><code>++ead:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emn-fl' title="Minimum exponent"><code>++emn:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emu-fl' title="Exact multiply"><code>++emu:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emx-fl' title="Maximum exponent"><code>++emx:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-fl' title="Equals (signed and unsigned integer cell)"><code>++equ:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fli-fl' title="Flip sign"><code>++fli:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-fl' title="Fused multiply-add"><code>++fma:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-fl' title="Decimal to float"><code>++grd:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-fl' title="Greater than / equal (producing flag)"><code>++gte:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-fl' title="Greater than (producing flag)"><code>++gth:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ibl-fl' title="Integer binary logarithm"><code>++ibl:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#inv-fl' title="Inverse"><code>++inv:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lfe-fl' title="Maximum"><code>++lfe:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lfn-fl' title="Largest normal float"><code>++lfn:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-fl' title="Less than / equal (producing flag)"><code>++lte:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-fl' title="Less than (signed and unsigned integer cell)"><code>++lth:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lug-fl' title="Central rounding mechanism"><code>++lug:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-fl' title="Multiply (signed and unsigned integer cell)"><code>++mul:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ned-fl' title="Require float"><code>++ned:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#prc-fl' title="Force precision of 2 or greater (floating point)"><code>++prc:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rau-fl' title="Various roundings (floating point)"><code>++rau:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rou-fl' title="Round to nearest float with 113-bit significand"><code>++rou:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-fl'><code>++san:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#shf-fl'><code>++shf:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#spd-fl'><code>++spd:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#spn-fl'><code>++spn:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sqt-fl'><code>++sqt:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sub-fl'><code>++sub:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sun-fl'><code>++sun:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#swr-fl'><code>++swr:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#syn-fl'><code>++syn:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toi-fl'><code>++toi:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toj-fl'><code>++toj:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#uni-fl'><code>++uni:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#xpd-fl'><code>++xpd:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#zer-fl'><code>++zer:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#fl'><code>++fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#abs-fl' title="Absolute value"><code>++abs:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#add-fl' title="Add (with exact/rounded flag)"><code>++add:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#den-fl' title="Denormalizes (floating point)"><code>++den:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#div-fl' title="Divide (signed and unsigned integer cell)"><code>++div:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#drg-fl' title="Get printable decimal (signed and unsigned integer cell)"><code>++drg:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#ead-fl' title="Exact add"><code>++ead:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#emn-fl' title="Minimum exponent"><code>++emn:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#emu-fl' title="Exact multiply"><code>++emu:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#emx-fl' title="Maximum exponent"><code>++emx:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#equ-fl' title="Equals (signed and unsigned integer cell)"><code>++equ:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#fli-fl' title="Flip sign"><code>++fli:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#fma-fl' title="Fused multiply-add"><code>++fma:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#grd-fl' title="Decimal to float"><code>++grd:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#gte-fl' title="Greater than / equal (producing flag)"><code>++gte:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#gth-fl' title="Greater than (producing flag)"><code>++gth:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#ibl-fl' title="Integer binary logarithm"><code>++ibl:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#inv-fl' title="Inverse"><code>++inv:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#lfe-fl' title="Maximum"><code>++lfe:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#lfn-fl' title="Largest normal float"><code>++lfn:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#lte-fl' title="Less than / equal (producing flag)"><code>++lte:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#lth-fl' title="Less than (signed and unsigned integer cell)"><code>++lth:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#lug-fl' title="Central rounding mechanism"><code>++lug:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#mul-fl' title="Multiply (signed and unsigned integer cell)"><code>++mul:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#ned-fl' title="Require float"><code>++ned:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#prc-fl' title="Force precision of 2 or greater (floating point)"><code>++prc:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#rau-fl' title="Various roundings (floating point)"><code>++rau:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#rou-fl' title="Round to nearest float with 113-bit significand"><code>++rou:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#san-fl'><code>++san:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#shf-fl'><code>++shf:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#spd-fl'><code>++spd:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#spn-fl'><code>++spn:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sqt-fl'><code>++sqt:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sub-fl'><code>++sub:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sun-fl'><code>++sun:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#swr-fl'><code>++swr:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#syn-fl'><code>++syn:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#toi-fl'><code>++toi:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#toj-fl'><code>++toj:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#uni-fl'><code>++uni:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#xpd-fl'><code>++xpd:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#zer-fl'><code>++zer:fl</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rd'><code>++rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rd' title="Add (double-precision float)"><code>++add:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rd' title="fn to double-precision binary float"><code>++bit:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rd' title="Double precision float"><code>++div:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rd' title="@rd to decimal float"><code>++drg:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rd' title="Equals (double-precision float)"><code>++equ:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rd' title="Exponent (@rd)"><code>++exp:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rd' title="Fused multiply-add (@rd)"><code>++fma:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rd' title="Decimal float to @rd"><code>++grd:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rd' title="Greater than / equal (double-precision float)"><code>++gte:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rd' title="Greater than (double-precision float)"><code>++gth:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rd' title="Less than / equal (double-precision float)"><code>++lte:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rd' title="Less than (double-precision float)"><code>++lth:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rd' title="Initialize ff (rd core)"><code>++ma:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rd' title="Multiply (double-precision float)"><code>++mul:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-rd'><code>++san:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sea-rd'><code>++sea:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sig-rd'><code>++sig:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sqt-rd'><code>++sqt:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sub-rd'><code>++sub:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sun-rd'><code>++sun:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toi-rd'><code>++toi:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#rd'><code>++rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#add-rd' title="Add (double-precision float)"><code>++add:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#bit-rd' title="fn to double-precision binary float"><code>++bit:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#div-rd' title="Double precision float"><code>++div:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#drg-rd' title="@rd to decimal float"><code>++drg:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#equ-rd' title="Equals (double-precision float)"><code>++equ:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#exp-rd' title="Exponent (@rd)"><code>++exp:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#fma-rd' title="Fused multiply-add (@rd)"><code>++fma:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#grd-rd' title="Decimal float to @rd"><code>++grd:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#gte-rd' title="Greater than / equal (double-precision float)"><code>++gte:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#gth-rd' title="Greater than (double-precision float)"><code>++gth:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#lte-rd' title="Less than / equal (double-precision float)"><code>++lte:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#lth-rd' title="Less than (double-precision float)"><code>++lth:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#ma-rd' title="Initialize ff (rd core)"><code>++ma:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#mul-rd' title="Multiply (double-precision float)"><code>++mul:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#san-rd'><code>++san:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sea-rd'><code>++sea:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sig-rd'><code>++sig:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sqt-rd'><code>++sqt:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sub-rd'><code>++sub:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sun-rd'><code>++sun:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#toi-rd'><code>++toi:rd</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rh'><code>++rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rh' title="Add (half-precision float)"><code>++add:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rh' title="fn to half-precision float"><code>++bit:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rh' title="Divide (half-precision float)"><code>++div:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rh' title="@rh to decimal float"><code>++drg:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rh' title="Equals (half-precision float)"><code>++equ:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rh' title="Exponent (half-precision float)"><code>++exp:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rh' title="Fused multiply-add (half-precision float)"><code>++fma:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fos-rh' title="@rs to @rh"><code>++fos:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rh' title="Decimal float to @rh"><code>++grd:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rh' title="Greater than / equal (half-precision float)"><code>++gte:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rh' title="Greater than (half-precision float)"><code>++gth:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rh' title="Less than / equal (half-precision float)"><code>++lte:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rh' title="Less than (half-precision float)"><code>++lth:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rh' title="Initialize ff (rh core)"><code>++ma:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rh' title="Multiply (quad-precision float)"><code>++mul:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-rh'><code>++san:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sea-rh'><code>++sea:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sig-rh'><code>++sig:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sqt-rh'><code>++sqt:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sub-rh'><code>++sub:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sun-rh'><code>++sun:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toi-rh'><code>++toi:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#tos-rh'><code>++tos:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#rh'><code>++rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#add-rh' title="Add (half-precision float)"><code>++add:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#bit-rh' title="fn to half-precision float"><code>++bit:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#div-rh' title="Divide (half-precision float)"><code>++div:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#drg-rh' title="@rh to decimal float"><code>++drg:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#equ-rh' title="Equals (half-precision float)"><code>++equ:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#exp-rh' title="Exponent (half-precision float)"><code>++exp:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#fma-rh' title="Fused multiply-add (half-precision float)"><code>++fma:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#fos-rh' title="@rs to @rh"><code>++fos:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#grd-rh' title="Decimal float to @rh"><code>++grd:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#gte-rh' title="Greater than / equal (half-precision float)"><code>++gte:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#gth-rh' title="Greater than (half-precision float)"><code>++gth:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#lte-rh' title="Less than / equal (half-precision float)"><code>++lte:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#lth-rh' title="Less than (half-precision float)"><code>++lth:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#ma-rh' title="Initialize ff (rh core)"><code>++ma:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#mul-rh' title="Multiply (quad-precision float)"><code>++mul:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#san-rh'><code>++san:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sea-rh'><code>++sea:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sig-rh'><code>++sig:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sqt-rh'><code>++sqt:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sub-rh'><code>++sub:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sun-rh'><code>++sun:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#toi-rh'><code>++toi:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#tos-rh'><code>++tos:rh</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rs'><code>++rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rs' title="Add (single-precision float)"><code>++add:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rs' title="fn to single-precision float"><code>++bit:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rs' title="Divide (single-precision float)"><code>++div:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rs' title="@rs to decimal float"><code>++drg:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rs' title="Equals (single-precision float)"><code>++equ:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rs' title="Exponent (@rs)"><code>++exp:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rs' title="Fused multiply-add (single-precision float)"><code>++fma:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rs' title="Decimal float to @rs"><code>++grd:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rs' title="Greater than / equal (single-precision float)"><code>++gte:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rs' title="Greater than (single-precision float)"><code>++gth:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rs' title="Less than / equal (single-precision float)"><code>++lte:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rs' title="Less than (single-precision float)"><code>++lth:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rs' title="Initialize ff (rs core)"><code>++ma:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rs' title="Multiply (single-precision float)"><code>++mul:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-rs'><code>++san:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sea-rs'><code>++sea:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sig-rs'><code>++sig:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sqt-rs'><code>++sqt:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sub-rs'><code>++sub:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sun-rs'><code>++sun:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toi-rs'><code>++toi:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#rs'><code>++rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#add-rs' title="Add (single-precision float)"><code>++add:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#bit-rs' title="fn to single-precision float"><code>++bit:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#div-rs' title="Divide (single-precision float)"><code>++div:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#drg-rs' title="@rs to decimal float"><code>++drg:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#equ-rs' title="Equals (single-precision float)"><code>++equ:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#exp-rs' title="Exponent (@rs)"><code>++exp:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#fma-rs' title="Fused multiply-add (single-precision float)"><code>++fma:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#grd-rs' title="Decimal float to @rs"><code>++grd:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#gte-rs' title="Greater than / equal (single-precision float)"><code>++gte:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#gth-rs' title="Greater than (single-precision float)"><code>++gth:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#lte-rs' title="Less than / equal (single-precision float)"><code>++lte:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#lth-rs' title="Less than (single-precision float)"><code>++lth:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#ma-rs' title="Initialize ff (rs core)"><code>++ma:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#mul-rs' title="Multiply (single-precision float)"><code>++mul:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#san-rs'><code>++san:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sea-rs'><code>++sea:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sig-rs'><code>++sig:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sqt-rs'><code>++sqt:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sub-rs'><code>++sub:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sun-rs'><code>++sun:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#toi-rs'><code>++toi:rs</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rq'><code>++rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rq' title="Add (quad-precision float)"><code>++add:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rq' title="fn to quad-precision float"><code>++bit:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rq' title="Divide (quad-precision float)"><code>++div:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rq' title="@rq to decimal float"><code>++drg:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rq' title="Equals (quad-precision float)"><code>++equ:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rq' title="Exponent (quad-precision float)"><code>++exp:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rq' title="Fused multiply-add (quad-precision float)"><code>++fma:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rq' title="Decimal float to @rq"><code>++grd:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rq' title="Greater than / equal (quad-precision float)"><code>++gte:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rq' title="Greater than (quad-precision float)"><code>++gth:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rq' title="Less than / equal (quad-precision float)"><code>++lte:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rq' title="Less than (quad-precision float)"><code>++lth:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rq' title="Initialize ff (rq core)"><code>++ma:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rq' title="Multiply (quad-precision float)"><code>++mul:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-rq'><code>++san:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sea-rq'><code>++sea:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sig-rq'><code>++sig:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sqt-rq'><code>++sqt:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sub-rq'><code>++sub:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sun-rq'><code>++sun:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toi-rq'><code>++toi:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#rq'><code>++rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#add-rq' title="Add (quad-precision float)"><code>++add:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#bit-rq' title="fn to quad-precision float"><code>++bit:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#div-rq' title="Divide (quad-precision float)"><code>++div:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#drg-rq' title="@rq to decimal float"><code>++drg:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#equ-rq' title="Equals (quad-precision float)"><code>++equ:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#exp-rq' title="Exponent (quad-precision float)"><code>++exp:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#fma-rq' title="Fused multiply-add (quad-precision float)"><code>++fma:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#grd-rq' title="Decimal float to @rq"><code>++grd:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#gte-rq' title="Greater than / equal (quad-precision float)"><code>++gte:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#gth-rq' title="Greater than (quad-precision float)"><code>++gth:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#lte-rq' title="Less than / equal (quad-precision float)"><code>++lte:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#lth-rq' title="Less than (quad-precision float)"><code>++lth:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#ma-rq' title="Initialize ff (rq core)"><code>++ma:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#mul-rq' title="Multiply (quad-precision float)"><code>++mul:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#san-rq'><code>++san:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sea-rq'><code>++sea:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sig-rq'><code>++sig:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sqt-rq'><code>++sqt:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sub-rq'><code>++sub:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sun-rq'><code>++sun:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#toi-rq'><code>++toi:rq</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rlyd'><code>++rlyd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rlyh'><code>++rlyh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rlyq'><code>++rlyq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rlys'><code>++rlys</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ryld'><code>++ryld</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rylh'><code>++rylh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rylq'><code>++rylq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ryls'><code>++ryls</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#rlyd'><code>++rlyd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#rlyh'><code>++rlyh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#rlyq'><code>++rlyq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#rlys'><code>++rlys</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#ryld'><code>++ryld</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#rylh'><code>++rylh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#rylq'><code>++rylq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#ryls'><code>++ryls</code></a>
 
 ### 3c: urbit time
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yo'><code>++yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#cet-yo' title="Days in a century"><code>++cet:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#day-yo' title="Seconds in day"><code>++day:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#era-yo' title="Leap-year period"><code>++era:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#hor-yo' title="Seconds in hour"><code>++hor:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#jes-yo' title="Maximum 64-bit timestamp"><code>++jes:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#mit-yo' title="Seconds in minute"><code>++mit:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#moh-yo' title="Days in month"><code>++moh:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#moy-yo' title="Days in months of leap-year"><code>++moy:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#qad-yo' title="Seconds in 4 years"><code>++qad:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yer-yo'><code>++yer:yo</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yo'><code>++yo</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#cet-yo' title="Days in a century"><code>++cet:yo</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#day-yo' title="Seconds in day"><code>++day:yo</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#era-yo' title="Leap-year period"><code>++era:yo</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#hor-yo' title="Seconds in hour"><code>++hor:yo</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#jes-yo' title="Maximum 64-bit timestamp"><code>++jes:yo</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#mit-yo' title="Seconds in minute"><code>++mit:yo</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#moh-yo' title="Days in month"><code>++moh:yo</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#moy-yo' title="Days in months of leap-year"><code>++moy:yo</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#qad-yo' title="Seconds in 4 years"><code>++qad:yo</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yer-yo'><code>++yer:yo</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yall'><code>++yall</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yawn'><code>++yawn</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#year'><code>++year</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yell'><code>++yell</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yelp'><code>++yelp</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yore'><code>++yore</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yule'><code>++yule</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yall'><code>++yall</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yawn'><code>++yawn</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#year'><code>++year</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yell'><code>++yell</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yelp'><code>++yelp</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yore'><code>++yore</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yule'><code>++yule</code></a>
 
 ### 3d: SHA hash family
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#og' title="Container arm for SHA-256 powered RNG"><code>++og</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#rad-og' title="Random in range"><code>++rad:og</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#rads-og' title="Random continuation"><code>++rads:og</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#raw-og' title="Random bits"><code>++raw:og</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#raws-og' title="Random bits continuation"><code>++raws:og</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#og' title="Container arm for SHA-256 powered RNG"><code>++og</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#rad-og' title="Random in range"><code>++rad:og</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#rads-og' title="Random continuation"><code>++rads:og</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#raw-og' title="Random bits"><code>++raw:og</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#raws-og' title="Random bits continuation"><code>++raws:og</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shad'><code>++shad</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shaf'><code>++shaf</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shal'><code>++shal</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#sham'><code>++sham</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shan'><code>++shan</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shas'><code>++shas</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shaw'><code>++shaw</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shax'><code>++shax</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shay'><code>++shay</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shaz'><code>++shaz</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shad'><code>++shad</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shaf'><code>++shaf</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shal'><code>++shal</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#sham'><code>++sham</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shan'><code>++shan</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shas'><code>++shas</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shaw'><code>++shaw</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shax'><code>++shax</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shay'><code>++shay</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shaz'><code>++shaz</code></a>
 
 ### 3e: AES encryption
 
-<a href='https://urbit.org/docs/reference/library/3e/'>_(removed)_</a>
+<a href='/docs/reference/library/3e/'>_(removed)_</a>
 
 ### 3f: scrambling
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#ob' title="Reversible scrambling v2"><code>++ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#feen-ob' title="Conceal structure v2"><code>++feen:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#fend-ob' title="Restore structure v2"><code>++fend:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#fice-ob' title="Feistel-like cipher"><code>++fice:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#raku-ob' title="Key list"><code>++raku:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#rund-ob' title="Reverse single Feistel-like"><code>++rund:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#rynd-ob' title="Reverse Feistel-like cipher"><code>++rynd:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#teil-ob'><code>++teil:ob</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#ob' title="Reversible scrambling v2"><code>++ob</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#feen-ob' title="Conceal structure v2"><code>++feen:ob</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#fend-ob' title="Restore structure v2"><code>++fend:ob</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#fice-ob' title="Feistel-like cipher"><code>++fice:ob</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#raku-ob' title="Key list"><code>++raku:ob</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#rund-ob' title="Reverse single Feistel-like"><code>++rund:ob</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#rynd-ob' title="Reverse Feistel-like cipher"><code>++rynd:ob</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#teil-ob'><code>++teil:ob</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#un'><code>++un</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#wred-un'><code>++wred:un</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#wren-un'><code>++wren:un</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#xafo-un'><code>++xafo:un</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#xaro-un'><code>++xaro:un</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#zaft-un'><code>++zaft:un</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#zart-un'><code>++zart:un</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#zyft-un'><code>++zyft:un</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#zyrt-un'><code>++zyrt:un</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#un'><code>++un</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#wred-un'><code>++wred:un</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#wren-un'><code>++wren:un</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#xafo-un'><code>++xafo:un</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#xaro-un'><code>++xaro:un</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#zaft-un'><code>++zaft:un</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#zart-un'><code>++zart:un</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#zyft-un'><code>++zyft:un</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#zyrt-un'><code>++zyrt:un</code></a>
 
 ### 3g: molds and mold builders
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#coin' title="Noun-literal syntax cases"><code>++coin</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#dime' title="Aura-atom pair"><code>++dime</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#edge' title="Parsing location metadata"><code>++edge</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#hair' title="Parsing line and column"><code>++hair</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#like' title="Generic edge"><code>++like</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#nail' title="Location, remainder of parsed text"><code>++nail</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#path' title="Filesystem path"><code>++path</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#pint' title="Parsing range"><code>++pint</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#rule' title="Parsing rule (match this with _)"><code>++rule</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#spot'><code>++spot</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#tone'><code>++tone</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#toon'><code>++toon</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#wonk'><code>++wonk</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#coin' title="Noun-literal syntax cases"><code>++coin</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#dime' title="Aura-atom pair"><code>++dime</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#edge' title="Parsing location metadata"><code>++edge</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#hair' title="Parsing line and column"><code>++hair</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#like' title="Generic edge"><code>++like</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#nail' title="Location, remainder of parsed text"><code>++nail</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#path' title="Filesystem path"><code>++path</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#pint' title="Parsing range"><code>++pint</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#rule' title="Parsing rule (match this with _)"><code>++rule</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#spot'><code>++spot</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#tone'><code>++tone</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#toon'><code>++toon</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#wonk'><code>++wonk</code></a>
 
 ### 4a: exotic bases
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#po' title="Phonetic base"><code>++po</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#ind-po' title="Parse suffix"><code>++ind:po</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#ins-po' title="Parse prefix"><code>++ins:po</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#tod-po'><code>++tod:po</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#tos-po'><code>++tos:po</code></a>
+<a class="tooltip" href='/docs/reference/library/4a/#po' title="Phonetic base"><code>++po</code></a>
+<a class="tooltip" href='/docs/reference/library/4a/#ind-po' title="Parse suffix"><code>++ind:po</code></a>
+<a class="tooltip" href='/docs/reference/library/4a/#ins-po' title="Parse prefix"><code>++ins:po</code></a>
+<a class="tooltip" href='/docs/reference/library/4a/#tod-po'><code>++tod:po</code></a>
+<a class="tooltip" href='/docs/reference/library/4a/#tos-po'><code>++tos:po</code></a>
 
 ### 4b: text processing
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#at' title="(Undocumented)"><code>++at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#r-at' title="(Undocumented)"><code>++r:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rf-at' title="(Undocumented)"><code>++rf:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rn-at' title="(Undocumented)"><code>++rn:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rt-at' title="(Undocumented)"><code>++rt:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rta-at' title="(Undocumented)"><code>++rta:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rtam-at' title="(Undocumented)"><code>++rtam:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rub-at' title="(Undocumented)"><code>++rub:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rud-at' title="(Undocumented)"><code>++rud:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rum-at' title="(Undocumented)"><code>++rum:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rup-at' title="(Undocumented)"><code>++rup:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#ruv-at' title="(Undocumented)"><code>++ruv:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rux-at' title="(Undocumented)"><code>++rux:at</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#at' title="(Undocumented)"><code>++at</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#r-at' title="(Undocumented)"><code>++r:at</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#rf-at' title="(Undocumented)"><code>++rf:at</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#rn-at' title="(Undocumented)"><code>++rn:at</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#rt-at' title="(Undocumented)"><code>++rt:at</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#rta-at' title="(Undocumented)"><code>++rta:at</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#rtam-at' title="(Undocumented)"><code>++rtam:at</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#rub-at' title="(Undocumented)"><code>++rub:at</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#rud-at' title="(Undocumented)"><code>++rud:at</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#rum-at' title="(Undocumented)"><code>++rum:at</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#rup-at' title="(Undocumented)"><code>++rup:at</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#ruv-at' title="(Undocumented)"><code>++ruv:at</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#rux-at' title="(Undocumented)"><code>++rux:at</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#cass' title="To lowercase"><code>++cass</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#crip' title="Tape to cord"><code>++crip</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#cuss' title="To uppercase"><code>++cuss</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#mesc' title="Escape special characters"><code>++mesc</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#runt' title="Prepend n times"><code>++runt</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#sand'><code>++sand</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#sane'><code>++sane</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#teff'><code>++teff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#trim'><code>++trim</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#trip'><code>++trip</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#tuba'><code>++tuba</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#tufa'><code>++tufa</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#tuft'><code>++tuft</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#turf'><code>++turf</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#wack'><code>++wack</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#wick'><code>++wick</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#woad'><code>++woad</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#wood'><code>++wood</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#cass' title="To lowercase"><code>++cass</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#crip' title="Tape to cord"><code>++crip</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#cuss' title="To uppercase"><code>++cuss</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#mesc' title="Escape special characters"><code>++mesc</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#runt' title="Prepend n times"><code>++runt</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#sand'><code>++sand</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#sane'><code>++sane</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#teff'><code>++teff</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#trim'><code>++trim</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#trip'><code>++trip</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#tuba'><code>++tuba</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#tufa'><code>++tufa</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#tuft'><code>++tuft</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#turf'><code>++turf</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#wack'><code>++wack</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#wick'><code>++wick</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#woad'><code>++woad</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#wood'><code>++wood</code></a>
 
 ### 4c: tank printer
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#re' title="Pretty-printing engine (tank)"><code>++re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#din-re' title="(Undocumented)"><code>++din:re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#fit-re' title="Fit on one line test"><code>++fit:re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#ram-re' title="Flatten tank to tape"><code>++ram:re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#rig-re' title="Wrap tape in / (tank)"><code>++rig:re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#wig-re'><code>++wig:re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#win-re'><code>++win:re</code></a>
+<a class="tooltip" href='/docs/reference/library/4c/#re' title="Pretty-printing engine (tank)"><code>++re</code></a>
+<a class="tooltip" href='/docs/reference/library/4c/#din-re' title="(Undocumented)"><code>++din:re</code></a>
+<a class="tooltip" href='/docs/reference/library/4c/#fit-re' title="Fit on one line test"><code>++fit:re</code></a>
+<a class="tooltip" href='/docs/reference/library/4c/#ram-re' title="Flatten tank to tape"><code>++ram:re</code></a>
+<a class="tooltip" href='/docs/reference/library/4c/#rig-re' title="Wrap tape in / (tank)"><code>++rig:re</code></a>
+<a class="tooltip" href='/docs/reference/library/4c/#wig-re'><code>++wig:re</code></a>
+<a class="tooltip" href='/docs/reference/library/4c/#win-re'><code>++win:re</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#shep'><code>++shep</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#shop'><code>++shop</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#show'><code>++show</code></a>
+<a class="tooltip" href='/docs/reference/library/4c/#shep'><code>++shep</code></a>
+<a class="tooltip" href='/docs/reference/library/4c/#shop'><code>++shop</code></a>
+<a class="tooltip" href='/docs/reference/library/4c/#show'><code>++show</code></a>
 
 ### 4d: parsing (tracing)
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4d/#last' title="Further trace"><code>++last</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4d/#lust' title="Detect new line"><code>++lust</code></a>
+<a class="tooltip" href='/docs/reference/library/4d/#last' title="Further trace"><code>++last</code></a>
+<a class="tooltip" href='/docs/reference/library/4d/#lust' title="Detect new line"><code>++lust</code></a>
 
 ### 4e: parsing (combinators)
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#bend' title="Conditional composer"><code>++bend</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#comp' title="Arbitrary compose"><code>++comp</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#fail' title="Never parse"><code>++fail</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#glue' title="Skip delimiter"><code>++glue</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#less' title="Parse unless"><code>++less</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#pfix' title="Discard first rule"><code>++pfix</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#plug' title="Parse to tuple"><code>++plug</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#pose' title="Parse options"><code>++pose</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#sfix'><code>++sfix</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#simu'><code>++simu</code></a>
+<a class="tooltip" href='/docs/reference/library/4e/#bend' title="Conditional composer"><code>++bend</code></a>
+<a class="tooltip" href='/docs/reference/library/4e/#comp' title="Arbitrary compose"><code>++comp</code></a>
+<a class="tooltip" href='/docs/reference/library/4e/#fail' title="Never parse"><code>++fail</code></a>
+<a class="tooltip" href='/docs/reference/library/4e/#glue' title="Skip delimiter"><code>++glue</code></a>
+<a class="tooltip" href='/docs/reference/library/4e/#less' title="Parse unless"><code>++less</code></a>
+<a class="tooltip" href='/docs/reference/library/4e/#pfix' title="Discard first rule"><code>++pfix</code></a>
+<a class="tooltip" href='/docs/reference/library/4e/#plug' title="Parse to tuple"><code>++plug</code></a>
+<a class="tooltip" href='/docs/reference/library/4e/#pose' title="Parse options"><code>++pose</code></a>
+<a class="tooltip" href='/docs/reference/library/4e/#sfix'><code>++sfix</code></a>
+<a class="tooltip" href='/docs/reference/library/4e/#simu'><code>++simu</code></a>
 
 ### 4f: parsing (rule builders)
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#bass' title="Parser modifier (LSB-ordered ++list as atom of ++base)"><code>++bass</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#boss' title="Parser modifier: LSB"><code>++boss</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#cold' title="Replace with constant"><code>++cold</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#cook' title="Apply gate"><code>++cook</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#easy' title="Always parse"><code>++easy</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#full' title="Parse to end"><code>++full</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#funk' title="Add to tape"><code>++funk</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#here' title="Place-based apply"><code>++here</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#ifix' title="Infix"><code>++ifix</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#jest' title="Match a cord"><code>++jest</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#just' title="Match a single character"><code>++just</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#knee' title="Recursive parsers"><code>++knee</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#mask' title="Match character"><code>++mask</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#more' title="Parse list with delimiter"><code>++more</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#most' title="Parse list of at least one match"><code>++most</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#next' title="Consume character"><code>++next</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#plus' title="List of at least one match"><code>++plus</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#sear'><code>++sear</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#shim'><code>++shim</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#slug'><code>++slug</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#stag'><code>++stag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#star'><code>++star</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#stet'><code>++stet</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#stew'><code>++stew</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#stir'><code>++stir</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#stun'><code>++stun</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#bass' title="Parser modifier (LSB-ordered ++list as atom of ++base)"><code>++bass</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#boss' title="Parser modifier: LSB"><code>++boss</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#cold' title="Replace with constant"><code>++cold</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#cook' title="Apply gate"><code>++cook</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#easy' title="Always parse"><code>++easy</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#full' title="Parse to end"><code>++full</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#funk' title="Add to tape"><code>++funk</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#here' title="Place-based apply"><code>++here</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#ifix' title="Infix"><code>++ifix</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#jest' title="Match a cord"><code>++jest</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#just' title="Match a single character"><code>++just</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#knee' title="Recursive parsers"><code>++knee</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#mask' title="Match character"><code>++mask</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#more' title="Parse list with delimiter"><code>++more</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#most' title="Parse list of at least one match"><code>++most</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#next' title="Consume character"><code>++next</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#plus' title="List of at least one match"><code>++plus</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#sear'><code>++sear</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#shim'><code>++shim</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#slug'><code>++slug</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#stag'><code>++stag</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#star'><code>++star</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#stet'><code>++stet</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#stew'><code>++stew</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#stir'><code>++stir</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#stun'><code>++stun</code></a>
 
 ### 4g: parsing (outside caller)
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rash' title="Parse or crash"><code>++rash</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rush' title="Parse or null"><code>++rush</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rust' title="Parse tape or null"><code>++rust</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#scan'><code>++scan</code></a>
+<a class="tooltip" href='/docs/reference/library/4g/#rash' title="Parse or crash"><code>++rash</code></a>
+<a class="tooltip" href='/docs/reference/library/4g/#rush' title="Parse or null"><code>++rush</code></a>
+<a class="tooltip" href='/docs/reference/library/4g/#rust' title="Parse tape or null"><code>++rust</code></a>
+<a class="tooltip" href='/docs/reference/library/4g/#scan'><code>++scan</code></a>
 
 ### 4h: parsing (ascii glyphs)
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ace' title="Parse space"><code>++ace</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#bar' title="Parse | (bar)"><code>++bar</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#bas' title="Parse \ (bas)"><code>++bas</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#buc' title="Parse $ (buc)"><code>++buc</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#cab' title="Parse _ (cab)"><code>++cab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#cen' title="Parse % (cen)"><code>++cen</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#col' title="Parse : (col)"><code>++col</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#com' title="Parse , (comma)"><code>++com</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#doq' title="Parse double quote"><code>++doq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#dot' title="Parse period"><code>++dot</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#fas' title="Parse / (fas)"><code>++fas</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#gal' title="Parse < (gal)"><code>++gal</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#gar' title="Parse > (gar)"><code>++gar</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#hax' title="Parse # (hax)"><code>++hax</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#hep' title="Parse - (hep)"><code>++hep</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#kel' title="Parse { (kel)"><code>++kel</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ker' title="Parse } (ker)"><code>++ker</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ket' title="Parse ^ (ket)"><code>++ket</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#lus' title="Parse + (lus)"><code>++lus</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pam' title="Parse & (pam)"><code>++pam</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pat' title="Parse @ (pat)"><code>++pat</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pel' title="Parse ( (pel)"><code>++pel</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#per' title="Parse ) (per)"><code>++per</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#sel'><code>++sel</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#sem'><code>++sem</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ser'><code>++ser</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#sig'><code>++sig</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#soq'><code>++soq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#tar'><code>++tar</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#tec'><code>++tec</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#tis'><code>++tis</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#wut'><code>++wut</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#zap'><code>++zap</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#ace' title="Parse space"><code>++ace</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#bar' title="Parse | (bar)"><code>++bar</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#bas' title="Parse \ (bas)"><code>++bas</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#buc' title="Parse $ (buc)"><code>++buc</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#cab' title="Parse _ (cab)"><code>++cab</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#cen' title="Parse % (cen)"><code>++cen</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#col' title="Parse : (col)"><code>++col</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#com' title="Parse , (comma)"><code>++com</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#doq' title="Parse double quote"><code>++doq</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#dot' title="Parse period"><code>++dot</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#fas' title="Parse / (fas)"><code>++fas</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#gal' title="Parse < (gal)"><code>++gal</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#gar' title="Parse > (gar)"><code>++gar</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#hax' title="Parse # (hax)"><code>++hax</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#hep' title="Parse - (hep)"><code>++hep</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#kel' title="Parse { (kel)"><code>++kel</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#ker' title="Parse } (ker)"><code>++ker</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#ket' title="Parse ^ (ket)"><code>++ket</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#lus' title="Parse + (lus)"><code>++lus</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#pam' title="Parse & (pam)"><code>++pam</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#pat' title="Parse @ (pat)"><code>++pat</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#pel' title="Parse ( (pel)"><code>++pel</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#per' title="Parse ) (per)"><code>++per</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#sel'><code>++sel</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#sem'><code>++sem</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#ser'><code>++ser</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#sig'><code>++sig</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#soq'><code>++soq</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#tar'><code>++tar</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#tec'><code>++tec</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#tis'><code>++tis</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#wut'><code>++wut</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#zap'><code>++zap</code></a>
 
 ### 4i: parsing (useful idioms)
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#alf' title="Parse alphabetic characters"><code>++alf</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#aln' title="Parse alphanumeric characters"><code>++aln</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#alp' title="Parse alphanumeric characters and -"><code>++alp</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#bet' title="Parse hep and lus axis syntax"><code>++bet</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#bin' title="Binary to atom"><code>++bin</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#but' title="Parse binary digit"><code>++but</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#cit' title="Octal digit"><code>++cit</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dem' title="Decimal to atom"><code>++dem</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dit' title="Decimal digit"><code>++dit</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dog' title="Optional gap"><code>++dog</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#doh' title="@p separator"><code>++doh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dun' title="-- to ~"><code>++dun</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#duz' title="== to ~"><code>++duz</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gah' title="New line or ''"><code>++gah</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gap' title="Plural whitespace"><code>++gap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gaq' title="End of line"><code>++gaq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gaw' title="Classic whitespace"><code>++gaw</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gay' title="Optional gap"><code>++gay</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gon' title="Parse long numbers"><code>++gon</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gul' title="Axis syntax < or >"><code>++gul</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hex' title="Hexadecimal to atom"><code>++hex</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hig' title="Parse single uppercase letter"><code>++hig</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hit' title="Parse single hexadecimal digit"><code>++hit</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#iny' title="Indentation block"><code>++iny</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#low' title="Parse lowercase letter"><code>++low</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#mes' title="Parse hexabyte"><code>++mes</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#nix' title="Parse letters and -"><code>++nix</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#nud' title="Parse numeric character"><code>++nud</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#prn' title="Parse any printable character"><code>++prn</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#qit' title="Parse character to cord atom"><code>++qit</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#qut' title="Parse cord"><code>++qut</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#soz'><code>++soz</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#sym'><code>++sym</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#ven'><code>++ven</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#vit'><code>++vit</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#vul'><code>++vul</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#alf' title="Parse alphabetic characters"><code>++alf</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#aln' title="Parse alphanumeric characters"><code>++aln</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#alp' title="Parse alphanumeric characters and -"><code>++alp</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#bet' title="Parse hep and lus axis syntax"><code>++bet</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#bin' title="Binary to atom"><code>++bin</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#but' title="Parse binary digit"><code>++but</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#cit' title="Octal digit"><code>++cit</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#dem' title="Decimal to atom"><code>++dem</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#dit' title="Decimal digit"><code>++dit</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#dog' title="Optional gap"><code>++dog</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#doh' title="@p separator"><code>++doh</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#dun' title="-- to ~"><code>++dun</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#duz' title="== to ~"><code>++duz</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#gah' title="New line or ''"><code>++gah</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#gap' title="Plural whitespace"><code>++gap</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#gaq' title="End of line"><code>++gaq</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#gaw' title="Classic whitespace"><code>++gaw</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#gay' title="Optional gap"><code>++gay</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#gon' title="Parse long numbers"><code>++gon</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#gul' title="Axis syntax < or >"><code>++gul</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#hex' title="Hexadecimal to atom"><code>++hex</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#hig' title="Parse single uppercase letter"><code>++hig</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#hit' title="Parse single hexadecimal digit"><code>++hit</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#iny' title="Indentation block"><code>++iny</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#low' title="Parse lowercase letter"><code>++low</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#mes' title="Parse hexabyte"><code>++mes</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#nix' title="Parse letters and -"><code>++nix</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#nud' title="Parse numeric character"><code>++nud</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#prn' title="Parse any printable character"><code>++prn</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#qit' title="Parse character to cord atom"><code>++qit</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#qut' title="Parse cord"><code>++qut</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#soz'><code>++soz</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#sym'><code>++sym</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#ven'><code>++ven</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#vit'><code>++vit</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#vul'><code>++vul</code></a>
 
 ### 4j: parsing (bases and base digits)
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ab' title="Primitive parser engine"><code>++ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#bix-ab' title="Parse hex pair"><code>++bix:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hif-ab' title="Parse phonetic pair"><code>++hif:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#huf-ab' title="Parse two phonetic pairs"><code>++huf:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hyf-ab' title="Parse 8 phonetic bytes"><code>++hyf:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#pev-ab' title="Parse <=5 in base 32"><code>++pev:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#pew-ab' title="Parse <= 5 in base 64"><code>++pew:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#piv-ab' title="Parse 5 digits in base 32"><code>++piv:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#piw-ab' title="Parse 5 digits in base 64"><code>++piw:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qeb-ab' title="Parse <=4 binary digits"><code>++qeb:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qex-ab' title="Parse <=4 hexadecimal digits"><code>++qex:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qib-ab' title="Parse 4 binary digits"><code>++qib:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qix-ab' title="Parse 4 hexadecimal digits"><code>++qix:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#seb-ab'><code>++seb:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sed-ab'><code>++sed:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sev-ab'><code>++sev:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sew-ab'><code>++sew:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sex-ab'><code>++sex:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sib-ab'><code>++sib:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sid-ab'><code>++sid:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#siv-ab'><code>++siv:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#siw-ab'><code>++siw:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#six-ab'><code>++six:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sov-ab'><code>++sov:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sow-ab'><code>++sow:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sox-ab'><code>++sox:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ted-ab'><code>++ted:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#tid-ab'><code>++tid:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#til-ab'><code>++til:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#tip-ab'><code>++tip:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#tiq-ab'><code>++tiq:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#urs-ab'><code>++urs:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#urt-ab'><code>++urt:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#voy-ab'><code>++voy:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#ab' title="Primitive parser engine"><code>++ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#bix-ab' title="Parse hex pair"><code>++bix:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#hif-ab' title="Parse phonetic pair"><code>++hif:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#huf-ab' title="Parse two phonetic pairs"><code>++huf:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#hyf-ab' title="Parse 8 phonetic bytes"><code>++hyf:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#pev-ab' title="Parse <=5 in base 32"><code>++pev:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#pew-ab' title="Parse <= 5 in base 64"><code>++pew:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#piv-ab' title="Parse 5 digits in base 32"><code>++piv:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#piw-ab' title="Parse 5 digits in base 64"><code>++piw:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#qeb-ab' title="Parse <=4 binary digits"><code>++qeb:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#qex-ab' title="Parse <=4 hexadecimal digits"><code>++qex:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#qib-ab' title="Parse 4 binary digits"><code>++qib:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#qix-ab' title="Parse 4 hexadecimal digits"><code>++qix:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#seb-ab'><code>++seb:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sed-ab'><code>++sed:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sev-ab'><code>++sev:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sew-ab'><code>++sew:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sex-ab'><code>++sex:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sib-ab'><code>++sib:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sid-ab'><code>++sid:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#siv-ab'><code>++siv:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#siw-ab'><code>++siw:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#six-ab'><code>++six:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sov-ab'><code>++sov:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sow-ab'><code>++sow:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sox-ab'><code>++sox:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#ted-ab'><code>++ted:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#tid-ab'><code>++tid:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#til-ab'><code>++til:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#tip-ab'><code>++tip:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#tiq-ab'><code>++tiq:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#urs-ab'><code>++urs:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#urt-ab'><code>++urt:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#voy-ab'><code>++voy:ab</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ag' title="Top-level atom parser engine"><code>++ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ape-ag' title="Parse 0 or rule"><code>++ape:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#bay-ag' title="Parses binary number"><code>++bay:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#bip-ag' title="Parse IPv6"><code>++bip:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dem-ag' title="Parse decmal with dots"><code>++dem:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dim-ag' title="Parse decimal number"><code>++dim:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dum-ag' title="Parse decimal with leading zero"><code>++dum:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#fed-ag' title="Parse @p"><code>++fed:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hex-ag' title="Parse hexadecimal number"><code>++hex:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#lip-ag' title="Parse IPv4 address"><code>++lip:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#viz-ag'><code>++viz:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#vum-ag'><code>++vum:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#wiz-ag'><code>++wiz:ag</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#ag' title="Top-level atom parser engine"><code>++ag</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#ape-ag' title="Parse 0 or rule"><code>++ape:ag</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#bay-ag' title="Parses binary number"><code>++bay:ag</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#bip-ag' title="Parse IPv6"><code>++bip:ag</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#dem-ag' title="Parse decmal with dots"><code>++dem:ag</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#dim-ag' title="Parse decimal number"><code>++dim:ag</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#dum-ag' title="Parse decimal with leading zero"><code>++dum:ag</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#fed-ag' title="Parse @p"><code>++fed:ag</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#hex-ag' title="Parse hexadecimal number"><code>++hex:ag</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#lip-ag' title="Parse IPv4 address"><code>++lip:ag</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#viz-ag'><code>++viz:ag</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#vum-ag'><code>++vum:ag</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#wiz-ag'><code>++wiz:ag</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#mu' title="Core used to scramble 16-bit atoms"><code>++mu</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#zag-mu'><code>++zag:mu</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#zig-mu'><code>++zig:mu</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#zug-mu'><code>++zug:mu</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#mu' title="Core used to scramble 16-bit atoms"><code>++mu</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#zag-mu'><code>++zag:mu</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#zig-mu'><code>++zig:mu</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#zug-mu'><code>++zug:mu</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ne' title="Digit rendering engine"><code>++ne</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#d-ne' title="Render decimal"><code>++d:ne</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#v-ne'><code>++v:ne</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#w-ne'><code>++w:ne</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#x-ne'><code>++x:ne</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#ne' title="Digit rendering engine"><code>++ne</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#d-ne' title="Render decimal"><code>++d:ne</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#v-ne'><code>++v:ne</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#w-ne'><code>++w:ne</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#x-ne'><code>++x:ne</code></a>
 
 ### 4k: parsing (atom printing)
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#co' title="Literal rendering engine"><code>++co</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rear-co' title="Prepend and render atom as tape"><code>++rear:co</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rend-co' title="Render coin lot as tape"><code>++rend:co</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rent-co' title="Render coin lot as span"><code>++rent:co</code></a>
+<a class="tooltip" href='/docs/reference/library/4k/#co' title="Literal rendering engine"><code>++co</code></a>
+<a class="tooltip" href='/docs/reference/library/4k/#rear-co' title="Prepend and render atom as tape"><code>++rear:co</code></a>
+<a class="tooltip" href='/docs/reference/library/4k/#rend-co' title="Render coin lot as tape"><code>++rend:co</code></a>
+<a class="tooltip" href='/docs/reference/library/4k/#rent-co' title="Render coin lot as span"><code>++rent:co</code></a>
 
 ### 4l: parsing (atom parsing)
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#so'><code>++so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#bisk-so' title="Parse odor-atom pair"><code>++bisk:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#crub-so' title="Parse @da, @dr, @p, @t"><code>++crub:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#nuck-so' title="Top-level coin parser"><code>++nuck:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#nusk-so' title="Parse coin literal with escapes"><code>++nusk:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#perd-so' title="Parses dime/tiple without standard prefixes"><code>++perd:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#royl-so' title="Parse dime float"><code>++royl:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#royl-cell-so' title="(Undocumented)"><code>++royl-cell:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#tash-so'><code>++tash:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#twid-so'><code>++twid:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#zust-so'><code>++zust:so</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#so'><code>++so</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#bisk-so' title="Parse odor-atom pair"><code>++bisk:so</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#crub-so' title="Parse @da, @dr, @p, @t"><code>++crub:so</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#nuck-so' title="Top-level coin parser"><code>++nuck:so</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#nusk-so' title="Parse coin literal with escapes"><code>++nusk:so</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#perd-so' title="Parses dime/tiple without standard prefixes"><code>++perd:so</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#royl-so' title="Parse dime float"><code>++royl:so</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#royl-cell-so' title="(Undocumented)"><code>++royl-cell:so</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#tash-so'><code>++tash:so</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#twid-so'><code>++twid:so</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#zust-so'><code>++zust:so</code></a>
 
 ### 4m: parsing (formatting functions)
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#scot'><code>++scot</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#scow'><code>++scow</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#slat'><code>++slat</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#slav'><code>++slav</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#slaw'><code>++slaw</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#slay'><code>++slay</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#smyt'><code>++smyt</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#spat'><code>++spat</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#spud'><code>++spud</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#stab'><code>++stab</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#scot'><code>++scot</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#scow'><code>++scow</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#slat'><code>++slat</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#slav'><code>++slav</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#slaw'><code>++slaw</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#slay'><code>++slay</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#smyt'><code>++smyt</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#spat'><code>++spat</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#spud'><code>++spud</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#stab'><code>++stab</code></a>
 
 ### 4n: parsing (virtualization)
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mack' title="Nock subject to unit"><code>++mack</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mink' title="Mock (virtual Nock) interpreter"><code>++mink</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mock' title="Compute formula on subject with hint"><code>++mock</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mong' title="Slam gate with sample"><code>++mong</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mook' title="Intelligently render crash annotation"><code>++mook</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mule' title="Typed virtual"><code>++mule</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mute' title="Untyped virtual"><code>++mute</code></a>
+<a class="tooltip" href='/docs/reference/library/4n/#mack' title="Nock subject to unit"><code>++mack</code></a>
+<a class="tooltip" href='/docs/reference/library/4n/#mink' title="Mock (virtual Nock) interpreter"><code>++mink</code></a>
+<a class="tooltip" href='/docs/reference/library/4n/#mock' title="Compute formula on subject with hint"><code>++mock</code></a>
+<a class="tooltip" href='/docs/reference/library/4n/#mong' title="Slam gate with sample"><code>++mong</code></a>
+<a class="tooltip" href='/docs/reference/library/4n/#mook' title="Intelligently render crash annotation"><code>++mook</code></a>
+<a class="tooltip" href='/docs/reference/library/4n/#mule' title="Typed virtual"><code>++mule</code></a>
+<a class="tooltip" href='/docs/reference/library/4n/#mute' title="Untyped virtual"><code>++mute</code></a>
 
 ### 4o: parsing (molds)
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#abel' title="Compiler alias"><code>++abel</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#aura' title="'Type' of atom"><code>++aura</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#axis' title="Nock axis"><code>++axis</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#base' title="Base type"><code>++base</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#bean' title="Boolean"><code>++bean</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#beer' title="Tape builder"><code>++beer</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#beet' title="XML interpolation cases"><code>++beet</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#chum' title="Jet hint information"><code>++chum</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#coil' title="Tuple of core information"><code>++coil</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#foot' title="Cases of arms by variance model"><code>++foot</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#limb' title="Reference into subject by name/axis"><code>++limb</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#line' title="(Undocumented)"><code>++line</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#metl' title="(Undocumented)"><code>++metl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#nock' title="Virtual machine (see Nock)"><code>++nock</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#noun' title="(Undocumented)"><code>++noun</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#null' title="(Undocumented)"><code>++null</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#port' title="(Undocumented)"><code>++port</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#span'><code>++span</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#tiki'><code>++tiki</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#toga'><code>++toga</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#tone'><code>++tone</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#tuna'><code>++tuna</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#tusk'><code>++tusk</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#tyke'><code>++tyke</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#typo'><code>++typo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#tyre'><code>++tyre</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#vase'><code>++vase</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#vise'><code>++vise</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#wing'><code>++wing</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#abel' title="Compiler alias"><code>++abel</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#aura' title="'Type' of atom"><code>++aura</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#axis' title="Nock axis"><code>++axis</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#base' title="Base type"><code>++base</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#bean' title="Boolean"><code>++bean</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#beer' title="Tape builder"><code>++beer</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#beet' title="XML interpolation cases"><code>++beet</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#chum' title="Jet hint information"><code>++chum</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#coil' title="Tuple of core information"><code>++coil</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#foot' title="Cases of arms by variance model"><code>++foot</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#limb' title="Reference into subject by name/axis"><code>++limb</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#line' title="(Undocumented)"><code>++line</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#metl' title="(Undocumented)"><code>++metl</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#nock' title="Virtual machine (see Nock)"><code>++nock</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#noun' title="(Undocumented)"><code>++noun</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#null' title="(Undocumented)"><code>++null</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#port' title="(Undocumented)"><code>++port</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#span'><code>++span</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#tiki'><code>++tiki</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#toga'><code>++toga</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#tone'><code>++tone</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#tuna'><code>++tuna</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#tusk'><code>++tusk</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#tyke'><code>++tyke</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#typo'><code>++typo</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#tyre'><code>++tyre</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#vase'><code>++vase</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#vise'><code>++vise</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#wing'><code>++wing</code></a>
 
 ### 5a: compiler utilities
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/5a/'>_(To be documented)_</a>
+<a class="tooltip" href='/docs/reference/library/5a/'>_(To be documented)_</a>
 
 ### 5b: macro expansion
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/5b/'>_(To be documented)_</a>
+<a class="tooltip" href='/docs/reference/library/5b/'>_(To be documented)_</a>
 
 ### 5c: compiler backend and prettyprinter
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/5c/'>_(To be documented)_</a>
+<a class="tooltip" href='/docs/reference/library/5c/'>_(To be documented)_</a>
 
 ### 5d: parser
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/5d/'>_(To be documented)_</a>
+<a class="tooltip" href='/docs/reference/library/5d/'>_(To be documented)_</a>
 
 ### 5e: caching compiler
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/5e/'>_(To be documented)_</a>
+<a class="tooltip" href='/docs/reference/library/5e/'>_(To be documented)_</a>
 
 ### 5f: molds and mold builders
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/5f/#mane'><code>++mane</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/5f/#manx'><code>++manx</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/5f/#marl'><code>++marl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/5f/#mars'><code>++mars</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/5f/#mart'><code>++mart</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/5f/#marx'><code>++marx</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/5f/#pass'><code>++pass</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/5f/#ring'><code>++ring</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/5f/#time'><code>++time</code></a>
+<a class="tooltip" href='/docs/reference/library/5f/#mane'><code>++mane</code></a>
+<a class="tooltip" href='/docs/reference/library/5f/#manx'><code>++manx</code></a>
+<a class="tooltip" href='/docs/reference/library/5f/#marl'><code>++marl</code></a>
+<a class="tooltip" href='/docs/reference/library/5f/#mars'><code>++mars</code></a>
+<a class="tooltip" href='/docs/reference/library/5f/#mart'><code>++mart</code></a>
+<a class="tooltip" href='/docs/reference/library/5f/#marx'><code>++marx</code></a>
+<a class="tooltip" href='/docs/reference/library/5f/#pass'><code>++pass</code></a>
+<a class="tooltip" href='/docs/reference/library/5f/#ring'><code>++ring</code></a>
+<a class="tooltip" href='/docs/reference/library/5f/#time'><code>++time</code></a>
 
 ### 5g: profiling support
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/5g/'>_(To be documented)_</a>
+<a class="tooltip" href='/docs/reference/library/5g/'>_(To be documented)_</a>

--- a/reference/library/_index.md
+++ b/reference/library/_index.md
@@ -118,203 +118,203 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#day-yo' data-tippy-content="Seconds in day"><code>++day:yo</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#dec' data-tippy-content="Decrement"><code>++dec</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#def-by' data-tippy-content="Difference (map)"><code>+-def:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#del-by'><code>+-del:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#del-in'><code>+-del:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#del-ju'><code>+-del:ju</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dem'><code>++dem</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dem-ag'><code>++dem:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#den-fl'><code>++den:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#dep-by'><code>+-dep:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#dep-to'><code>+-dep:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#dif-fe'><code>++dif:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dif-fo'><code>++dif:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#dif-in'><code>+-dif:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dif-si'><code>++dif:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#dig-by'><code>+-dig:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#dig-in'><code>+-dig:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dim-ag'><code>++dim:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#dime'><code>++dime</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#din-re'><code>++din:re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#dis'><code>++dis</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dit'><code>++dit</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#div'><code>++div</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-ff'><code>++div:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-fl'><code>++div:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rd'><code>++div:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rh'><code>++div:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rs'><code>++div:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rq'><code>++div:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dog'><code>++dog</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#doh'><code>++doh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#doq'><code>++doq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#dor'><code>++dor</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#dot'><code>++dot</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-ff'><code>++drg:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-fl'><code>++drg:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rd'><code>++drg:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rh'><code>++drg:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rs'><code>++drg:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rq'><code>++drg:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#drop'><code>++drop</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dul-si'><code>++dul:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dum-ag'><code>++dum:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dun'><code>++dun</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#duz'><code>++duz</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#dvr'><code>++dvr</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#del-by' data-tippy-content="Delete (map)"><code>+-del:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#del-in' data-tippy-content="Delete (set)"><code>+-del:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#del-ju' data-tippy-content="Delete (jug)"><code>+-del:ju</code></a>
+    <a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dem' data-tippy-content="Decimal to atom"><code>++dem</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dem-ag' data-tippy-content="Parse decmal with dots"><code>++dem:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#den-fl' data-tippy-content="Denormalizes (floating point)"><code>++den:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#dep-by' data-tippy-content="Difference as patch (map)"><code>+-dep:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#dep-to' data-tippy-content="Maximum depth (queue)"><code>+-dep:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#dif-fe' data-tippy-content="Difference between atoms (modular basis)"><code>++dif:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dif-fo' data-tippy-content='Subtraction (modular base)'><code>++dif:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#dif-in' data-tippy-content='Difference (set)'><code>+-dif:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dif-si' data-tippy-content="Subtraction (signed integer)"><code>++dif:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#dig-by' data-tippy-content="Address of key (map)"><code>+-dig:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#dig-in' data-tippy-content="Address of a in set"><code>+-dig:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dim-ag' data-tippy-content="Parse decimal number"><code>++dim:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#dime' data-tippy-content="Aura-atom pair"><code>++dime</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#din-re' data-tippy-content="(Undocumented)"><code>++din:re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#dis' data-tippy-content="Binary AND (atoms)"><code>++dis</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dit' data-tippy-content="Decimal digit"><code>++dit</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#div' data-tippy-content="Divide"><code>++div</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-ff' data-tippy-content="Divide (IEEE float)"><code>++div:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-fl' data-tippy-content="Divide (signed and unsigned integer cell)"><code>++div:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rd' data-tippy-content="Double precision float"><code>++div:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rh' data-tippy-content="Divide (half-precision float)"><code>++div:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rs' data-tippy-content="Divide (single-precision float)"><code>++div:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rq' data-tippy-content="Divide (quad-precision float)"><code>++div:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dog' data-tippy-content="Optional gap"><code>++dog</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#doh' data-tippy-content="@p separator"><code>++doh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#doq' data-tippy-content="Parse double quote"><code>++doq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#dor' data-tippy-content="Numeric order"><code>++dor</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#dot' data-tippy-content="Parse period"><code>++dot</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-ff' data-tippy-content="@r to decimal float"><code>++drg:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-fl' data-tippy-content="Get printable decimal (signed and unsigned integer cell)"><code>++drg:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rd' data-tippy-content="@rd to decimal float"><code>++drg:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rh' data-tippy-content="@rh to decimal float"><code>++drg:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rs' data-tippy-content="@rs to decimal float"><code>++drg:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rq' data-tippy-content="@rq to decimal float"><code>++drg:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#drop' data-tippy-content="Unit to list"><code>++drop</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dul-si' data-tippy-content="Modulus (signed integer)"><code>++dul:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dum-ag' data-tippy-content="Parse decimal with leading zero"><code>++dum:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dun' data-tippy-content="-- to ~"><code>++dun</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#duz' data-tippy-content="== to ~"><code>++duz</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#dvr' data-tippy-content="Divide (with remainder)"><code>++dvr</code></a>
 
 ### e
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ead-fl'><code>++ead:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#each'><code>++each</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#easy'><code>++easy</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#edge'><code>++edge</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#egcd'><code>++egcd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emn-fl'><code>++emn:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emu-fl'><code>++emu:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emx-fl'><code>++emx:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#end'><code>++end</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-ff'><code>++equ:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-fl'><code>++equ:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rd'><code>++equ:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rh'><code>++equ:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rs'><code>++equ:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rq'><code>++equ:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#era-yo'><code>++era:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-ff'><code>++exp:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#exp-fo'><code>++exp:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rd'><code>++exp:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rh'><code>++exp:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rs'><code>++exp:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rq'><code>++exp:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ead-fl' data-tippy-content="Exact add"><code>++ead:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#each' data-tippy-content="Mold of fork between two types"><code>++each</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#easy' data-tippy-content="Always parse"><code>++easy</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#edge' data-tippy-content="Parsing location metadata"><code>++edge</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#egcd' data-tippy-content="Extended Euclidean algorithm"><code>++egcd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emn-fl' data-tippy-content="Minimum exponent"><code>++emn:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emu-fl' data-tippy-content="Exact multiply"><code>++emu:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emx-fl' data-tippy-content="Maximum exponent"><code>++emx:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#end' data-tippy-content="Tail"><code>++end</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-ff' data-tippy-content="Equals (IEEE float)"><code>++equ:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-fl' data-tippy-content="Equals (signed and unsigned integer cell)"><code>++equ:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rd' data-tippy-content="Equals (double-precision float)"><code>++equ:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rh' data-tippy-content="Equals (half-precision float)"><code>++equ:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rs' data-tippy-content="Equals (single-precision float)"><code>++equ:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rq' data-tippy-content="Equals (quad-precision float)"><code>++equ:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#era-yo' data-tippy-content="Leap-year period"><code>++era:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-ff' data-tippy-content="Get exponent (IEEE float)"><code>++exp:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#exp-fo' data-tippy-content="Exponent (modular base)"><code>++exp:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rd' data-tippy-content="Exponent (@rd)"><code>++exp:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rh' data-tippy-content="Exponent (half-precision float)"><code>++exp:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rs' data-tippy-content="Exponent (@rs)"><code>++exp:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rq' data-tippy-content="Exponent (quad-precision float)"><code>++exp:rq</code></a>
 
 ### f
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#fail'><code>++fail</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#fall'><code>++fall</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#fand'><code>++fand</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#fas'><code>++fas</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#fe'><code>++fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#fed-ag'><code>++fed:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#feen-ob'><code>++feen:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#fend-ob'><code>++fend:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#fice-ob'><code>++fice:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#fil'><code>++fil</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#find'><code>++find</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#fit-re'><code>++fit:re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fli-fl'><code>++fli:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#flop'><code>++flop</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-ff'><code>++fma:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-fl'><code>++fma:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rd'><code>++fma:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rh'><code>++fma:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rs'><code>++fma:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rq'><code>++fma:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#fnv'><code>++fnv</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fo'><code>++fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#foot'><code>++foot</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fos-rh'><code>++fos:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fra-fo'><code>++fra:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fra-si'><code>++fra:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#full'><code>++full</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#funk'><code>++funk</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#fail' data-tippy-content="Never parse"><code>++fail</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#fall' data-tippy-content="Give unit a default value"><code>++fall</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#fand' data-tippy-content="All indices in list"><code>++fand</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#fas' data-tippy-content="Parse / (fas)"><code>++fas</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#fe' data-tippy-content="Modulo bloq"><code>++fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#fed-ag' data-tippy-content="Parse @p"><code>++fed:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#feen-ob' data-tippy-content="Conceal structure v2"><code>++feen:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#fend-ob' data-tippy-content="Restore structure v2"><code>++fend:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#fice-ob' data-tippy-content="Feistel-like cipher"><code>++fice:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#fil' data-tippy-content="Fill bloqstream"><code>++fil</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#find' data-tippy-content="First index in list"><code>++find</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#fit-re' data-tippy-content="Fit on one line test"><code>++fit:re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fli-fl' data-tippy-content="Flip sign"><code>++fli:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#flop' data-tippy-content="Reverse list"><code>++flop</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-ff' data-tippy-content="Fused multiply-add (IEEE float)"><code>++fma:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-fl' data-tippy-content="Fused multiply-add"><code>++fma:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rd' data-tippy-content="Fused multiply-add (@rd)"><code>++fma:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rh' data-tippy-content="Fused multiply-add (half-precision float)"><code>++fma:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rs' data-tippy-content="Fused multiply-add (single-precision float)"><code>++fma:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rq' data-tippy-content="Fused multiply-add (quad-precision float)"><code>++fma:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#fnv' data-tippy-content="FNV scrambler"><code>++fnv</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fo' data-tippy-content="Modulo prime"><code>++fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#foot' data-tippy-content="Cases of arms by variance model"><code>++foot</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fos-rh' data-tippy-content="@rs to @rh"><code>++fos:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fra-fo' data-tippy-content="Divide (modular base)"><code>++fra:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fra-si' data-tippy-content="Divide (signed integer)"><code>++fra:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#full' data-tippy-content="Parse to end"><code>++full</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#funk' data-tippy-content="Add to tape"><code>++funk</code></a>
 
 ### g
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gah'><code>++gah</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#gal'><code>++gal</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gap'><code>++gap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gaq'><code>++gaq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#gar'><code>++gar</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#gas-by'><code>+-gas:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#gas-in'><code>+-gas:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#gas-to'><code>+-gas:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#gate'><code>++gate</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gaw'><code>++gaw</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gay'><code>++gay</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#get-by'><code>+-get:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#get-ja'><code>+-get:ja</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#get-ju'><code>+-get:ju</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#get-to'><code>+-get:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#glue'><code>++glue</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gon'><code>++gon</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#gor'><code>++gor</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#got-by'><code>+-got:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-ff'><code>++grd:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-fl'><code>++grd:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rd'><code>++grd:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rh'><code>++grd:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rs'><code>++grd:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rq'><code>++grd:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#gte'><code>++gte</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-ff'><code>++gte:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-fl'><code>++gte:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rd'><code>++gte:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rh'><code>++gte:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rs'><code>++gte:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rq'><code>++gte:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#gth'><code>++gth</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-ff'><code>++gth:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-fl'><code>++gth:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rd'><code>++gth:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rh'><code>++gth:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rs'><code>++gth:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rq'><code>++gth:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gul'><code>++gul</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#gulf'><code>++gulf</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gah' data-tippy-content="New line or ''"><code>++gah</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#gal' data-tippy-content="Parse < (gal)"><code>++gal</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gap' data-tippy-content="Plural whitespace"><code>++gap</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gaq' data-tippy-content="End of line"><code>++gaq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#gar' data-tippy-content="Parse > (gar)"><code>++gar</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#gas-by' data-tippy-content="Concatenate (map)"><code>+-gas:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#gas-in' data-tippy-content="Concatenate (set)"><code>+-gas:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#gas-to' data-tippy-content="Push list into queue"><code>+-gas:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#gate' data-tippy-content="Function"><code>++gate</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gaw' data-tippy-content="Classic whitespace"><code>++gaw</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gay' data-tippy-content="Optional gap"><code>++gay</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#get-by' data-tippy-content="Grab unit value"><code>+-get:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#get-ja' data-tippy-content="Grab value by key"><code>+-get:ja</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#get-ju' data-tippy-content="Retrieve set"><code>+-get:ju</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#get-to' data-tippy-content="Head-tail pair"><code>+-get:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#glue' data-tippy-content="Skip delimiter"><code>++glue</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gon' data-tippy-content="Parse long numbers"><code>++gon</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#gor' data-tippy-content="Hash order"><code>++gor</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#got-by' data-tippy-content="Assert for value (map)"><code>+-got:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-ff' data-tippy-content="Decimal float to @r"><code>++grd:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-fl' data-tippy-content="Decimal to float"><code>++grd:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rd' data-tippy-content="Decimal float to @rd"><code>++grd:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rh' data-tippy-content="Decimal float to @rh"><code>++grd:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rs' data-tippy-content="Decimal float to @rs"><code>++grd:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rq' data-tippy-content="Decimal float to @rq"><code>++grd:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#gte' data-tippy-content="Greater than / equal"><code>++gte</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-ff' data-tippy-content="Greater than / equal (IEEE float)"><code>++gte:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-fl' data-tippy-content="Greater than / equal (producing flag)"><code>++gte:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rd' data-tippy-content="Greater than / equal (double-precision float)"><code>++gte:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rh' data-tippy-content="Greater than / equal (half-precision float)"><code>++gte:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rs' data-tippy-content="Greater than / equal (single-precision float)"><code>++gte:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rq' data-tippy-content="Greater than / equal (quad-precision float)"><code>++gte:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#gth' data-tippy-content="Greater than"><code>++gth</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-ff' data-tippy-content="Greater than (IEEE float)"><code>++gth:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-fl' data-tippy-content="Greater than (producing flag)"><code>++gth:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rd' data-tippy-content="Greater than (double-precision float)"><code>++gth:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rh' data-tippy-content="Greater than (half-precision float)"><code>++gth:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rs' data-tippy-content="Greater than (single-precision float)"><code>++gth:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rq' data-tippy-content="Greater than (quad-precision float)"><code>++gth:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gul' data-tippy-content="Axis syntax < or >"><code>++gul</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#gulf' data-tippy-content="List from range"><code>++gulf</code></a>
 
 ### h
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#hair'><code>++hair</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#hard'><code>++hard</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#has-by'><code>+-has:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#has-in'><code>+-has:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#has-ju'><code>+-has:ju</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#hax'><code>++hax</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#head'><code>++head</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#here'><code>++here</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#hep'><code>++hep</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hex'><code>++hex</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hex-ag'><code>++hex:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hif-ab'><code>++hif:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hig'><code>++hig</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hit'><code>++hit</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#homo'><code>++homo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#hor'><code>++hor</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#hor-yo'><code>++hor:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#huf-ab'><code>++huf:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hyf-ab'><code>++hyf:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#hair' data-tippy-content="Parsing line and column"><code>++hair</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#hard' data-tippy-content="Force remold"><code>++hard</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#has-by' data-tippy-content="Key existence check (map)"><code>+-has:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#has-in' data-tippy-content="Key existence check (set)"><code>+-has:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#has-ju' data-tippy-content="Check contents (jug)"><code>+-has:ju</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#hax' data-tippy-content="Parse # (hax)"><code>++hax</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#head' data-tippy-content="Get head of cell"><code>++head</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#here' data-tippy-content="Place-based apply"><code>++here</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#hep' data-tippy-content="Parse - (hep)"><code>++hep</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hex' data-tippy-content="Hexadecimal to atom"><code>++hex</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hex-ag' data-tippy-content="Parse hexadecimal number"><code>++hex:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hif-ab' data-tippy-content="Parse phonetic pair"><code>++hif:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hig' data-tippy-content="Parse single uppercase letter"><code>++hig</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hit' data-tippy-content="Parse single hexadecimal digit"><code>++hit</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#homo' data-tippy-content="Homogenize list"><code>++homo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#hor' data-tippy-content="Horizontal hash order"><code>++hor</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#hor-yo' data-tippy-content="Seconds in hour"><code>++hor:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#huf-ab' data-tippy-content="Parse two phonetic pairs"><code>++huf:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hyf-ab' data-tippy-content="Parse 8 phonetic bytes"><code>++hyf:ab</code></a>
 
 ### i
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ibl-fl'><code>++ibl:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#ifix'><code>++ifix</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#ind-po'><code>++ind:po</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#ins-po'><code>++ins:po</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#int-by'><code>+-int:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#int-in'><code>+-int:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#inv-fe'><code>++inv:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#inv-fl'><code>++inv:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#inv-fo'><code>++inv:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#iny'><code>++iny</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ibl-fl' data-tippy-content="Integer binary logarithm"><code>++ibl:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#ifix' data-tippy-content="Infix"><code>++ifix</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#ind-po' data-tippy-content="Parse suffix"><code>++ind:po</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#ins-po' data-tippy-content="Parse prefix"><code>++ins:po</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#int-by' data-tippy-content="Intersection (map)"><code>+-int:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#int-in' data-tippy-content="Intersection (set)"><code>+-int:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#inv-fe' data-tippy-content="Inverse order of modular field"><code>++inv:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#inv-fl' data-tippy-content="Inverse"><code>++inv:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#inv-fo' data-tippy-content="Inverse (signed modulus)"><code>++inv:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#iny' data-tippy-content="Indentation block"><code>++iny</code></a>
 
 ### j
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#ja'><code>++ja</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#jam'><code>++jam</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#jar'><code>++jar</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#jes-yo'><code>++jes:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#jest'><code>++jest</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#ju'><code>++ju</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#jug'><code>++jug</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#just'><code>++just</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#ja' data-tippy-content="Jar engine"><code>++ja</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#jam' data-tippy-content="Pack noun to atom"><code>++jam</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#jar' data-tippy-content="Mold generator (jar)"><code>++jar</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#jes-yo' data-tippy-content="Maximum 64-bit timestamp"><code>++jes:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#jest' data-tippy-content="Match a cord"><code>++jest</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#ju' data-tippy-content="Jug operations"><code>++ju</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#jug' data-tippy-content="Mold generator (jug)"><code>++jug</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#just' data-tippy-content="Match a single character"><code>++just</code></a>
 
 ### k
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#kel'><code>++kel</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ker'><code>++ker</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ket'><code>++ket</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#knee'><code>++knee</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#knot'><code>++knot</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#kel' data-tippy-content="Parse { (kel)"><code>++kel</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ker' data-tippy-content="Parse } (ker)"><code>++ker</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ket' data-tippy-content="Parse ^ (ket)"><code>++ket</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#knee' data-tippy-content="Recursive parsers"><code>++knee</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#knot' data-tippy-content="Atom type of ASCII characters"><code>++knot</code></a>
 
 ### l
 
@@ -813,10 +813,10 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#add' data-tippy-content="Add"><code>++add</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#dec' data-tippy-content="Decrement"><code>++dec</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#div'><code>++div</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#dvr'><code>++dvr</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#gte'><code>++gte</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#gth'><code>++gth</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#div' data-tippy-content="Divide"><code>++div</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#dvr' data-tippy-content="Divide (with remainder)"><code>++dvr</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#gte' data-tippy-content="Greater than / equal"><code>++gte</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#gth' data-tippy-content="Greater than"><code>++gth</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#lte'><code>++lte</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#lth'><code>++lth</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#max'><code>++max</code></a>
@@ -834,8 +834,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### 1c: molds and mold builders
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#bloq' data-tippy-content="Blocksize"><code>++bloq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#each'><code>++each</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#gate'><code>++gate</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#each' data-tippy-content="Mold of fork between two types"><code>++each</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#gate' data-tippy-content="Function"><code>++gate</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#list'><code>++list</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#lone'><code>++lone</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#pair'><code>++pair</code></a>
@@ -853,8 +853,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#bond' data-tippy-content="Replace null"><code>++bond</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#both' data-tippy-content="Group unit values into pair"><code>++both</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#clap' data-tippy-content="Apply function to two units"><code>++clap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#drop'><code>++drop</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#fall'><code>++fall</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#drop' data-tippy-content="Unit to list"><code>++drop</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#fall' data-tippy-content="Give unit a default value"><code>++fall</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#lift'><code>++lift</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#mate'><code>++mate</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#need'><code>++need</code></a>
@@ -862,11 +862,11 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 2b: list logic
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#fand'><code>++fand</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#find'><code>++find</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#flop'><code>++flop</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#gulf'><code>++gulf</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#homo'><code>++homo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#fand' data-tippy-content="All indices in list"><code>++fand</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#find' data-tippy-content="First index in list"><code>++find</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#flop' data-tippy-content="Reverse list"><code>++flop</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#gulf' data-tippy-content="List from range"><code>++gulf</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#homo' data-tippy-content="Homogenize list"><code>++homo</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#lent'><code>++lent</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#levy'><code>++levy</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#lien'><code>++lien</code></a>
@@ -894,9 +894,9 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 2c: bit arithmetic
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#fe'><code>++fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#dif-fe'><code>++dif:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#inv-fe'><code>++inv:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#fe' data-tippy-content="Modulo bloq"><code>++fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#dif-fe' data-tippy-content="Difference between atoms (modular basis)"><code>++dif:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#inv-fe' data-tippy-content="Inverse order of modular field"><code>++inv:fe</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#net-fe'><code>++net:fe</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#out-fe'><code>++out:fe</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rol-fe'><code>++rol:fe</code></a>
@@ -908,8 +908,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#can' data-tippy-content="Assemble"><code>++can</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#cat' data-tippy-content="Concatenate"><code>++cat</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#cut' data-tippy-content="Slice"><code>++cut</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#end'><code>++end</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#fil'><code>++fil</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#end' data-tippy-content="Tail"><code>++end</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#fil' data-tippy-content="Fill bloqstream"><code>++fil</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#lsh'><code>++lsh</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#met'><code>++met</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rap'><code>++rap</code></a>
@@ -922,13 +922,13 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### 2d: bit logic
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#con' data-tippy-content="Binary OR"><code>++con</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#dis'><code>++dis</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#dis' data-tippy-content="Binary AND (atoms)"><code>++dis</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#mix'><code>++mix</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#not'><code>++not</code></a>
 
 ### 2e: insecure hashing
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#fnv'><code>++fnv</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#fnv' data-tippy-content="FNV scrambler"><code>++fnv</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#mug'><code>++mug</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#muk'><code>++muk</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#mum'><code>++mum</code></a>
@@ -936,9 +936,9 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### 2f: noun ordering
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#aor' data-tippy-content="Alphabetical order"><code>++aor</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#dor'><code>++dor</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#gor'><code>++gor</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#hor'><code>++hor</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#dor' data-tippy-content="Numeric order"><code>++dor</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#gor' data-tippy-content="Hash order"><code>++gor</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#hor' data-tippy-content="Horizontal hash order"><code>++hor</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#lor'><code>++lor</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#vor'><code>++vor</code></a>
 
@@ -954,12 +954,12 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#any-in' data-tippy-content="Logical OR (set and gate)"><code>+-any:in</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#apt-in' data-tippy-content="Check correctness (set)"><code>+-apt:in</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#bif-in' data-tippy-content="Bifurcate set"><code>+-bif:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#del-in'><code>+-del:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#dif-in'><code>+-dif:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#dig-in'><code>+-dig:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#gas-in'><code>+-gas:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#has-in'><code>+-has:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#int-in'><code>+-int:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#del-in' data-tippy-content="Delete (set)"><code>+-del:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#dif-in' data-tippy-content='Difference (set)'><code>+-dif:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#dig-in' data-tippy-content="Address of a in set"><code>+-dig:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#gas-in' data-tippy-content="Concatenate (set)"><code>+-gas:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#has-in' data-tippy-content="Key existence check (set)"><code>+-has:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#int-in' data-tippy-content="Intersection (set)"><code>+-int:in</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#put-in'><code>+-put:in</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#rep-in'><code>+-rep:in</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#run-in'><code>+-run:in</code></a>
@@ -975,14 +975,14 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#apt-by' data-tippy-content="Check correctness (map)"><code>+-apt:by</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#bif-by' data-tippy-content="Bifurcate map"><code>+-bif:by</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#def-by' data-tippy-content="Difference (map)"><code>+-def:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#del-by'><code>+-del:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#dep-by'><code>+-dep:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#dig-by'><code>+-dig:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#gas-by'><code>+-gas:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#get-by'><code>+-get:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#got-by'><code>+-got:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#has-by'><code>+-has:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#int-by'><code>+-int:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#del-by' data-tippy-content="Delete (map)"><code>+-del:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#dep-by' data-tippy-content="Difference as patch (map)"><code>+-dep:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#dig-by' data-tippy-content="Address of key (map)"><code>+-dig:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#gas-by' data-tippy-content="Concatenate (map)"><code>+-gas:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#get-by' data-tippy-content="Grab unit value"><code>+-get:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#got-by' data-tippy-content="Assert for value (map)"><code>+-got:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#has-by' data-tippy-content="Key existence check (map)"><code>+-has:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#int-by' data-tippy-content="Intersection (map)"><code>+-int:by</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#mar-by'><code>+-mar:by</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#put-by'><code>+-put:by</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rep-by'><code>+-rep:by</code></a>
@@ -996,23 +996,23 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 2j: jar and jug logic
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#ja'><code>++ja</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#ja' data-tippy-content="Jar engine"><code>++ja</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#add-ja' data-tippy-content="Prepend to list"><code>+-add:ja</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#get-ja'><code>+-get:ja</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#get-ja' data-tippy-content="Grab value by key"><code>+-get:ja</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#ju'><code>++ju</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#del-ju'><code>+-del:ju</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#get-ju'><code>+-get:ju</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#has-ju'><code>+-has:ju</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#ju' data-tippy-content="Jug operations"><code>++ju</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#del-ju' data-tippy-content="Delete (jug)"><code>+-del:ju</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#get-ju' data-tippy-content="Retrieve set"><code>+-get:ju</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#has-ju' data-tippy-content="Check contents (jug)"><code>+-has:ju</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#put-ju'><code>+-put:ju</code></a>
 
 ### 2k: queue logic
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#to'><code>++to</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#bal-to' data-tippy-content="Balance queue"><code>+-bal:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#dep-to'><code>+-dep:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#gas-to'><code>+-gas:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#get-to'><code>+-get:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#dep-to' data-tippy-content="Maximum depth (queue)"><code>+-dep:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#gas-to' data-tippy-content="Push list into queue"><code>+-gas:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#get-to' data-tippy-content="Head-tail pair"><code>+-get:to</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#nap-to'><code>+-nap:to</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#nip-to'><code>+-nip:to</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#put-to'><code>+-put:to</code></a>
@@ -1044,8 +1044,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#corl' data-tippy-content="Compose backward"><code>++corl</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#curr' data-tippy-content="Right-curry a gate"><code>++curr</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#cury' data-tippy-content="Curry left a gate"><code>++cury</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#hard'><code>++hard</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#head'><code>++head</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#hard' data-tippy-content="Force remold"><code>++hard</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#head' data-tippy-content="Get head of cell"><code>++head</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#mean'><code>++mean</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#same'><code>++same</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#slog'><code>++slog</code></a>
@@ -1055,8 +1055,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 2o: normalizing containers
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#jar'><code>++jar</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#jug'><code>++jug</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#jar' data-tippy-content="Mold generator (jar)"><code>++jar</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#jug' data-tippy-content="Mold generator (jug)"><code>++jug</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#map'><code>++map</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#qeu'><code>++qeu</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#set'><code>++set</code></a>
@@ -1064,7 +1064,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### 2p: serialization
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#cue' data-tippy-content="Unpack atom to noun"><code>++cue</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#jam'><code>++jam</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#jam' data-tippy-content="Pack noun to atom"><code>++jam</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#mat'><code>++mat</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#rub'><code>++rub</code></a>
 
@@ -1073,7 +1073,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#char' data-tippy-content="Character"><code>++char</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#cord' data-tippy-content="UTF-8 text"><code>++cord</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#date' data-tippy-content="Point in time"><code>++date</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#knot'><code>++knot</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#knot' data-tippy-content="Atom type of ASCII characters"><code>++knot</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#tang'><code>++tang</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#tank'><code>++tank</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#tape'><code>++tape</code></a>
@@ -1084,11 +1084,11 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 3a: modular and signed ints
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fo'><code>++fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dif-fo'><code>++dif:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#exp-fo'><code>++exp:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fra-fo'><code>++fra:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#inv-fo'><code>++inv:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fo' data-tippy-content="Modulo prime"><code>++fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dif-fo' data-tippy-content='Subtraction (modular base)'><code>++dif:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#exp-fo' data-tippy-content="Exponent (modular base)"><code>++exp:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fra-fo' data-tippy-content="Divide (modular base)"><code>++fra:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#inv-fo' data-tippy-content="Inverse (signed modulus)"><code>++inv:fo</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#pro-fo'><code>++pro:fo</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#sit-fo'><code>++sit:fo</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#sum-fo'><code>++sum:fo</code></a>
@@ -1096,9 +1096,9 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#si'><code>++si</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#abs-si' data-tippy-content="Absolute value (signed integer)"><code>++abs:si</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#cmp-si' data-tippy-content="Compare (signed integer)"><code>++cmp:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dif-si'><code>++dif:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dul-si'><code>++dul:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fra-si'><code>++fra:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dif-si' data-tippy-content="Subtraction (signed integer)"><code>++dif:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dul-si' data-tippy-content="Modulus (signed integer)"><code>++dul:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fra-si' data-tippy-content="Divide (signed integer)"><code>++fra:si</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#new-si'><code>++new:si</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#old-si'><code>++old:si</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#pro-si'><code>++pro:si</code></a>
@@ -1107,7 +1107,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#sun-si'><code>++sun:si</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#syn-si'><code>++syn:si</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#egcd'><code>++egcd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#egcd' data-tippy-content="Extended Euclidean algorithm"><code>++egcd</code></a>
 
 ### 3b: floating point
 
@@ -1119,14 +1119,14 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-ff' data-tippy-content="Add (floating point)"><code>++add:ff</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bif-ff' data-tippy-content="Converts from fn to @r"><code>++bif:ff</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-ff' data-tippy-content="fn to @r with rounding"><code>++bit:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-ff'><code>++div:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-ff'><code>++drg:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-ff'><code>++equ:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-ff'><code>++exp:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-ff'><code>++fma:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-ff'><code>++grd:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-ff'><code>++gte:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-ff'><code>++gth:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-ff' data-tippy-content="Divide (IEEE float)"><code>++div:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-ff' data-tippy-content="@r to decimal float"><code>++drg:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-ff' data-tippy-content="Equals (IEEE float)"><code>++equ:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-ff' data-tippy-content="Get exponent (IEEE float)"><code>++exp:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-ff' data-tippy-content="Fused multiply-add (IEEE float)"><code>++fma:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-ff' data-tippy-content="Decimal float to @r"><code>++grd:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-ff' data-tippy-content="Greater than / equal (IEEE float)"><code>++gte:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-ff' data-tippy-content="Greater than (IEEE float)"><code>++gth:ff</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-ff'><code>++lte:ff</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-ff'><code>++lth:ff</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#me-ff'><code>++me:ff</code></a>
@@ -1144,21 +1144,21 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fl'><code>++fl</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#abs-fl' data-tippy-content="Absolute value"><code>++abs:fl</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-fl' data-tippy-content="Add (with exact/rounded flag)"><code>++add:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#den-fl'><code>++den:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-fl'><code>++div:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-fl'><code>++drg:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ead-fl'><code>++ead:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emn-fl'><code>++emn:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emu-fl'><code>++emu:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emx-fl'><code>++emx:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-fl'><code>++equ:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fli-fl'><code>++fli:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-fl'><code>++fma:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-fl'><code>++grd:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-fl'><code>++gte:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-fl'><code>++gth:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ibl-fl'><code>++ibl:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#inv-fl'><code>++inv:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#den-fl' data-tippy-content="Denormalizes (floating point)"><code>++den:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-fl' data-tippy-content="Divide (signed and unsigned integer cell)"><code>++div:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-fl' data-tippy-content="Get printable decimal (signed and unsigned integer cell)"><code>++drg:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ead-fl' data-tippy-content="Exact add"><code>++ead:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emn-fl' data-tippy-content="Minimum exponent"><code>++emn:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emu-fl' data-tippy-content="Exact multiply"><code>++emu:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emx-fl' data-tippy-content="Maximum exponent"><code>++emx:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-fl' data-tippy-content="Equals (signed and unsigned integer cell)"><code>++equ:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fli-fl' data-tippy-content="Flip sign"><code>++fli:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-fl' data-tippy-content="Fused multiply-add"><code>++fma:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-fl' data-tippy-content="Decimal to float"><code>++grd:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-fl' data-tippy-content="Greater than / equal (producing flag)"><code>++gte:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-fl' data-tippy-content="Greater than (producing flag)"><code>++gth:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ibl-fl' data-tippy-content="Integer binary logarithm"><code>++ibl:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#inv-fl' data-tippy-content="Inverse"><code>++inv:fl</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lfe-fl'><code>++lfe:fl</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lfn-fl'><code>++lfn:fl</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-fl'><code>++lte:fl</code></a>
@@ -1187,14 +1187,14 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rd'><code>++rd</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rd' data-tippy-content="Add (double-precision float)"><code>++add:rd</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rd' data-tippy-content="fn to double-precision binary float"><code>++bit:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rd'><code>++div:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rd'><code>++drg:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rd'><code>++equ:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rd'><code>++exp:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rd'><code>++fma:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rd'><code>++grd:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rd'><code>++gte:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rd'><code>++gth:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rd' data-tippy-content="Double precision float"><code>++div:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rd' data-tippy-content="@rd to decimal float"><code>++drg:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rd' data-tippy-content="Equals (double-precision float)"><code>++equ:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rd' data-tippy-content="Exponent (@rd)"><code>++exp:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rd' data-tippy-content="Fused multiply-add (@rd)"><code>++fma:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rd' data-tippy-content="Decimal float to @rd"><code>++grd:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rd' data-tippy-content="Greater than / equal (double-precision float)"><code>++gte:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rd' data-tippy-content="Greater than (double-precision float)"><code>++gth:rd</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rd'><code>++lte:rd</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rd'><code>++lth:rd</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rd'><code>++ma:rd</code></a>
@@ -1210,15 +1210,15 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rh'><code>++rh</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rh' data-tippy-content="Add (half-precision float)"><code>++add:rh</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rh' data-tippy-content="fn to half-precision float"><code>++bit:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rh'><code>++div:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rh'><code>++drg:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rh'><code>++equ:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rh'><code>++exp:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rh'><code>++fma:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fos-rh'><code>++fos:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rh'><code>++grd:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rh'><code>++gte:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rh'><code>++gth:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rh' data-tippy-content="Divide (half-precision float)"><code>++div:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rh' data-tippy-content="@rh to decimal float"><code>++drg:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rh' data-tippy-content="Equals (half-precision float)"><code>++equ:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rh' data-tippy-content="Exponent (half-precision float)"><code>++exp:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rh' data-tippy-content="Fused multiply-add (half-precision float)"><code>++fma:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fos-rh' data-tippy-content="@rs to @rh"><code>++fos:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rh' data-tippy-content="Decimal float to @rh"><code>++grd:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rh' data-tippy-content="Greater than / equal (half-precision float)"><code>++gte:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rh' data-tippy-content="Greater than (half-precision float)"><code>++gth:rh</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rh'><code>++lte:rh</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rh'><code>++lth:rh</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rh'><code>++ma:rh</code></a>
@@ -1235,14 +1235,14 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rs'><code>++rs</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rs' data-tippy-content="Add (single-precision float)"><code>++add:rs</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rs' data-tippy-content="fn to single-precision float"><code>++bit:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rs'><code>++div:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rs'><code>++drg:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rs'><code>++equ:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rs'><code>++exp:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rs'><code>++fma:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rs'><code>++grd:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rs'><code>++gte:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rs'><code>++gth:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rs' data-tippy-content="Divide (single-precision float)"><code>++div:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rs' data-tippy-content="@rs to decimal float"><code>++drg:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rs' data-tippy-content="Equals (single-precision float)"><code>++equ:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rs' data-tippy-content="Exponent (@rs)"><code>++exp:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rs' data-tippy-content="Fused multiply-add (single-precision float)"><code>++fma:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rs' data-tippy-content="Decimal float to @rs"><code>++grd:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rs' data-tippy-content="Greater than / equal (single-precision float)"><code>++gte:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rs' data-tippy-content="Greater than (single-precision float)"><code>++gth:rs</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rs'><code>++lte:rs</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rs'><code>++lth:rs</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rs'><code>++ma:rs</code></a>
@@ -1258,14 +1258,14 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rq'><code>++rq</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rq' data-tippy-content="Add (quad-precision float)"><code>++add:rq</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rq' data-tippy-content="fn to quad-precision float"><code>++bit:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rq'><code>++div:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rq'><code>++drg:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rq'><code>++equ:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rq'><code>++exp:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rq'><code>++fma:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rq'><code>++grd:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rq'><code>++gte:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rq'><code>++gth:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rq' data-tippy-content="Divide (quad-precision float)"><code>++div:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rq' data-tippy-content="@rq to decimal float"><code>++drg:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rq' data-tippy-content="Equals (quad-precision float)"><code>++equ:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rq' data-tippy-content="Exponent (quad-precision float)"><code>++exp:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rq' data-tippy-content="Fused multiply-add (quad-precision float)"><code>++fma:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rq' data-tippy-content="Decimal float to @rq"><code>++grd:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rq' data-tippy-content="Greater than / equal (quad-precision float)"><code>++gte:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rq' data-tippy-content="Greater than (quad-precision float)"><code>++gth:rq</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rq'><code>++lte:rq</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rq'><code>++lth:rq</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rq'><code>++ma:rq</code></a>
@@ -1292,9 +1292,9 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yo'><code>++yo</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#cet-yo' data-tippy-content="Days in a century"><code>++cet:yo</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#day-yo' data-tippy-content="Seconds in day"><code>++day:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#era-yo'><code>++era:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#hor-yo'><code>++hor:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#jes-yo'><code>++jes:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#era-yo' data-tippy-content="Leap-year period"><code>++era:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#hor-yo' data-tippy-content="Seconds in hour"><code>++hor:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#jes-yo' data-tippy-content="Maximum 64-bit timestamp"><code>++jes:yo</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#mit-yo'><code>++mit:yo</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#moh-yo'><code>++moh:yo</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#moy-yo'><code>++moy:yo</code></a>
@@ -1330,14 +1330,14 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 3e: AES encryption
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3e/'>_(removed)_</a>
+<a href='https://urbit.org/docs/reference/library/3e/'>_(removed)_</a>
 
 ### 3f: scrambling
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#ob'><code>++ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#feen-ob'><code>++feen:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#fend-ob'><code>++fend:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#fice-ob'><code>++fice:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#feen-ob' data-tippy-content="Conceal structure v2"><code>++feen:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#fend-ob' data-tippy-content="Restore structure v2"><code>++fend:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#fice-ob' data-tippy-content="Feistel-like cipher"><code>++fice:ob</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#raku-ob'><code>++raku:ob</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#rund-ob'><code>++rund:ob</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#rynd-ob'><code>++rynd:ob</code></a>
@@ -1356,9 +1356,9 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### 3g: molds and mold builders
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#coin' data-tippy-content="Noun-literal syntax cases"><code>++coin</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#dime'><code>++dime</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#edge'><code>++edge</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#hair'><code>++hair</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#dime' data-tippy-content="Aura-atom pair"><code>++dime</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#edge' data-tippy-content="Parsing location metadata"><code>++edge</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#hair' data-tippy-content="Parsing line and column"><code>++hair</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#like'><code>++like</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#nail'><code>++nail</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#path'><code>++path</code></a>
@@ -1372,8 +1372,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### 4a: exotic bases
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#po'><code>++po</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#ind-po'><code>++ind:po</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#ins-po'><code>++ins:po</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#ind-po' data-tippy-content="Parse suffix"><code>++ind:po</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#ins-po' data-tippy-content="Parse prefix"><code>++ins:po</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#tod-po'><code>++tod:po</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#tos-po'><code>++tos:po</code></a>
 
@@ -1415,8 +1415,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### 4c: tank printer
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#re'><code>++re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#din-re'><code>++din:re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#fit-re'><code>++fit:re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#din-re' data-tippy-content="(Undocumented)"><code>++din:re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#fit-re' data-tippy-content="Fit on one line test"><code>++fit:re</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#ram-re'><code>++ram:re</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#rig-re'><code>++rig:re</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#wig-re'><code>++wig:re</code></a>
@@ -1435,8 +1435,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#bend' data-tippy-content="Conditional composer"><code>++bend</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#comp' data-tippy-content="Arbitrary compose"><code>++comp</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#fail'><code>++fail</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#glue'><code>++glue</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#fail' data-tippy-content="Never parse"><code>++fail</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#glue' data-tippy-content="Skip delimiter"><code>++glue</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#less'><code>++less</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#pfix'><code>++pfix</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#plug'><code>++plug</code></a>
@@ -1450,14 +1450,14 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#boss' data-tippy-content="Parser modifier: LSB"><code>++boss</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#cold' data-tippy-content="Replace with constant"><code>++cold</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#cook' data-tippy-content="Apply gate"><code>++cook</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#easy'><code>++easy</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#full'><code>++full</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#funk'><code>++funk</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#here'><code>++here</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#ifix'><code>++ifix</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#jest'><code>++jest</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#just'><code>++just</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#knee'><code>++knee</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#easy' data-tippy-content="Always parse"><code>++easy</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#full' data-tippy-content="Parse to end"><code>++full</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#funk' data-tippy-content="Add to tape"><code>++funk</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#here' data-tippy-content="Place-based apply"><code>++here</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#ifix' data-tippy-content="Infix"><code>++ifix</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#jest' data-tippy-content="Match a cord"><code>++jest</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#just' data-tippy-content="Match a single character"><code>++just</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#knee' data-tippy-content="Recursive parsers"><code>++knee</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#mask'><code>++mask</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#more'><code>++more</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#most'><code>++most</code></a>
@@ -1490,16 +1490,16 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#cen' data-tippy-content="Parse % (cen)"><code>++cen</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#col' data-tippy-content="Parse : (col)"><code>++col</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#com' data-tippy-content="Parse , (comma)"><code>++com</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#doq'><code>++doq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#dot'><code>++dot</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#fas'><code>++fas</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#gal'><code>++gal</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#gar'><code>++gar</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#hax'><code>++hax</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#hep'><code>++hep</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#kel'><code>++kel</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ker'><code>++ker</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ket'><code>++ket</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#doq' data-tippy-content="Parse double quote"><code>++doq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#dot' data-tippy-content="Parse period"><code>++dot</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#fas' data-tippy-content="Parse / (fas)"><code>++fas</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#gal' data-tippy-content="Parse < (gal)"><code>++gal</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#gar' data-tippy-content="Parse > (gar)"><code>++gar</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#hax' data-tippy-content="Parse # (hax)"><code>++hax</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#hep' data-tippy-content="Parse - (hep)"><code>++hep</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#kel' data-tippy-content="Parse { (kel)"><code>++kel</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ker' data-tippy-content="Parse } (ker)"><code>++ker</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ket' data-tippy-content="Parse ^ (ket)"><code>++ket</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#lus'><code>++lus</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pam'><code>++pam</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pat'><code>++pat</code></a>
@@ -1525,23 +1525,23 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#bin' data-tippy-content="Binary to atom"><code>++bin</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#but' data-tippy-content="Parse binary digit"><code>++but</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#cit' data-tippy-content="Octal digit"><code>++cit</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dem'><code>++dem</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dit'><code>++dit</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dog'><code>++dog</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#doh'><code>++doh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dun'><code>++dun</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#duz'><code>++duz</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gah'><code>++gah</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gap'><code>++gap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gaq'><code>++gaq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gaw'><code>++gaw</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gay'><code>++gay</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gon'><code>++gon</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gul'><code>++gul</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hex'><code>++hex</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hig'><code>++hig</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hit'><code>++hit</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#iny'><code>++iny</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dem' data-tippy-content="Decimal to atom"><code>++dem</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dit' data-tippy-content="Decimal digit"><code>++dit</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dog' data-tippy-content="Optional gap"><code>++dog</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#doh' data-tippy-content="@p separator"><code>++doh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dun' data-tippy-content="-- to ~"><code>++dun</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#duz' data-tippy-content="== to ~"><code>++duz</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gah' data-tippy-content="New line or ''"><code>++gah</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gap' data-tippy-content="Plural whitespace"><code>++gap</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gaq' data-tippy-content="End of line"><code>++gaq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gaw' data-tippy-content="Classic whitespace"><code>++gaw</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gay' data-tippy-content="Optional gap"><code>++gay</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gon' data-tippy-content="Parse long numbers"><code>++gon</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gul' data-tippy-content="Axis syntax < or >"><code>++gul</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hex' data-tippy-content="Hexadecimal to atom"><code>++hex</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hig' data-tippy-content="Parse single uppercase letter"><code>++hig</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hit' data-tippy-content="Parse single hexadecimal digit"><code>++hit</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#iny' data-tippy-content="Indentation block"><code>++iny</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#low'><code>++low</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#mes'><code>++mes</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#nix'><code>++nix</code></a>
@@ -1559,9 +1559,9 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ab' data-tippy-content="Primitive parser engine"><code>++ab</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#bix-ab' data-tippy-content="Parse hex pair"><code>++bix:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hif-ab'><code>++hif:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#huf-ab'><code>++huf:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hyf-ab'><code>++hyf:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hif-ab' data-tippy-content="Parse phonetic pair"><code>++hif:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#huf-ab' data-tippy-content="Parse two phonetic pairs"><code>++huf:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hyf-ab' data-tippy-content="Parse 8 phonetic bytes"><code>++hyf:ab</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#pev-ab'><code>++pev:ab</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#pew-ab'><code>++pew:ab</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#piv-ab'><code>++piv:ab</code></a>
@@ -1596,11 +1596,11 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ape-ag' data-tippy-content="Parse 0 or rule"><code>++ape:ag</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#bay-ag' data-tippy-content="Parses binary number"><code>++bay:ag</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#bip-ag' data-tippy-content="Parse IPv6"><code>++bip:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dem-ag'><code>++dem:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dim-ag'><code>++dim:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dum-ag'><code>++dum:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#fed-ag'><code>++fed:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hex-ag'><code>++hex:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dem-ag' data-tippy-content="Parse decmal with dots"><code>++dem:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dim-ag' data-tippy-content="Parse decimal number"><code>++dim:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dum-ag' data-tippy-content="Parse decimal with leading zero"><code>++dum:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#fed-ag' data-tippy-content="Parse @p"><code>++fed:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hex-ag' data-tippy-content="Parse hexadecimal number"><code>++hex:ag</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#lip-ag'><code>++lip:ag</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#viz-ag'><code>++viz:ag</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#vum-ag'><code>++vum:ag</code></a>
@@ -1672,7 +1672,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#beet' data-tippy-content="XML interpolation cases"><code>++beet</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#chum' data-tippy-content="Jet hint information"><code>++chum</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#coil' data-tippy-content="Tuple of core information"><code>++coil</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#foot'><code>++foot</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#foot' data-tippy-content="Cases of arms by variance model"><code>++foot</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#limb'><code>++limb</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#line'><code>++line</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#metl'><code>++metl</code></a>

--- a/reference/library/_index.md
+++ b/reference/library/_index.md
@@ -318,20 +318,20 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### l
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4d/#last'><code>++last</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#le-nl'><code>++le:nl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#lent'><code>++lent</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#levy'><code>++levy</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lfe-fl'><code>++lfe:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lfn-fl'><code>++lfn:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#lien'><code>++lien</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#lift'><code>++lift</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#like'><code>++like</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#limb'><code>++limb</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#limo'><code>++limo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#line'><code>++line</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#lip-ag'><code>++lip:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#list'><code>++list</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4d/#last' data-tippy-content="Further trace"><code>++last</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#le-nl' data-tippy-content="Construct list from null-terminated noun"><code>++le:nl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#lent' data-tippy-content="List length"><code>++lent</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#levy' data-tippy-content="Logical AND on list"><code>++levy</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lfe-fl' data-tippy-content="Maximum"><code>++lfe:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lfn-fl' data-tippy-content="Largest normal float"><code>++lfn:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#lien' data-tippy-content="Logical OR on list"><code>++lien</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#lift' data-tippy-content="Curried bind"><code>++lift</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#like' data-tippy-content="Generic edge"><code>++like</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#limb' data-tippy-content="Reference into subject by name/axis"><code>++limb</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#limo' data-tippy-content="Construct list from null-terminated tuple"><code>++limo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#line' data-tippy-content="(Undocumented)"><code>++line</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#lip-ag' data-tippy-content="Parse IPv4 address"><code>++lip:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#list' data-tippy-content="Mold constructor (list)"><code>++list</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#lone'><code>++lone</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#lor'><code>++lor</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#low'><code>++low</code></a>
@@ -836,7 +836,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#bloq' data-tippy-content="Blocksize"><code>++bloq</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#each' data-tippy-content="Mold of fork between two types"><code>++each</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#gate' data-tippy-content="Function"><code>++gate</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#list'><code>++list</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#list' data-tippy-content="Mold constructor (list)"><code>++list</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#lone'><code>++lone</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#pair'><code>++pair</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#pole'><code>++pole</code></a>
@@ -855,7 +855,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#clap' data-tippy-content="Apply function to two units"><code>++clap</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#drop' data-tippy-content="Unit to list"><code>++drop</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#fall' data-tippy-content="Give unit a default value"><code>++fall</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#lift'><code>++lift</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#lift' data-tippy-content="Curried bind"><code>++lift</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#mate'><code>++mate</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#need'><code>++need</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#some'><code>++some</code></a>
@@ -867,10 +867,10 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#flop' data-tippy-content="Reverse list"><code>++flop</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#gulf' data-tippy-content="List from range"><code>++gulf</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#homo' data-tippy-content="Homogenize list"><code>++homo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#lent'><code>++lent</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#levy'><code>++levy</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#lien'><code>++lien</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#limo'><code>++limo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#lent' data-tippy-content="List length"><code>++lent</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#levy' data-tippy-content="Logical AND on list"><code>++levy</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#lien' data-tippy-content="Logical OR on list"><code>++lien</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#limo' data-tippy-content="Construct list from null-terminated tuple"><code>++limo</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#murn'><code>++murn</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#oust'><code>++oust</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#reap'><code>++reap</code></a>
@@ -1028,7 +1028,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### 2m: container from noun
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#nl'><code>++nl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#le-nl'><code>++le:nl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#le-nl' data-tippy-content="Construct list from null-terminated noun"><code>++le:nl</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#my-nl'><code>++my:nl</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#si-nl'><code>++si:nl</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#snag-nl'><code>++snag:nl</code></a>
@@ -1159,8 +1159,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-fl' data-tippy-content="Greater than (producing flag)"><code>++gth:fl</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ibl-fl' data-tippy-content="Integer binary logarithm"><code>++ibl:fl</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#inv-fl' data-tippy-content="Inverse"><code>++inv:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lfe-fl'><code>++lfe:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lfn-fl'><code>++lfn:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lfe-fl' data-tippy-content="Maximum"><code>++lfe:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lfn-fl' data-tippy-content="Largest normal float"><code>++lfn:fl</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-fl'><code>++lte:fl</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-fl'><code>++lth:fl</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lug-fl'><code>++lug:fl</code></a>
@@ -1359,7 +1359,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#dime' data-tippy-content="Aura-atom pair"><code>++dime</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#edge' data-tippy-content="Parsing location metadata"><code>++edge</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#hair' data-tippy-content="Parsing line and column"><code>++hair</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#like'><code>++like</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#like' data-tippy-content="Generic edge"><code>++like</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#nail'><code>++nail</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#path'><code>++path</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#pint'><code>++pint</code></a>
@@ -1428,7 +1428,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 4d: parsing (tracing)
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4d/#last'><code>++last</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4d/#last' data-tippy-content="Further trace"><code>++last</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4d/#lust'><code>++lust</code></a>
 
 ### 4e: parsing (combinators)
@@ -1601,7 +1601,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dum-ag' data-tippy-content="Parse decimal with leading zero"><code>++dum:ag</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#fed-ag' data-tippy-content="Parse @p"><code>++fed:ag</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hex-ag' data-tippy-content="Parse hexadecimal number"><code>++hex:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#lip-ag'><code>++lip:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#lip-ag' data-tippy-content="Parse IPv4 address"><code>++lip:ag</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#viz-ag'><code>++viz:ag</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#vum-ag'><code>++vum:ag</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#wiz-ag'><code>++wiz:ag</code></a>
@@ -1673,8 +1673,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#chum' data-tippy-content="Jet hint information"><code>++chum</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#coil' data-tippy-content="Tuple of core information"><code>++coil</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#foot' data-tippy-content="Cases of arms by variance model"><code>++foot</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#limb'><code>++limb</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#line'><code>++line</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#limb' data-tippy-content="Reference into subject by name/axis"><code>++limb</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#line' data-tippy-content="(Undocumented)"><code>++line</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#metl'><code>++metl</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#nock'><code>++nock</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#noun'><code>++noun</code></a>

--- a/reference/library/_index.md
+++ b/reference/library/_index.md
@@ -13,1718 +13,1718 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### a
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#ab' data-tippy-content="Primitive parser engine"><code>++ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#abs-fl' data-tippy-content="Absolute value"><code>++abs:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#abs-si' data-tippy-content="Absolute value (signed integer)"><code>++abs:si</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#abel' data-tippy-content="Compiler alias"><code>++abel</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#ace' data-tippy-content="Parse space"><code>++ace</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#add' data-tippy-content="Add"><code>++add</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#add-ff' data-tippy-content="Add (floating point)"><code>++add:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#add-fl' data-tippy-content="Add (with exact/rounded flag)"><code>++add:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#add-ja' data-tippy-content="Prepend to list"><code>+-add:ja</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#add-rd' data-tippy-content="Add (double-precision float)"><code>++add:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#add-rh' data-tippy-content="Add (half-precision float)"><code>++add:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#add-rs' data-tippy-content="Add (single-precision float)"><code>++add:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#add-rq' data-tippy-content="Add (quad-precision float)"><code>++add:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#ag' data-tippy-content="Top-level atom parser engine"><code>++ag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#alf' data-tippy-content="Parse alphabetic characters"><code>++alf</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#all-by' data-tippy-content="Logical AND (map and wet gate)"><code>+-all:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#all-in' data-tippy-content="Logical AND (set and wet gate)"><code>+-all:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#aln' data-tippy-content="Parse alphanumeric characters"><code>++aln</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#alp' data-tippy-content="Parse alphanumeric characters and -"><code>++alp</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#any-by' data-tippy-content="Logical OR (map and wet gate)"><code>+-any:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#any-in' data-tippy-content="Logical OR (set and gate)"><code>+-any:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2f.md#aor' data-tippy-content="Alphabetical order"><code>++aor</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#ape-ag' data-tippy-content="Parse 0 or rule"><code>++ape:ag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#apt-by' data-tippy-content="Check correctness (map)"><code>+-apt:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#apt-in' data-tippy-content="Check correctness (set)"><code>+-apt:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#at' data-tippy-content="(Undocumented)"><code>++at</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#aura' data-tippy-content="'Type' of atom"><code>++aura</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#axis' data-tippy-content="Nock axis"><code>++axis</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ab' data-tippy-content="Primitive parser engine"><code>++ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#abs-fl' data-tippy-content="Absolute value"><code>++abs:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#abs-si' data-tippy-content="Absolute value (signed integer)"><code>++abs:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#abel' data-tippy-content="Compiler alias"><code>++abel</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ace' data-tippy-content="Parse space"><code>++ace</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#add' data-tippy-content="Add"><code>++add</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-ff' data-tippy-content="Add (floating point)"><code>++add:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-fl' data-tippy-content="Add (with exact/rounded flag)"><code>++add:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#add-ja' data-tippy-content="Prepend to list"><code>+-add:ja</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rd' data-tippy-content="Add (double-precision float)"><code>++add:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rh' data-tippy-content="Add (half-precision float)"><code>++add:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rs' data-tippy-content="Add (single-precision float)"><code>++add:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rq' data-tippy-content="Add (quad-precision float)"><code>++add:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ag' data-tippy-content="Top-level atom parser engine"><code>++ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#alf' data-tippy-content="Parse alphabetic characters"><code>++alf</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#all-by' data-tippy-content="Logical AND (map and wet gate)"><code>+-all:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#all-in' data-tippy-content="Logical AND (set and wet gate)"><code>+-all:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#aln' data-tippy-content="Parse alphanumeric characters"><code>++aln</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#alp' data-tippy-content="Parse alphanumeric characters and -"><code>++alp</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#any-by' data-tippy-content="Logical OR (map and wet gate)"><code>+-any:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#any-in' data-tippy-content="Logical OR (set and gate)"><code>+-any:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#aor' data-tippy-content="Alphabetical order"><code>++aor</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ape-ag' data-tippy-content="Parse 0 or rule"><code>++ape:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#apt-by' data-tippy-content="Check correctness (map)"><code>+-apt:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#apt-in' data-tippy-content="Check correctness (set)"><code>+-apt:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#at' data-tippy-content="(Undocumented)"><code>++at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#aura' data-tippy-content="'Type' of atom"><code>++aura</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#axis' data-tippy-content="Nock axis"><code>++axis</code></a>
 
 ### b
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#bal-to' data-tippy-content="Balance queue"><code>+-bal:to</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#bar' data-tippy-content="Parse | (bar)"><code>++bar</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#bas' data-tippy-content="Parse \ (bas)"><code>++bas</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#base' data-tippy-content="Base type"><code>++base</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#bass' data-tippy-content="Parser modifier (LSB-ordered ++list as atom of ++base)"><code>++bass</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#bay-ag' data-tippy-content="Parses binary number"><code>++bay:ag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#bean' data-tippy-content="Boolean"><code>++bean</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#beer' data-tippy-content="Tape builder"><code>++beer</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#beet' data-tippy-content="XML interpolation cases"><code>++beet</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#bend' data-tippy-content="Conditional composer"><code>++bend</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#bet' data-tippy-content="Parse hep and lus axis syntax"><code>++bet</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#bex' data-tippy-content="Binary exponent"><code>++bex</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bif-ff' data-tippy-content="Converts from fn to @r"><code>++bif:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#bif-by' data-tippy-content="Bifurcate map"><code>+-bif:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#bif-in' data-tippy-content="Bifurcate set"><code>+-bif:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#biff' data-tippy-content="Unit as argument"><code>++biff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#bin' data-tippy-content="Binary to atom"><code>++bin</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#bind' data-tippy-content="Non-unit function to unit, producing unit"><code>++bind</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#bip-ag' data-tippy-content="Parse IPv6"><code>++bip:ag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-ff' data-tippy-content="fn to @r with rounding"><code>++bit:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rd' data-tippy-content="fn to double-precision binary float"><code>++bit:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rh' data-tippy-content="fn to half-precision float"><code>++bit:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rs' data-tippy-content="fn to single-precision float"><code>++bit:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rq' data-tippy-content="fn to quad-precision float"><code>++bit:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#bix-ab' data-tippy-content="Parse hex pair"><code>++bix:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#bisk-so' data-tippy-content="Parse odor-atom pair"><code>++bisk:so</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#bloq' data-tippy-content="Blocksize"><code>++bloq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#bond' data-tippy-content="Replace null"><code>++bond</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#boss' data-tippy-content="Parser modifier: LSB"><code>++boss</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#both' data-tippy-content="Group unit values into pair"><code>++both</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#buc' data-tippy-content="Parse $ (buc)"><code>++buc</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#but' data-tippy-content="Parse binary digit"><code>++but</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#bal-to' data-tippy-content="Balance queue"><code>+-bal:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#bar' data-tippy-content="Parse | (bar)"><code>++bar</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#bas' data-tippy-content="Parse \ (bas)"><code>++bas</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#base' data-tippy-content="Base type"><code>++base</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#bass' data-tippy-content="Parser modifier (LSB-ordered ++list as atom of ++base)"><code>++bass</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#bay-ag' data-tippy-content="Parses binary number"><code>++bay:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#bean' data-tippy-content="Boolean"><code>++bean</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#beer' data-tippy-content="Tape builder"><code>++beer</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#beet' data-tippy-content="XML interpolation cases"><code>++beet</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#bend' data-tippy-content="Conditional composer"><code>++bend</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#bet' data-tippy-content="Parse hep and lus axis syntax"><code>++bet</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#bex' data-tippy-content="Binary exponent"><code>++bex</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bif-ff' data-tippy-content="Converts from fn to @r"><code>++bif:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#bif-by' data-tippy-content="Bifurcate map"><code>+-bif:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#bif-in' data-tippy-content="Bifurcate set"><code>+-bif:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#biff' data-tippy-content="Unit as argument"><code>++biff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#bin' data-tippy-content="Binary to atom"><code>++bin</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#bind' data-tippy-content="Non-unit function to unit, producing unit"><code>++bind</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#bip-ag' data-tippy-content="Parse IPv6"><code>++bip:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-ff' data-tippy-content="fn to @r with rounding"><code>++bit:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rd' data-tippy-content="fn to double-precision binary float"><code>++bit:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rh' data-tippy-content="fn to half-precision float"><code>++bit:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rs' data-tippy-content="fn to single-precision float"><code>++bit:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rq' data-tippy-content="fn to quad-precision float"><code>++bit:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#bix-ab' data-tippy-content="Parse hex pair"><code>++bix:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#bisk-so' data-tippy-content="Parse odor-atom pair"><code>++bisk:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#bloq' data-tippy-content="Blocksize"><code>++bloq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#bond' data-tippy-content="Replace null"><code>++bond</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#boss' data-tippy-content="Parser modifier: LSB"><code>++boss</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#both' data-tippy-content="Group unit values into pair"><code>++both</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#buc' data-tippy-content="Parse $ (buc)"><code>++buc</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#but' data-tippy-content="Parse binary digit"><code>++but</code></a>
 
 ### c
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#cab' data-tippy-content="Parse _ (cab)"><code>++cab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#can' data-tippy-content="Assemble"><code>++can</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1b.md#cap' data-tippy-content="Tree head"><code>++cap</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#cass' data-tippy-content="To lowercase"><code>++cass</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#cat' data-tippy-content="Concatenate"><code>++cat</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#cen' data-tippy-content="Parse % (cen)"><code>++cen</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#cet-yo' data-tippy-content="Days in a century"><code>++cet:yo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#char' data-tippy-content="Character"><code>++char</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#chum' data-tippy-content="Jet hint information"><code>++chum</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#cit' data-tippy-content="Octal digit"><code>++cit</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#clap' data-tippy-content="Apply function to two units"><code>++clap</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#cmp-si' data-tippy-content="Compare (signed integer)"><code>++cmp:si</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4k.md#co' data-tippy-content="Literal rendering engine"><code>++co</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#coil' data-tippy-content="Tuple of core information"><code>++coil</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#coin' data-tippy-content="Noun-literal syntax cases"><code>++coin</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#col' data-tippy-content="Parse : (col)"><code>++col</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#cold' data-tippy-content="Replace with constant"><code>++cold</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#com' data-tippy-content="Parse , (com)"><code>++com</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#comp' data-tippy-content="Arbitrary compose"><code>++comp</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2d.md#con' data-tippy-content="Binary OR"><code>++con</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#cook' data-tippy-content="Apply gate"><code>++cook</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#cord' data-tippy-content="UTF-8 text"><code>++cord</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#cork' data-tippy-content="Compose forward"><code>++cork</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#corl' data-tippy-content="Compose backward"><code>++corl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#crip' data-tippy-content="Tape to cord"><code>++crip</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#crub-so' data-tippy-content="Parse @da, @dr, @p, @t"><code>++crub:so</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2p.md#cue' data-tippy-content="Unpack atom to noun"><code>++cue</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#curr' data-tippy-content="Right-curry a gate"><code>++curr</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#cury' data-tippy-content="Curry left a gate"><code>++cury</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#cuss' data-tippy-content="To uppercase"><code>++cuss</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#cut' data-tippy-content="Slice"><code>++cut</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#cab' data-tippy-content="Parse _ (cab)"><code>++cab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#can' data-tippy-content="Assemble"><code>++can</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#cap' data-tippy-content="Tree head"><code>++cap</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#cass' data-tippy-content="To lowercase"><code>++cass</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#cat' data-tippy-content="Concatenate"><code>++cat</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#cen' data-tippy-content="Parse % (cen)"><code>++cen</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#cet-yo' data-tippy-content="Days in a century"><code>++cet:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#char' data-tippy-content="Character"><code>++char</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#chum' data-tippy-content="Jet hint information"><code>++chum</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#cit' data-tippy-content="Octal digit"><code>++cit</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#clap' data-tippy-content="Apply function to two units"><code>++clap</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#cmp-si' data-tippy-content="Compare (signed integer)"><code>++cmp:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#co' data-tippy-content="Literal rendering engine"><code>++co</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#coil' data-tippy-content="Tuple of core information"><code>++coil</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#coin' data-tippy-content="Noun-literal syntax cases"><code>++coin</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#col' data-tippy-content="Parse : (col)"><code>++col</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#cold' data-tippy-content="Replace with constant"><code>++cold</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#com' data-tippy-content="Parse , (com)"><code>++com</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#comp' data-tippy-content="Arbitrary compose"><code>++comp</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#con' data-tippy-content="Binary OR"><code>++con</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#cook' data-tippy-content="Apply gate"><code>++cook</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#cord' data-tippy-content="UTF-8 text"><code>++cord</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#cork' data-tippy-content="Compose forward"><code>++cork</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#corl' data-tippy-content="Compose backward"><code>++corl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#crip' data-tippy-content="Tape to cord"><code>++crip</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#crub-so' data-tippy-content="Parse @da, @dr, @p, @t"><code>++crub:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#cue' data-tippy-content="Unpack atom to noun"><code>++cue</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#curr' data-tippy-content="Right-curry a gate"><code>++curr</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#cury' data-tippy-content="Curry left a gate"><code>++cury</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#cuss' data-tippy-content="To uppercase"><code>++cuss</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#cut' data-tippy-content="Slice"><code>++cut</code></a>
 
 ### d
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#d-ne' data-tippy-content="Render decimal"><code>++d:ne</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#date' data-tippy-content="Point in time"><code>++date</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#day-yo' data-tippy-content="Seconds in day"><code>++day:yo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#dec' data-tippy-content="Decrement"><code>++dec</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#def-by' data-tippy-content="Difference (map)"><code>+-def:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#del-by'><code>+-del:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#del-in'><code>+-del:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#del-ju'><code>+-del:ju</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#dem'><code>++dem</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#dem-ag'><code>++dem:ag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#den-fl'><code>++den:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#dep-by'><code>+-dep:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#dep-to'><code>+-dep:to</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#dif-fe'><code>++dif:fe</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#dif-fo'><code>++dif:fo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#dif-in'><code>+-dif:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#dif-si'><code>++dif:si</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#dig-by'><code>+-dig:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#dig-in'><code>+-dig:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#dim-ag'><code>++dim:ag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#dime'><code>++dime</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#din-re'><code>++din:re</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2d.md#dis'><code>++dis</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#dit'><code>++dit</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#div'><code>++div</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#div-ff'><code>++div:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#div-fl'><code>++div:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#div-rd'><code>++div:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#div-rh'><code>++div:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#div-rs'><code>++div:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#div-rq'><code>++div:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#dog'><code>++dog</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#doh'><code>++doh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#doq'><code>++doq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2f.md#dor'><code>++dor</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#dot'><code>++dot</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#drg-ff'><code>++drg:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#drg-fl'><code>++drg:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#drg-rd'><code>++drg:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#drg-rh'><code>++drg:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#drg-rs'><code>++drg:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#drg-rq'><code>++drg:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#drop'><code>++drop</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#dul-si'><code>++dul:si</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#dum-ag'><code>++dum:ag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#dun'><code>++dun</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#duz'><code>++duz</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#dvr'><code>++dvr</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#d-ne' data-tippy-content="Render decimal"><code>++d:ne</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#date' data-tippy-content="Point in time"><code>++date</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#day-yo' data-tippy-content="Seconds in day"><code>++day:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#dec' data-tippy-content="Decrement"><code>++dec</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#def-by' data-tippy-content="Difference (map)"><code>+-def:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#del-by'><code>+-del:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#del-in'><code>+-del:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#del-ju'><code>+-del:ju</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dem'><code>++dem</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dem-ag'><code>++dem:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#den-fl'><code>++den:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#dep-by'><code>+-dep:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#dep-to'><code>+-dep:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#dif-fe'><code>++dif:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dif-fo'><code>++dif:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#dif-in'><code>+-dif:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dif-si'><code>++dif:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#dig-by'><code>+-dig:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#dig-in'><code>+-dig:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dim-ag'><code>++dim:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#dime'><code>++dime</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#din-re'><code>++din:re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#dis'><code>++dis</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dit'><code>++dit</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#div'><code>++div</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-ff'><code>++div:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-fl'><code>++div:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rd'><code>++div:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rh'><code>++div:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rs'><code>++div:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rq'><code>++div:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dog'><code>++dog</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#doh'><code>++doh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#doq'><code>++doq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#dor'><code>++dor</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#dot'><code>++dot</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-ff'><code>++drg:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-fl'><code>++drg:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rd'><code>++drg:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rh'><code>++drg:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rs'><code>++drg:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rq'><code>++drg:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#drop'><code>++drop</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dul-si'><code>++dul:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dum-ag'><code>++dum:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dun'><code>++dun</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#duz'><code>++duz</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#dvr'><code>++dvr</code></a>
 
 ### e
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ead-fl'><code>++ead:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#each'><code>++each</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#easy'><code>++easy</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#edge'><code>++edge</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#egcd'><code>++egcd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#emn-fl'><code>++emn:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#emu-fl'><code>++emu:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#emx-fl'><code>++emx:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#end'><code>++end</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#equ-ff'><code>++equ:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#equ-fl'><code>++equ:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#equ-rd'><code>++equ:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#equ-rh'><code>++equ:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#equ-rs'><code>++equ:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#equ-rq'><code>++equ:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#era-yo'><code>++era:yo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#exp-ff'><code>++exp:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#exp-fo'><code>++exp:fo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#exp-rd'><code>++exp:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#exp-rh'><code>++exp:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#exp-rs'><code>++exp:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#exp-rq'><code>++exp:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ead-fl'><code>++ead:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#each'><code>++each</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#easy'><code>++easy</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#edge'><code>++edge</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#egcd'><code>++egcd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emn-fl'><code>++emn:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emu-fl'><code>++emu:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emx-fl'><code>++emx:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#end'><code>++end</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-ff'><code>++equ:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-fl'><code>++equ:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rd'><code>++equ:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rh'><code>++equ:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rs'><code>++equ:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rq'><code>++equ:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#era-yo'><code>++era:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-ff'><code>++exp:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#exp-fo'><code>++exp:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rd'><code>++exp:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rh'><code>++exp:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rs'><code>++exp:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rq'><code>++exp:rq</code></a>
 
 ### f
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#fail'><code>++fail</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#fall'><code>++fall</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#fand'><code>++fand</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#fas'><code>++fas</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#fe'><code>++fe</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#fed-ag'><code>++fed:ag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#feen-ob'><code>++feen:ob</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#fend-ob'><code>++fend:ob</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#fice-ob'><code>++fice:ob</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#fil'><code>++fil</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#find'><code>++find</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#fit-re'><code>++fit:re</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fli-fl'><code>++fli:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#flop'><code>++flop</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fma-ff'><code>++fma:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fma-fl'><code>++fma:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fma-rd'><code>++fma:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fma-rh'><code>++fma:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fma-rs'><code>++fma:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fma-rq'><code>++fma:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2e.md#fnv'><code>++fnv</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#fo'><code>++fo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#foot'><code>++foot</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fos-rh'><code>++fos:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#fra-fo'><code>++fra:fo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#fra-si'><code>++fra:si</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#full'><code>++full</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#funk'><code>++funk</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#fail'><code>++fail</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#fall'><code>++fall</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#fand'><code>++fand</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#fas'><code>++fas</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#fe'><code>++fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#fed-ag'><code>++fed:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#feen-ob'><code>++feen:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#fend-ob'><code>++fend:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#fice-ob'><code>++fice:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#fil'><code>++fil</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#find'><code>++find</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#fit-re'><code>++fit:re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fli-fl'><code>++fli:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#flop'><code>++flop</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-ff'><code>++fma:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-fl'><code>++fma:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rd'><code>++fma:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rh'><code>++fma:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rs'><code>++fma:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rq'><code>++fma:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#fnv'><code>++fnv</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fo'><code>++fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#foot'><code>++foot</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fos-rh'><code>++fos:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fra-fo'><code>++fra:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fra-si'><code>++fra:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#full'><code>++full</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#funk'><code>++funk</code></a>
 
 ### g
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#gah'><code>++gah</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#gal'><code>++gal</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#gap'><code>++gap</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#gaq'><code>++gaq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#gar'><code>++gar</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#gas-by'><code>+-gas:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#gas-in'><code>+-gas:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#gas-to'><code>+-gas:to</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#gate'><code>++gate</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#gaw'><code>++gaw</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#gay'><code>++gay</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#get-by'><code>+-get:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#get-ja'><code>+-get:ja</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#get-ju'><code>+-get:ju</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#get-to'><code>+-get:to</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#glue'><code>++glue</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#gon'><code>++gon</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2f.md#gor'><code>++gor</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#got-by'><code>+-got:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#grd-ff'><code>++grd:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#grd-fl'><code>++grd:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#grd-rd'><code>++grd:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#grd-rh'><code>++grd:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#grd-rs'><code>++grd:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#grd-rq'><code>++grd:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#gte'><code>++gte</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gte-ff'><code>++gte:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gte-fl'><code>++gte:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gte-rd'><code>++gte:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gte-rh'><code>++gte:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gte-rs'><code>++gte:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gte-rq'><code>++gte:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#gth'><code>++gth</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gth-ff'><code>++gth:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gth-fl'><code>++gth:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gth-rd'><code>++gth:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gth-rh'><code>++gth:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gth-rs'><code>++gth:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gth-rq'><code>++gth:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#gul'><code>++gul</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#gulf'><code>++gulf</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gah'><code>++gah</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#gal'><code>++gal</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gap'><code>++gap</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gaq'><code>++gaq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#gar'><code>++gar</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#gas-by'><code>+-gas:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#gas-in'><code>+-gas:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#gas-to'><code>+-gas:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#gate'><code>++gate</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gaw'><code>++gaw</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gay'><code>++gay</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#get-by'><code>+-get:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#get-ja'><code>+-get:ja</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#get-ju'><code>+-get:ju</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#get-to'><code>+-get:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#glue'><code>++glue</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gon'><code>++gon</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#gor'><code>++gor</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#got-by'><code>+-got:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-ff'><code>++grd:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-fl'><code>++grd:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rd'><code>++grd:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rh'><code>++grd:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rs'><code>++grd:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rq'><code>++grd:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#gte'><code>++gte</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-ff'><code>++gte:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-fl'><code>++gte:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rd'><code>++gte:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rh'><code>++gte:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rs'><code>++gte:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rq'><code>++gte:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#gth'><code>++gth</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-ff'><code>++gth:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-fl'><code>++gth:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rd'><code>++gth:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rh'><code>++gth:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rs'><code>++gth:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rq'><code>++gth:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gul'><code>++gul</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#gulf'><code>++gulf</code></a>
 
 ### h
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#hair'><code>++hair</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#hard'><code>++hard</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#has-by'><code>+-has:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#has-in'><code>+-has:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#has-ju'><code>+-has:ju</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#hax'><code>++hax</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#head'><code>++head</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#here'><code>++here</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#hep'><code>++hep</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#hex'><code>++hex</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#hex-ag'><code>++hex:ag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#hif-ab'><code>++hif:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#hig'><code>++hig</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#hit'><code>++hit</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#homo'><code>++homo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2f.md#hor'><code>++hor</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#hor-yo'><code>++hor:yo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#huf-ab'><code>++huf:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#hyf-ab'><code>++hyf:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#hair'><code>++hair</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#hard'><code>++hard</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#has-by'><code>+-has:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#has-in'><code>+-has:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#has-ju'><code>+-has:ju</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#hax'><code>++hax</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#head'><code>++head</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#here'><code>++here</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#hep'><code>++hep</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hex'><code>++hex</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hex-ag'><code>++hex:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hif-ab'><code>++hif:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hig'><code>++hig</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hit'><code>++hit</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#homo'><code>++homo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#hor'><code>++hor</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#hor-yo'><code>++hor:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#huf-ab'><code>++huf:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hyf-ab'><code>++hyf:ab</code></a>
 
 ### i
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ibl-fl'><code>++ibl:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#ifix'><code>++ifix</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4a.md#ind-po'><code>++ind:po</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4a.md#ins-po'><code>++ins:po</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#int-by'><code>+-int:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#int-in'><code>+-int:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#inv-fe'><code>++inv:fe</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#inv-fl'><code>++inv:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#inv-fo'><code>++inv:fo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#iny'><code>++iny</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ibl-fl'><code>++ibl:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#ifix'><code>++ifix</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#ind-po'><code>++ind:po</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#ins-po'><code>++ins:po</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#int-by'><code>+-int:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#int-in'><code>+-int:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#inv-fe'><code>++inv:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#inv-fl'><code>++inv:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#inv-fo'><code>++inv:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#iny'><code>++iny</code></a>
 
 ### j
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#ja'><code>++ja</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2p.md#jam'><code>++jam</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2o.md#jar'><code>++jar</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#jes-yo'><code>++jes:yo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#jest'><code>++jest</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#ju'><code>++ju</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2o.md#jug'><code>++jug</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#just'><code>++just</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#ja'><code>++ja</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#jam'><code>++jam</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#jar'><code>++jar</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#jes-yo'><code>++jes:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#jest'><code>++jest</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#ju'><code>++ju</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#jug'><code>++jug</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#just'><code>++just</code></a>
 
 ### k
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#kel'><code>++kel</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#ker'><code>++ker</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#ket'><code>++ket</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#knee'><code>++knee</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#knot'><code>++knot</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#kel'><code>++kel</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ker'><code>++ker</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ket'><code>++ket</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#knee'><code>++knee</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#knot'><code>++knot</code></a>
 
 ### l
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4d.md#last'><code>++last</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#le-nl'><code>++le:nl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#lent'><code>++lent</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#levy'><code>++levy</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lfe-fl'><code>++lfe:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lfn-fl'><code>++lfn:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#lien'><code>++lien</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#lift'><code>++lift</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#like'><code>++like</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#limb'><code>++limb</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#limo'><code>++limo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#line'><code>++line</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#lip-ag'><code>++lip:ag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#list'><code>++list</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#lone'><code>++lone</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2f.md#lor'><code>++lor</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#low'><code>++low</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#lsh'><code>++lsh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#lte'><code>++lte</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lte-ff'><code>++lte:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lte-fl'><code>++lte:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lte-rd'><code>++lte:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lte-rh'><code>++lte:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lte-rs'><code>++lte:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lte-rq'><code>++lte:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#lth'><code>++lth</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lth-ff'><code>++lth:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lth-fl'><code>++lth:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lth-rd'><code>++lth:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lth-rh'><code>++lth:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lth-rs'><code>++lth:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lth-rq'><code>++lth:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lug-fl'><code>++lug:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#lus'><code>++lus</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4d.md#lust'><code>++lust</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#less'><code>++less</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#ly'><code>++ly</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4d/#last'><code>++last</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#le-nl'><code>++le:nl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#lent'><code>++lent</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#levy'><code>++levy</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lfe-fl'><code>++lfe:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lfn-fl'><code>++lfn:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#lien'><code>++lien</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#lift'><code>++lift</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#like'><code>++like</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#limb'><code>++limb</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#limo'><code>++limo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#line'><code>++line</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#lip-ag'><code>++lip:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#list'><code>++list</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#lone'><code>++lone</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#lor'><code>++lor</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#low'><code>++low</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#lsh'><code>++lsh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#lte'><code>++lte</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-ff'><code>++lte:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-fl'><code>++lte:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rd'><code>++lte:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rh'><code>++lte:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rs'><code>++lte:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rq'><code>++lte:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#lth'><code>++lth</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-ff'><code>++lth:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-fl'><code>++lth:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rd'><code>++lth:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rh'><code>++lth:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rs'><code>++lth:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rq'><code>++lth:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lug-fl'><code>++lug:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#lus'><code>++lus</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4d/#lust'><code>++lust</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#less'><code>++less</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#ly'><code>++ly</code></a>
 
 ### m
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ma-rd'><code>++ma:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ma-rh'><code>++ma:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ma-rs'><code>++ma:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ma-rq'><code>++ma:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4n.md#mack'><code>++mack</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2l.md#malt'><code>++malt</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2o.md#map'><code>++map</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#mar-by'><code>+-mar:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1b.md#mas'><code>++mas</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#mask'><code>++mask</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2p.md#mat'><code>++mat</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#mate'><code>++mate</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#max'><code>++max</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#me-ff'><code>++me:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#mean'><code>++mean</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#mes'><code>++mes</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#mesc'><code>++mesc</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#met'><code>++met</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#metl'><code>++metl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#min'><code>++min</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4n.md#mink'><code>++mink</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#mit-yo'><code>++mit:yo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2d.md#mix'><code>++mix</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4n.md#mock'><code>++mock</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#mod'><code>++mod</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#moh-yo'><code>++moh:yo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2l.md#molt'><code>++molt</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4n.md#mong'><code>++mong</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4n.md#mook'><code>++mook</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#more'><code>++more</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#most'><code>++most</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#moy-yo'><code>++moy:yo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#mu'><code>++mu</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2e.md#mug'><code>++mug</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2e.md#muk'><code>++muk</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#mul'><code>++mul</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#mul-ff'><code>++mul:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#mul-fl'><code>++mul:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#mul-rd'><code>++mul:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#mul-rh'><code>++mul:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#mul-rs'><code>++mul:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#mul-rq'><code>++mul:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4n.md#mule'><code>++mule</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4n.md#mute'><code>++mute</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2e.md#mum'><code>++mum</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#murn'><code>++murn</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#my'><code>++my</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#my-nl'><code>++my:nl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rd'><code>++ma:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rh'><code>++ma:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rs'><code>++ma:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rq'><code>++ma:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mack'><code>++mack</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2l/#malt'><code>++malt</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#map'><code>++map</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#mar-by'><code>+-mar:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#mas'><code>++mas</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#mask'><code>++mask</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#mat'><code>++mat</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#mate'><code>++mate</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#max'><code>++max</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#me-ff'><code>++me:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#mean'><code>++mean</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#mes'><code>++mes</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#mesc'><code>++mesc</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#met'><code>++met</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#metl'><code>++metl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#min'><code>++min</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mink'><code>++mink</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#mit-yo'><code>++mit:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#mix'><code>++mix</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mock'><code>++mock</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#mod'><code>++mod</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#moh-yo'><code>++moh:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2l/#molt'><code>++molt</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mong'><code>++mong</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mook'><code>++mook</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#more'><code>++more</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#most'><code>++most</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#moy-yo'><code>++moy:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#mu'><code>++mu</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#mug'><code>++mug</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#muk'><code>++muk</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#mul'><code>++mul</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-ff'><code>++mul:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-fl'><code>++mul:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rd'><code>++mul:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rh'><code>++mul:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rs'><code>++mul:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rq'><code>++mul:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mule'><code>++mule</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mute'><code>++mute</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#mum'><code>++mum</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#murn'><code>++murn</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#my'><code>++my</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#my-nl'><code>++my:nl</code></a>
 
 ### n
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#nail'><code>++nail</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#nap-to'><code>+-nap:to</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#ne'><code>++ne</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ned-fl'><code>++ned:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#need'><code>++need</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#net-fe'><code>++net:fe</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#new-si'><code>++new:si</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#next'><code>++next</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#nip-to'><code>+-nip:to</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#nix'><code>++nix</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#nl'><code>++nl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#nock'><code>++nock</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2d.md#not'><code>++not</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#noun'><code>++noun</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#nuck-so'><code>++nuck:so</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#nud'><code>++nud</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#null'><code>++null</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#nusk-so'><code>++nusk:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#nail'><code>++nail</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#nap-to'><code>+-nap:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ne'><code>++ne</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ned-fl'><code>++ned:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#need'><code>++need</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#net-fe'><code>++net:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#new-si'><code>++new:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#next'><code>++next</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#nip-to'><code>+-nip:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#nix'><code>++nix</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#nl'><code>++nl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#nock'><code>++nock</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#not'><code>++not</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#noun'><code>++noun</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#nuck-so'><code>++nuck:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#nud'><code>++nud</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#null'><code>++null</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#nusk-so'><code>++nusk:so</code></a>
 
 ### o
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#ob'><code>++ob</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#og'><code>++og</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#old-si'><code>++old:si</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#oust'><code>++oust</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#out-fe'><code>++out:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#ob'><code>++ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#og'><code>++og</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#old-si'><code>++old:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#oust'><code>++oust</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#out-fe'><code>++out:fe</code></a>
 
 ### p
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#pa-ff'><code>++pa:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#pair'><code>++pair</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#pam'><code>++pam</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#pat'><code>++pat</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#path'><code>++path</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1b.md#peg'><code>++peg</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#pel'><code>++pel</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#per'><code>++per</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#perd-so'><code>++perd:so</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#pev-ab'><code>++pev:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#pew-ab'><code>++pew:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#pfix'><code>++pfix</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#pint'><code>++pint</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#piv-ab'><code>++piv:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#piw-ab'><code>++piw:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#plug'><code>++plug</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#plus'><code>++plus</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4a.md#po'><code>++po</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#pole'><code>++pole</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#port'><code>++port</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#pose'><code>++pose</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2g.md#pow'><code>++pow</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#prc-fl'><code>++prc:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#prn'><code>++prn</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#pro-fo'><code>++pro:fo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#pro-si'><code>++pro:si</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#put-by'><code>+-put:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#put-in'><code>+-put:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#put-ju'><code>+-put:ju</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#put-to'><code>+-put:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#pa-ff'><code>++pa:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#pair'><code>++pair</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pam'><code>++pam</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pat'><code>++pat</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#path'><code>++path</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#peg'><code>++peg</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pel'><code>++pel</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#per'><code>++per</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#perd-so'><code>++perd:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#pev-ab'><code>++pev:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#pew-ab'><code>++pew:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#pfix'><code>++pfix</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#pint'><code>++pint</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#piv-ab'><code>++piv:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#piw-ab'><code>++piw:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#plug'><code>++plug</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#plus'><code>++plus</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#po'><code>++po</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#pole'><code>++pole</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#port'><code>++port</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#pose'><code>++pose</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2g/#pow'><code>++pow</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#prc-fl'><code>++prc:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#prn'><code>++prn</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#pro-fo'><code>++pro:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#pro-si'><code>++pro:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#put-by'><code>+-put:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#put-in'><code>+-put:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#put-ju'><code>+-put:ju</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#put-to'><code>+-put:to</code></a>
 
 ### q
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#qad-yo'><code>++qad:yo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#qeb-ab'><code>++qeb:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2o.md#qeu'><code>++qeu</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#qex-ab'><code>++qex:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#qib-ab'><code>++qib:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#qit'><code>++qit</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#qix-ab'><code>++qix:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#quip'><code>++quip</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#qut'><code>++qut</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#qad-yo'><code>++qad:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qeb-ab'><code>++qeb:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#qeu'><code>++qeu</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qex-ab'><code>++qex:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qib-ab'><code>++qib:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#qit'><code>++qit</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qix-ab'><code>++qix:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#quip'><code>++quip</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#qut'><code>++qut</code></a>
 
 ### r
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#r-at'><code>++r:at</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#rad-og'><code>++rad:og</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#rads-og'><code>++rads:og</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#raku-ob'><code>++raku:ob</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#ram-re'><code>++ram:re</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#rap'><code>++rap</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4g.md#rash'><code>++rash</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rau-fl'><code>++rau:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#raw-og'><code>++raw:og</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#raws-og'><code>++raws:og</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#re'><code>++re</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4k.md#rear-co'><code>++rear:co</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#reap'><code>++reap</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#reel'><code>++reel</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#rem-si'><code>++rem:si</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4k.md#rend-co'><code>++rend:co</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4k.md#rent-co'><code>++rent:co</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#rep'><code>++rep</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#rep-by'><code>+-rep:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#rep-in'><code>+-rep:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rf-at'><code>++rf:at</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#rib-by'><code>+-rib:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#rig-re'><code>++rig:re</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#rip'><code>++rip</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rn-at'><code>++rn:at</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#rol-fe'><code>++rol:fe</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#roll'><code>++roll</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#r-at'><code>++r:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#rad-og'><code>++rad:og</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#rads-og'><code>++rads:og</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#raku-ob'><code>++raku:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#ram-re'><code>++ram:re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rap'><code>++rap</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rash'><code>++rash</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rau-fl'><code>++rau:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#raw-og'><code>++raw:og</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#raws-og'><code>++raws:og</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#re'><code>++re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rear-co'><code>++rear:co</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#reap'><code>++reap</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#reel'><code>++reel</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#rem-si'><code>++rem:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rend-co'><code>++rend:co</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rent-co'><code>++rent:co</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rep'><code>++rep</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rep-by'><code>+-rep:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#rep-in'><code>+-rep:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rf-at'><code>++rf:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rib-by'><code>+-rib:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#rig-re'><code>++rig:re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rip'><code>++rip</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rn-at'><code>++rn:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rol-fe'><code>++rol:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#roll'><code>++roll</code></a>
 <code>++rood</code>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#ror-fe'><code>++ror:fe</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rou-fl'><code>++rou:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#royl-so'><code>++royl:so</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#royl-cell-so'><code>++royl-cell:so</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#rsh'><code>++rsh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rt-at'><code>++rt:at</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rta-at'><code>++rta:at</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rtam-at'><code>++rtam:at</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2p.md#rub'><code>++rub</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rub-at'><code>++rub:at</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rud-at'><code>++rud:at</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#rule'><code>++rule</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rum-at'><code>++rum:at</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#run-by'><code>+-run:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#run-in'><code>+-run:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#rund-ob'><code>++rund:ob</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#runt'><code>++runt</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rup-at'><code>++rup:at</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4g.md#rush'><code>++rush</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4g.md#rust'><code>++rust</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#rut-by'><code>+-rut:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#ruv-at'><code>++ruv:at</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rux-at'><code>++rux:at</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#rynd-ob'><code>++rynd:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#ror-fe'><code>++ror:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rou-fl'><code>++rou:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#royl-so'><code>++royl:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#royl-cell-so'><code>++royl-cell:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rsh'><code>++rsh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rt-at'><code>++rt:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rta-at'><code>++rta:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rtam-at'><code>++rtam:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#rub'><code>++rub</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rub-at'><code>++rub:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rud-at'><code>++rud:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#rule'><code>++rule</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rum-at'><code>++rum:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#run-by'><code>+-run:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#run-in'><code>+-run:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#rund-ob'><code>++rund:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#runt'><code>++runt</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rup-at'><code>++rup:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rush'><code>++rush</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rust'><code>++rust</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rut-by'><code>+-rut:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#ruv-at'><code>++ruv:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rux-at'><code>++rux:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#rynd-ob'><code>++rynd:ob</code></a>
 
 ### s
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#same'><code>++same</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#san-ff'><code>++san:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#san-fl'><code>++san:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#san-rd'><code>++san:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#san-rh'><code>++san:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#san-rs'><code>++san:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#san-rq'><code>++san:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#sand'><code>++sand</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#sane'><code>++sane</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sb-ff'><code>++sb:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#scag'><code>++scag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4g.md#scan'><code>++scan</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#scot'><code>++scot</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#scow'><code>++scow</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sea-ff'><code>++sea:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sea-rd'><code>++sea:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sea-rh'><code>++sea:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sea-rs'><code>++sea:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sea-rq'><code>++sea:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#sear'><code>++sear</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#seb-ab'><code>++seb:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sed-ab'><code>++sed:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#sel'><code>++sel</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#sem'><code>++sem</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#ser'><code>++ser</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2o.md#set'><code>++set</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sev-ab'><code>++sev:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sew-ab'><code>++sew:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sex-ab'><code>++sex:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#sfix'><code>++sfix</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shad'><code>++shad</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shaf'><code>++shaf</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shal'><code>++shal</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#sham'><code>++sham</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shan'><code>++shan</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shas'><code>++shas</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shaw'><code>++shaw</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shax'><code>++shax</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shay'><code>++shay</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shaz'><code>++shaz</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#shep'><code>++shep</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#shf-fl'><code>++shf:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#shim'><code>++shim</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#shop'><code>++shop</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#show'><code>++show</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#si'><code>++si</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#si-nl'><code>++si:nl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sib-ab'><code>++sib:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sid-ab'><code>++sid:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#sig'><code>++sig</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sig-ff'><code>++sig:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sig-rd'><code>++sig:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sig-rh'><code>++sig:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sig-rs'><code>++sig:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sig-rq'><code>++sig:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2l.md#silt'><code>++silt</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#simu'><code>++simu</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#sit-fe'><code>++sit:fe</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#sit-fo'><code>++sit:fo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#siv-ab'><code>++siv:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#siw-ab'><code>++siw:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#six-ab'><code>++six:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#skid'><code>++skid</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#skim'><code>++skim</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#skip'><code>++skip</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#slag'><code>++slag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#slat'><code>++slat</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#slav'><code>++slav</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#slaw'><code>++slaw</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#slay'><code>++slay</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#slog'><code>++slog</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#slug'><code>++slug</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#smyt'><code>++smyt</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#snag'><code>++snag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#snag-nl'><code>++snag:nl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#snoc'><code>++snoc</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#so'><code>++so</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#soft'><code>++soft</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#some'><code>++some</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#soq'><code>++soq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#sort'><code>++sort</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sov-ab'><code>++sov:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sow-ab'><code>++sow:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sox-ab'><code>++sox:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#soz'><code>++soz</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#span'><code>++span</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#spat'><code>++spat</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#spd-fl'><code>++spd:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#spin'><code>++spin</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#spn-fl'><code>++spn:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#spot'><code>++spot</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#spud'><code>++spud</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#spun'><code>++spun</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2g.md#sqt'><code>++sqt</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sqt-ff'><code>++sqt:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sqt-fl'><code>++sqt:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sqt-rd'><code>++sqt:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sqt-rh'><code>++sqt:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sqt-rs'><code>++sqt:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sqt-rq'><code>++sqt:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#stab'><code>++stab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#stag'><code>++stag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#star'><code>++star</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#stet'><code>++stet</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#stew'><code>++stew</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#stir'><code>++stir</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#stun'><code>++stun</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#sub'><code>++sub</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sub-ff'><code>++sub:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sub-fl'><code>++sub:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sub-rd'><code>++sub:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sub-rh'><code>++sub:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sub-rs'><code>++sub:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sub-rq'><code>++sub:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#sum-fe'><code>++sum:fe</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#sum-fo'><code>++sum:fo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#sum-si'><code>++sum:si</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sun-ff'><code>++sun:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sun-fl'><code>++sun:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sun-rd'><code>++sun:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sun-rh'><code>++sun:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sun-rs'><code>++sun:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sun-rq'><code>++sun:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#sun-si'><code>++sun:si</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#swag'><code>++swag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#swp'><code>++swp</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#swr-fl'><code>++swr:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#sy'><code>++sy</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#sym'><code>++sym</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#syn-fl'><code>++syn:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#syn-si'><code>++syn:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#same'><code>++same</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-ff'><code>++san:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-fl'><code>++san:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-rd'><code>++san:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-rh'><code>++san:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-rs'><code>++san:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-rq'><code>++san:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#sand'><code>++sand</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#sane'><code>++sane</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sb-ff'><code>++sb:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#scag'><code>++scag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#scan'><code>++scan</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#scot'><code>++scot</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#scow'><code>++scow</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sea-ff'><code>++sea:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sea-rd'><code>++sea:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sea-rh'><code>++sea:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sea-rs'><code>++sea:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sea-rq'><code>++sea:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#sear'><code>++sear</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#seb-ab'><code>++seb:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sed-ab'><code>++sed:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#sel'><code>++sel</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#sem'><code>++sem</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ser'><code>++ser</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#set'><code>++set</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sev-ab'><code>++sev:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sew-ab'><code>++sew:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sex-ab'><code>++sex:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#sfix'><code>++sfix</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shad'><code>++shad</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shaf'><code>++shaf</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shal'><code>++shal</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#sham'><code>++sham</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shan'><code>++shan</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shas'><code>++shas</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shaw'><code>++shaw</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shax'><code>++shax</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shay'><code>++shay</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shaz'><code>++shaz</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#shep'><code>++shep</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#shf-fl'><code>++shf:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#shim'><code>++shim</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#shop'><code>++shop</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#show'><code>++show</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#si'><code>++si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#si-nl'><code>++si:nl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sib-ab'><code>++sib:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sid-ab'><code>++sid:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#sig'><code>++sig</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sig-ff'><code>++sig:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sig-rd'><code>++sig:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sig-rh'><code>++sig:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sig-rs'><code>++sig:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sig-rq'><code>++sig:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2l/#silt'><code>++silt</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#simu'><code>++simu</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#sit-fe'><code>++sit:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#sit-fo'><code>++sit:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#siv-ab'><code>++siv:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#siw-ab'><code>++siw:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#six-ab'><code>++six:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#skid'><code>++skid</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#skim'><code>++skim</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#skip'><code>++skip</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#slag'><code>++slag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#slat'><code>++slat</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#slav'><code>++slav</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#slaw'><code>++slaw</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#slay'><code>++slay</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#slog'><code>++slog</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#slug'><code>++slug</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#smyt'><code>++smyt</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#snag'><code>++snag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#snag-nl'><code>++snag:nl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#snoc'><code>++snoc</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#so'><code>++so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#soft'><code>++soft</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#some'><code>++some</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#soq'><code>++soq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#sort'><code>++sort</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sov-ab'><code>++sov:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sow-ab'><code>++sow:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sox-ab'><code>++sox:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#soz'><code>++soz</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#span'><code>++span</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#spat'><code>++spat</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#spd-fl'><code>++spd:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#spin'><code>++spin</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#spn-fl'><code>++spn:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#spot'><code>++spot</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#spud'><code>++spud</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#spun'><code>++spun</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2g/#sqt'><code>++sqt</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sqt-ff'><code>++sqt:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sqt-fl'><code>++sqt:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sqt-rd'><code>++sqt:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sqt-rh'><code>++sqt:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sqt-rs'><code>++sqt:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sqt-rq'><code>++sqt:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#stab'><code>++stab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#stag'><code>++stag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#star'><code>++star</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#stet'><code>++stet</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#stew'><code>++stew</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#stir'><code>++stir</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#stun'><code>++stun</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#sub'><code>++sub</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sub-ff'><code>++sub:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sub-fl'><code>++sub:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sub-rd'><code>++sub:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sub-rh'><code>++sub:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sub-rs'><code>++sub:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sub-rq'><code>++sub:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#sum-fe'><code>++sum:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#sum-fo'><code>++sum:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#sum-si'><code>++sum:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sun-ff'><code>++sun:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sun-fl'><code>++sun:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sun-rd'><code>++sun:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sun-rh'><code>++sun:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sun-rs'><code>++sun:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sun-rq'><code>++sun:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#sun-si'><code>++sun:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#swag'><code>++swag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#swp'><code>++swp</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#swr-fl'><code>++swr:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#sy'><code>++sy</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#sym'><code>++sym</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#syn-fl'><code>++syn:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#syn-si'><code>++syn:si</code></a>
 
 ### t
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#tail'><code>++tail</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#tap-to'><code>+-tap:to</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#tar'><code>++tar</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#tang'><code>++tang</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#tank'><code>++tank</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#tap-by'><code>+-tap:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#tap-in'><code>+-tap:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#tape'><code>++tape</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#tarp'><code>++tarp</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#tash-so'><code>++tash:so</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#tec'><code>++tec</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#ted-ab'><code>++ted:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#teff'><code>++teff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#teil-ob'><code>++teil:ob</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#term'><code>++term</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#test'><code>++test</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#tid-ab'><code>++tid:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#tiki'><code>++tiki</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#til-ab'><code>++til:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#tip-ab'><code>++tip:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#tiq-ab'><code>++tiq:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#tis'><code>++tis</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#to'><code>++to</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4a.md#tod-po'><code>++tod:po</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#toga'><code>++toga</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#toi-ff'><code>++toi:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#toi-fl'><code>++toi:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#toi-rd'><code>++toi:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#toi-rh'><code>++toi:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#toi-rs'><code>++toi:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#toi-rq'><code>++toi:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#toj-fl'><code>++toj:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#tone'><code>++tone</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#toon'><code>++toon</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#top-to'><code>+-top:to</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4a.md#tos-po'><code>++tos:po</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#tos-rh'><code>++tos:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#trap'><code>++trap</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#tree'><code>++tree</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#trel'><code>++trel</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#trim'><code>++trim</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#trip'><code>++trip</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#tuba'><code>++tuba</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#tufa'><code>++tufa</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#tuna'><code>++tuna</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#tuft'><code>++tuft</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#turf'><code>++turf</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#turn'><code>++turn</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#tusk'><code>++tusk</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#twid-so'><code>++twid:so</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#tyke'><code>++tyke</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#typo'><code>++typo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#tyre'><code>++tyre</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#tail'><code>++tail</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#tap-to'><code>+-tap:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#tar'><code>++tar</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#tang'><code>++tang</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#tank'><code>++tank</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#tap-by'><code>+-tap:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#tap-in'><code>+-tap:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#tape'><code>++tape</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#tarp'><code>++tarp</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#tash-so'><code>++tash:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#tec'><code>++tec</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ted-ab'><code>++ted:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#teff'><code>++teff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#teil-ob'><code>++teil:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#term'><code>++term</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#test'><code>++test</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#tid-ab'><code>++tid:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#tiki'><code>++tiki</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#til-ab'><code>++til:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#tip-ab'><code>++tip:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#tiq-ab'><code>++tiq:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#tis'><code>++tis</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#to'><code>++to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#tod-po'><code>++tod:po</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#toga'><code>++toga</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toi-ff'><code>++toi:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toi-fl'><code>++toi:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toi-rd'><code>++toi:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toi-rh'><code>++toi:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toi-rs'><code>++toi:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toi-rq'><code>++toi:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toj-fl'><code>++toj:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#tone'><code>++tone</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#toon'><code>++toon</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#top-to'><code>+-top:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#tos-po'><code>++tos:po</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#tos-rh'><code>++tos:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#trap'><code>++trap</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#tree'><code>++tree</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#trel'><code>++trel</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#trim'><code>++trim</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#trip'><code>++trip</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#tuba'><code>++tuba</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#tufa'><code>++tufa</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#tuna'><code>++tuna</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#tuft'><code>++tuft</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#turf'><code>++turf</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#turn'><code>++turn</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#tusk'><code>++tusk</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#twid-so'><code>++twid:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#tyke'><code>++tyke</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#typo'><code>++typo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#tyre'><code>++tyre</code></a>
 
 ### u
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#un'><code>++un</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#uni-by'><code>+-uni:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#uni-fl'><code>++uni:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#uni-in'><code>+-uni:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#unit'><code>++unit</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#urn-by'><code>+-urn:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#urs-ab'><code>++urs:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#urt-ab'><code>++urt:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#un'><code>++un</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#uni-by'><code>+-uni:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#uni-fl'><code>++uni:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#uni-in'><code>+-uni:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#unit'><code>++unit</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#urn-by'><code>+-urn:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#urs-ab'><code>++urs:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#urt-ab'><code>++urt:ab</code></a>
 
 ### v
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#v-ne'><code>++v:ne</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#v-ne'><code>++v:ne</code></a>
 <code>++vang</code>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#vase'><code>++vase</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#vase'><code>++vase</code></a>
 <code>++vast</code>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#ven'><code>++ven</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#vise'><code>++vise</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#vit'><code>++vit</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#viz-ag'><code>++viz:ag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2f.md#vor'><code>++vor</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#voy-ab'><code>++voy:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#vul'><code>++vul</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#vum-ag'><code>++vum:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#ven'><code>++ven</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#vise'><code>++vise</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#vit'><code>++vit</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#viz-ag'><code>++viz:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#vor'><code>++vor</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#voy-ab'><code>++voy:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#vul'><code>++vul</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#vum-ag'><code>++vum:ag</code></a>
 
 ### w
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#w-ne'><code>++w:ne</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#wack'><code>++wack</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#wain'><code>++wain</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#wall'><code>++wall</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#weld'><code>++weld</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#weld-nl'><code>++weld:nl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#welp'><code>++welp</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#wick'><code>++wick</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#wig-re'><code>++wig:re</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#win-re'><code>++win:re</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#wing'><code>++wing</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#wiz-ag'><code>++wiz:ag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#woad'><code>++woad</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#wood'><code>++wood</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#wonk'><code>++wonk</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#wred-un'><code>++wred:un</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#wren-un'><code>++wren:un</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#wut'><code>++wut</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#wyt-by'><code>+-wyt:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#wyt-in'><code>+-wyt:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#w-ne'><code>++w:ne</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#wack'><code>++wack</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#wain'><code>++wain</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#wall'><code>++wall</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#weld'><code>++weld</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#weld-nl'><code>++weld:nl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#welp'><code>++welp</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#wick'><code>++wick</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#wig-re'><code>++wig:re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#win-re'><code>++win:re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#wing'><code>++wing</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#wiz-ag'><code>++wiz:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#woad'><code>++woad</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#wood'><code>++wood</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#wonk'><code>++wonk</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#wred-un'><code>++wred:un</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#wren-un'><code>++wren:un</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#wut'><code>++wut</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#wyt-by'><code>+-wyt:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#wyt-in'><code>+-wyt:in</code></a>
 
 ### x
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#x-ne'><code>++x:ne</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#xeb'><code>++xeb</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#xpd-fl'><code>++xpd:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#x-ne'><code>++x:ne</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#xeb'><code>++xeb</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#xpd-fl'><code>++xpd:fl</code></a>
 
 ### y
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yall'><code>++yall</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yawn'><code>++yawn</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#year'><code>++year</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yell'><code>++yell</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yelp'><code>++yelp</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yer-yo'><code>++yer:yo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yo'><code>++yo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yore'><code>++yore</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yule'><code>++yule</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yall'><code>++yall</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yawn'><code>++yawn</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#year'><code>++year</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yell'><code>++yell</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yelp'><code>++yelp</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yer-yo'><code>++yer:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yo'><code>++yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yore'><code>++yore</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yule'><code>++yule</code></a>
 
 ### z
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#zaft-un'><code>++zaft:un</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#zag-mu'><code>++zag:mu</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#zap'><code>++zap</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#zart-un'><code>++zart:un</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#zer-fl'><code>++zer:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#zig-mu'><code>++zig:mu</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#zing'><code>++zing</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#zug-mu'><code>++zug:mu</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#zust-so'><code>++zust:so</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#zyft-un'><code>++zyft:un</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#zyrt-un'><code>++zyrt:un</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#zaft-un'><code>++zaft:un</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#zag-mu'><code>++zag:mu</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#zap'><code>++zap</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#zart-un'><code>++zart:un</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#zer-fl'><code>++zer:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#zig-mu'><code>++zig:mu</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#zing'><code>++zing</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#zug-mu'><code>++zug:mu</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#zust-so'><code>++zust:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#zyft-un'><code>++zyft:un</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#zyrt-un'><code>++zyrt:un</code></a>
 
 ## By Section
 
 ### 1a: basic arithmetic
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#add' data-tippy-content="Add"><code>++add</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#dec' data-tippy-content="Decrement"><code>++dec</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#div'><code>++div</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#dvr'><code>++dvr</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#gte'><code>++gte</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#gth'><code>++gth</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#lte'><code>++lte</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#lth'><code>++lth</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#max'><code>++max</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#min'><code>++min</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#mod'><code>++mod</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#mul'><code>++mul</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#sub'><code>++sub</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#add' data-tippy-content="Add"><code>++add</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#dec' data-tippy-content="Decrement"><code>++dec</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#div'><code>++div</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#dvr'><code>++dvr</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#gte'><code>++gte</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#gth'><code>++gth</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#lte'><code>++lte</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#lth'><code>++lth</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#max'><code>++max</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#min'><code>++min</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#mod'><code>++mod</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#mul'><code>++mul</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#sub'><code>++sub</code></a>
 
 ### 1b: tree addressing
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1b.md#cap' data-tippy-content="Tree head"><code>++cap</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1b.md#mas'><code>++mas</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1b.md#peg'><code>++peg</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#cap' data-tippy-content="Tree head"><code>++cap</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#mas'><code>++mas</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#peg'><code>++peg</code></a>
 
 ### 1c: molds and mold builders
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#bloq' data-tippy-content="Blocksize"><code>++bloq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#each'><code>++each</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#gate'><code>++gate</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#list'><code>++list</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#lone'><code>++lone</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#pair'><code>++pair</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#pole'><code>++pole</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#quip'><code>++quip</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#trap'><code>++trap</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#tree'><code>++tree</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#trel'><code>++trel</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#unit'><code>++unit</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#bloq' data-tippy-content="Blocksize"><code>++bloq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#each'><code>++each</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#gate'><code>++gate</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#list'><code>++list</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#lone'><code>++lone</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#pair'><code>++pair</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#pole'><code>++pole</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#quip'><code>++quip</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#trap'><code>++trap</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#tree'><code>++tree</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#trel'><code>++trel</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#unit'><code>++unit</code></a>
 
 ### 2a: unit logic
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#biff' data-tippy-content="Unit as argument"><code>++biff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#bind' data-tippy-content="Non-unit function to unit, producing unit"><code>++bind</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#bond' data-tippy-content="Replace null"><code>++bond</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#both' data-tippy-content="Group unit values into pair"><code>++both</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#clap' data-tippy-content="Apply function to two units"><code>++clap</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#drop'><code>++drop</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#fall'><code>++fall</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#lift'><code>++lift</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#mate'><code>++mate</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#need'><code>++need</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#some'><code>++some</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#biff' data-tippy-content="Unit as argument"><code>++biff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#bind' data-tippy-content="Non-unit function to unit, producing unit"><code>++bind</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#bond' data-tippy-content="Replace null"><code>++bond</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#both' data-tippy-content="Group unit values into pair"><code>++both</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#clap' data-tippy-content="Apply function to two units"><code>++clap</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#drop'><code>++drop</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#fall'><code>++fall</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#lift'><code>++lift</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#mate'><code>++mate</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#need'><code>++need</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#some'><code>++some</code></a>
 
 ### 2b: list logic
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#fand'><code>++fand</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#find'><code>++find</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#flop'><code>++flop</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#gulf'><code>++gulf</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#homo'><code>++homo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#lent'><code>++lent</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#levy'><code>++levy</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#lien'><code>++lien</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#limo'><code>++limo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#murn'><code>++murn</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#oust'><code>++oust</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#reap'><code>++reap</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#reel'><code>++reel</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#roll'><code>++roll</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#scag'><code>++scag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#skid'><code>++skid</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#skim'><code>++skim</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#skip'><code>++skip</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#slag'><code>++slag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#snag'><code>++snag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#snoc'><code>++snoc</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#sort'><code>++sort</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#spin'><code>++spin</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#spun'><code>++spun</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#swag'><code>++swag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#turn'><code>++turn</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#weld'><code>++weld</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#welp'><code>++welp</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#zing'><code>++zing</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#fand'><code>++fand</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#find'><code>++find</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#flop'><code>++flop</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#gulf'><code>++gulf</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#homo'><code>++homo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#lent'><code>++lent</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#levy'><code>++levy</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#lien'><code>++lien</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#limo'><code>++limo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#murn'><code>++murn</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#oust'><code>++oust</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#reap'><code>++reap</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#reel'><code>++reel</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#roll'><code>++roll</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#scag'><code>++scag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#skid'><code>++skid</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#skim'><code>++skim</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#skip'><code>++skip</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#slag'><code>++slag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#snag'><code>++snag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#snoc'><code>++snoc</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#sort'><code>++sort</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#spin'><code>++spin</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#spun'><code>++spun</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#swag'><code>++swag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#turn'><code>++turn</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#weld'><code>++weld</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#welp'><code>++welp</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#zing'><code>++zing</code></a>
 
 ### 2c: bit arithmetic
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#fe'><code>++fe</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#dif-fe'><code>++dif:fe</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#inv-fe'><code>++inv:fe</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#net-fe'><code>++net:fe</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#out-fe'><code>++out:fe</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#rol-fe'><code>++rol:fe</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#ror-fe'><code>++ror:fe</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#sit-fe'><code>++sit:fe</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#sum-fe'><code>++sum:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#fe'><code>++fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#dif-fe'><code>++dif:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#inv-fe'><code>++inv:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#net-fe'><code>++net:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#out-fe'><code>++out:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rol-fe'><code>++rol:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#ror-fe'><code>++ror:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#sit-fe'><code>++sit:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#sum-fe'><code>++sum:fe</code></a>
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#bex' data-tippy-content="Binary exponent"><code>++bex</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#can' data-tippy-content="Assemble"><code>++can</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#cat' data-tippy-content="Concatenate"><code>++cat</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#cut' data-tippy-content="Slice"><code>++cut</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#end'><code>++end</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#fil'><code>++fil</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#lsh'><code>++lsh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#met'><code>++met</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#rap'><code>++rap</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#rep'><code>++rep</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#rip'><code>++rip</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#rsh'><code>++rsh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#swp'><code>++swp</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#xeb'><code>++xeb</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#bex' data-tippy-content="Binary exponent"><code>++bex</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#can' data-tippy-content="Assemble"><code>++can</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#cat' data-tippy-content="Concatenate"><code>++cat</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#cut' data-tippy-content="Slice"><code>++cut</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#end'><code>++end</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#fil'><code>++fil</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#lsh'><code>++lsh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#met'><code>++met</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rap'><code>++rap</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rep'><code>++rep</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rip'><code>++rip</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rsh'><code>++rsh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#swp'><code>++swp</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#xeb'><code>++xeb</code></a>
 
 ### 2d: bit logic
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2d.md#con' data-tippy-content="Binary OR"><code>++con</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2d.md#dis'><code>++dis</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2d.md#mix'><code>++mix</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2d.md#not'><code>++not</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#con' data-tippy-content="Binary OR"><code>++con</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#dis'><code>++dis</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#mix'><code>++mix</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#not'><code>++not</code></a>
 
 ### 2e: insecure hashing
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2e.md#fnv'><code>++fnv</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2e.md#mug'><code>++mug</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2e.md#muk'><code>++muk</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2e.md#mum'><code>++mum</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#fnv'><code>++fnv</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#mug'><code>++mug</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#muk'><code>++muk</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#mum'><code>++mum</code></a>
 
 ### 2f: noun ordering
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2f.md#aor' data-tippy-content="Alphabetical order"><code>++aor</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2f.md#dor'><code>++dor</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2f.md#gor'><code>++gor</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2f.md#hor'><code>++hor</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2f.md#lor'><code>++lor</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2f.md#vor'><code>++vor</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#aor' data-tippy-content="Alphabetical order"><code>++aor</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#dor'><code>++dor</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#gor'><code>++gor</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#hor'><code>++hor</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#lor'><code>++lor</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#vor'><code>++vor</code></a>
 
 ### 2g: unsigned powers
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2g.md#pow'><code>++pow</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2g.md#sqt'><code>++sqt</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2g/#pow'><code>++pow</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2g/#sqt'><code>++sqt</code></a>
 
 ### 2h: set logic
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#in'><code>++in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#all-in' data-tippy-content="Logical AND (set and wet gate)"><code>+-all:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#any-in' data-tippy-content="Logical OR (set and gate)"><code>+-any:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#apt-in' data-tippy-content="Check correctness (set)"><code>+-apt:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#bif-in' data-tippy-content="Bifurcate set"><code>+-bif:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#del-in'><code>+-del:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#dif-in'><code>+-dif:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#dig-in'><code>+-dig:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#gas-in'><code>+-gas:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#has-in'><code>+-has:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#int-in'><code>+-int:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#put-in'><code>+-put:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#rep-in'><code>+-rep:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#run-in'><code>+-run:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#tap-in'><code>+-tap:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#uni-in'><code>+-uni:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#wyt-in'><code>+-wyt:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#in'><code>++in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#all-in' data-tippy-content="Logical AND (set and wet gate)"><code>+-all:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#any-in' data-tippy-content="Logical OR (set and gate)"><code>+-any:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#apt-in' data-tippy-content="Check correctness (set)"><code>+-apt:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#bif-in' data-tippy-content="Bifurcate set"><code>+-bif:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#del-in'><code>+-del:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#dif-in'><code>+-dif:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#dig-in'><code>+-dig:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#gas-in'><code>+-gas:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#has-in'><code>+-has:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#int-in'><code>+-int:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#put-in'><code>+-put:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#rep-in'><code>+-rep:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#run-in'><code>+-run:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#tap-in'><code>+-tap:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#uni-in'><code>+-uni:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#wyt-in'><code>+-wyt:in</code></a>
 
 ### 2i: map logic
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#by'><code>++by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#all-by' data-tippy-content="Logical AND (map and wet gate)"><code>+-all:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#any-by' data-tippy-content="Logical OR (map and wet gate)"><code>+-any:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#apt-by' data-tippy-content="Check correctness (map)"><code>+-apt:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#bif-by' data-tippy-content="Bifurcate map"><code>+-bif:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#def-by' data-tippy-content="Difference (map)"><code>+-def:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#del-by'><code>+-del:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#dep-by'><code>+-dep:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#dig-by'><code>+-dig:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#gas-by'><code>+-gas:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#get-by'><code>+-get:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#got-by'><code>+-got:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#has-by'><code>+-has:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#int-by'><code>+-int:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#mar-by'><code>+-mar:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#put-by'><code>+-put:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#rep-by'><code>+-rep:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#rib-by'><code>+-rib:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#run-by'><code>+-run:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#rut-by'><code>+-rut:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#tap-by'><code>+-tap:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#uni-by'><code>+-uni:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#urn-by'><code>+-urn:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#wyt-by'><code>+-wyt:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#by'><code>++by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#all-by' data-tippy-content="Logical AND (map and wet gate)"><code>+-all:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#any-by' data-tippy-content="Logical OR (map and wet gate)"><code>+-any:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#apt-by' data-tippy-content="Check correctness (map)"><code>+-apt:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#bif-by' data-tippy-content="Bifurcate map"><code>+-bif:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#def-by' data-tippy-content="Difference (map)"><code>+-def:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#del-by'><code>+-del:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#dep-by'><code>+-dep:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#dig-by'><code>+-dig:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#gas-by'><code>+-gas:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#get-by'><code>+-get:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#got-by'><code>+-got:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#has-by'><code>+-has:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#int-by'><code>+-int:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#mar-by'><code>+-mar:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#put-by'><code>+-put:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rep-by'><code>+-rep:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rib-by'><code>+-rib:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#run-by'><code>+-run:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rut-by'><code>+-rut:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#tap-by'><code>+-tap:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#uni-by'><code>+-uni:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#urn-by'><code>+-urn:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#wyt-by'><code>+-wyt:by</code></a>
 
 ### 2j: jar and jug logic
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#ja'><code>++ja</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#add-ja' data-tippy-content="Prepend to list"><code>+-add:ja</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#get-ja'><code>+-get:ja</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#ja'><code>++ja</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#add-ja' data-tippy-content="Prepend to list"><code>+-add:ja</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#get-ja'><code>+-get:ja</code></a>
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#ju'><code>++ju</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#del-ju'><code>+-del:ju</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#get-ju'><code>+-get:ju</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#has-ju'><code>+-has:ju</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#put-ju'><code>+-put:ju</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#ju'><code>++ju</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#del-ju'><code>+-del:ju</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#get-ju'><code>+-get:ju</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#has-ju'><code>+-has:ju</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#put-ju'><code>+-put:ju</code></a>
 
 ### 2k: queue logic
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#to'><code>++to</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#bal-to' data-tippy-content="Balance queue"><code>+-bal:to</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#dep-to'><code>+-dep:to</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#gas-to'><code>+-gas:to</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#get-to'><code>+-get:to</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#nap-to'><code>+-nap:to</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#nip-to'><code>+-nip:to</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#put-to'><code>+-put:to</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#tap-to'><code>+-tap:to</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#top-to'><code>+-top:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#to'><code>++to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#bal-to' data-tippy-content="Balance queue"><code>+-bal:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#dep-to'><code>+-dep:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#gas-to'><code>+-gas:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#get-to'><code>+-get:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#nap-to'><code>+-nap:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#nip-to'><code>+-nip:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#put-to'><code>+-put:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#tap-to'><code>+-tap:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#top-to'><code>+-top:to</code></a>
 
 ### 2l: container from container
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2l.md#malt'><code>++malt</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2l.md#molt'><code>++molt</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2l.md#silt'><code>++silt</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2l/#malt'><code>++malt</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2l/#molt'><code>++molt</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2l/#silt'><code>++silt</code></a>
 
 ### 2m: container from noun
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#nl'><code>++nl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#le-nl'><code>++le:nl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#my-nl'><code>++my:nl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#si-nl'><code>++si:nl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#snag-nl'><code>++snag:nl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#weld-nl'><code>++weld:nl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#nl'><code>++nl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#le-nl'><code>++le:nl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#my-nl'><code>++my:nl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#si-nl'><code>++si:nl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#snag-nl'><code>++snag:nl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#weld-nl'><code>++weld:nl</code></a>
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#ly'><code>++ly</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#my'><code>++my</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#sy'><code>++sy</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#ly'><code>++ly</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#my'><code>++my</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#sy'><code>++sy</code></a>
 
 ### 2n: functional hacks
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#cork' data-tippy-content="Compose forward"><code>++cork</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#corl' data-tippy-content="Compose backward"><code>++corl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#curr' data-tippy-content="Right-curry a gate"><code>++curr</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#cury' data-tippy-content="Curry left a gate"><code>++cury</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#hard'><code>++hard</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#head'><code>++head</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#mean'><code>++mean</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#same'><code>++same</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#slog'><code>++slog</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#soft'><code>++soft</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#tail'><code>++tail</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#test'><code>++test</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#cork' data-tippy-content="Compose forward"><code>++cork</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#corl' data-tippy-content="Compose backward"><code>++corl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#curr' data-tippy-content="Right-curry a gate"><code>++curr</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#cury' data-tippy-content="Curry left a gate"><code>++cury</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#hard'><code>++hard</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#head'><code>++head</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#mean'><code>++mean</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#same'><code>++same</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#slog'><code>++slog</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#soft'><code>++soft</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#tail'><code>++tail</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#test'><code>++test</code></a>
 
 ### 2o: normalizing containers
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2o.md#jar'><code>++jar</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2o.md#jug'><code>++jug</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2o.md#map'><code>++map</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2o.md#qeu'><code>++qeu</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2o.md#set'><code>++set</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#jar'><code>++jar</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#jug'><code>++jug</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#map'><code>++map</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#qeu'><code>++qeu</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#set'><code>++set</code></a>
 
 ### 2p: serialization
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2p.md#cue' data-tippy-content="Unpack atom to noun"><code>++cue</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2p.md#jam'><code>++jam</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2p.md#mat'><code>++mat</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2p.md#rub'><code>++rub</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#cue' data-tippy-content="Unpack atom to noun"><code>++cue</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#jam'><code>++jam</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#mat'><code>++mat</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#rub'><code>++rub</code></a>
 
 ### 2q: molds and mold builders
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#char' data-tippy-content="Character"><code>++char</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#cord' data-tippy-content="UTF-8 text"><code>++cord</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#date' data-tippy-content="Point in time"><code>++date</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#knot'><code>++knot</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#tang'><code>++tang</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#tank'><code>++tank</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#tape'><code>++tape</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#tarp'><code>++tarp</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#term'><code>++term</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#wain'><code>++wain</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#wall'><code>++wall</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#char' data-tippy-content="Character"><code>++char</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#cord' data-tippy-content="UTF-8 text"><code>++cord</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#date' data-tippy-content="Point in time"><code>++date</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#knot'><code>++knot</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#tang'><code>++tang</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#tank'><code>++tank</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#tape'><code>++tape</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#tarp'><code>++tarp</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#term'><code>++term</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#wain'><code>++wain</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#wall'><code>++wall</code></a>
 
 ### 3a: modular and signed ints
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#fo'><code>++fo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#dif-fo'><code>++dif:fo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#exp-fo'><code>++exp:fo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#fra-fo'><code>++fra:fo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#inv-fo'><code>++inv:fo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#pro-fo'><code>++pro:fo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#sit-fo'><code>++sit:fo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#sum-fo'><code>++sum:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fo'><code>++fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dif-fo'><code>++dif:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#exp-fo'><code>++exp:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fra-fo'><code>++fra:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#inv-fo'><code>++inv:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#pro-fo'><code>++pro:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#sit-fo'><code>++sit:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#sum-fo'><code>++sum:fo</code></a>
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#si'><code>++si</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#abs-si' data-tippy-content="Absolute value (signed integer)"><code>++abs:si</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#cmp-si' data-tippy-content="Compare (signed integer)"><code>++cmp:si</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#dif-si'><code>++dif:si</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#dul-si'><code>++dul:si</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#fra-si'><code>++fra:si</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#new-si'><code>++new:si</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#old-si'><code>++old:si</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#pro-si'><code>++pro:si</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#rem-si'><code>++rem:si</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#sum-si'><code>++sum:si</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#sun-si'><code>++sun:si</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#syn-si'><code>++syn:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#si'><code>++si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#abs-si' data-tippy-content="Absolute value (signed integer)"><code>++abs:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#cmp-si' data-tippy-content="Compare (signed integer)"><code>++cmp:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dif-si'><code>++dif:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dul-si'><code>++dul:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fra-si'><code>++fra:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#new-si'><code>++new:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#old-si'><code>++old:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#pro-si'><code>++pro:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#rem-si'><code>++rem:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#sum-si'><code>++sum:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#sun-si'><code>++sun:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#syn-si'><code>++syn:si</code></a>
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#egcd'><code>++egcd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#egcd'><code>++egcd</code></a>
 
 ### 3b: floating point
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#dn'><code>++dn</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fn'><code>++fn</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rn'><code>++rn</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#dn'><code>++dn</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fn'><code>++fn</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rn'><code>++rn</code></a>
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ff'><code>++ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#add-ff' data-tippy-content="Add (floating point)"><code>++add:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bif-ff' data-tippy-content="Converts from fn to @r"><code>++bif:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-ff' data-tippy-content="fn to @r with rounding"><code>++bit:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#div-ff'><code>++div:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#drg-ff'><code>++drg:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#equ-ff'><code>++equ:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#exp-ff'><code>++exp:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fma-ff'><code>++fma:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#grd-ff'><code>++grd:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gte-ff'><code>++gte:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gth-ff'><code>++gth:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lte-ff'><code>++lte:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lth-ff'><code>++lth:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#me-ff'><code>++me:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#mul-ff'><code>++mul:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#pa-ff'><code>++pa:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#san-ff'><code>++san:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sb-ff'><code>++sb:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sea-ff'><code>++sea:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sig-ff'><code>++sig:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sqt-ff'><code>++sqt:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sub-ff'><code>++sub:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sun-ff'><code>++sun:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#toi-ff'><code>++toi:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ff'><code>++ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-ff' data-tippy-content="Add (floating point)"><code>++add:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bif-ff' data-tippy-content="Converts from fn to @r"><code>++bif:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-ff' data-tippy-content="fn to @r with rounding"><code>++bit:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-ff'><code>++div:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-ff'><code>++drg:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-ff'><code>++equ:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-ff'><code>++exp:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-ff'><code>++fma:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-ff'><code>++grd:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-ff'><code>++gte:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-ff'><code>++gth:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-ff'><code>++lte:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-ff'><code>++lth:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#me-ff'><code>++me:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-ff'><code>++mul:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#pa-ff'><code>++pa:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-ff'><code>++san:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sb-ff'><code>++sb:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sea-ff'><code>++sea:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sig-ff'><code>++sig:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sqt-ff'><code>++sqt:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sub-ff'><code>++sub:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sun-ff'><code>++sun:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toi-ff'><code>++toi:ff</code></a>
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fl'><code>++fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#abs-fl' data-tippy-content="Absolute value"><code>++abs:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#add-fl' data-tippy-content="Add (with exact/rounded flag)"><code>++add:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#den-fl'><code>++den:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#div-fl'><code>++div:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#drg-fl'><code>++drg:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ead-fl'><code>++ead:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#emn-fl'><code>++emn:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#emu-fl'><code>++emu:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#emx-fl'><code>++emx:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#equ-fl'><code>++equ:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fli-fl'><code>++fli:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fma-fl'><code>++fma:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#grd-fl'><code>++grd:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gte-fl'><code>++gte:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gth-fl'><code>++gth:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ibl-fl'><code>++ibl:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#inv-fl'><code>++inv:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lfe-fl'><code>++lfe:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lfn-fl'><code>++lfn:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lte-fl'><code>++lte:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lth-fl'><code>++lth:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lug-fl'><code>++lug:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#mul-fl'><code>++mul:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ned-fl'><code>++ned:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#prc-fl'><code>++prc:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rau-fl'><code>++rau:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rou-fl'><code>++rou:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#san-fl'><code>++san:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#shf-fl'><code>++shf:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#spd-fl'><code>++spd:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#spn-fl'><code>++spn:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sqt-fl'><code>++sqt:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sub-fl'><code>++sub:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sun-fl'><code>++sun:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#swr-fl'><code>++swr:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#syn-fl'><code>++syn:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#toi-fl'><code>++toi:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#toj-fl'><code>++toj:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#uni-fl'><code>++uni:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#xpd-fl'><code>++xpd:fl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#zer-fl'><code>++zer:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fl'><code>++fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#abs-fl' data-tippy-content="Absolute value"><code>++abs:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-fl' data-tippy-content="Add (with exact/rounded flag)"><code>++add:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#den-fl'><code>++den:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-fl'><code>++div:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-fl'><code>++drg:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ead-fl'><code>++ead:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emn-fl'><code>++emn:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emu-fl'><code>++emu:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emx-fl'><code>++emx:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-fl'><code>++equ:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fli-fl'><code>++fli:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-fl'><code>++fma:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-fl'><code>++grd:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-fl'><code>++gte:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-fl'><code>++gth:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ibl-fl'><code>++ibl:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#inv-fl'><code>++inv:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lfe-fl'><code>++lfe:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lfn-fl'><code>++lfn:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-fl'><code>++lte:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-fl'><code>++lth:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lug-fl'><code>++lug:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-fl'><code>++mul:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ned-fl'><code>++ned:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#prc-fl'><code>++prc:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rau-fl'><code>++rau:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rou-fl'><code>++rou:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-fl'><code>++san:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#shf-fl'><code>++shf:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#spd-fl'><code>++spd:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#spn-fl'><code>++spn:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sqt-fl'><code>++sqt:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sub-fl'><code>++sub:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sun-fl'><code>++sun:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#swr-fl'><code>++swr:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#syn-fl'><code>++syn:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toi-fl'><code>++toi:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toj-fl'><code>++toj:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#uni-fl'><code>++uni:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#xpd-fl'><code>++xpd:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#zer-fl'><code>++zer:fl</code></a>
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rd'><code>++rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#add-rd' data-tippy-content="Add (double-precision float)"><code>++add:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rd' data-tippy-content="fn to double-precision binary float"><code>++bit:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#div-rd'><code>++div:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#drg-rd'><code>++drg:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#equ-rd'><code>++equ:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#exp-rd'><code>++exp:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fma-rd'><code>++fma:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#grd-rd'><code>++grd:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gte-rd'><code>++gte:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gth-rd'><code>++gth:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lte-rd'><code>++lte:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lth-rd'><code>++lth:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ma-rd'><code>++ma:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#mul-rd'><code>++mul:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#san-rd'><code>++san:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sea-rd'><code>++sea:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sig-rd'><code>++sig:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sqt-rd'><code>++sqt:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sub-rd'><code>++sub:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sun-rd'><code>++sun:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#toi-rd'><code>++toi:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rd'><code>++rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rd' data-tippy-content="Add (double-precision float)"><code>++add:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rd' data-tippy-content="fn to double-precision binary float"><code>++bit:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rd'><code>++div:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rd'><code>++drg:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rd'><code>++equ:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rd'><code>++exp:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rd'><code>++fma:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rd'><code>++grd:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rd'><code>++gte:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rd'><code>++gth:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rd'><code>++lte:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rd'><code>++lth:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rd'><code>++ma:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rd'><code>++mul:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-rd'><code>++san:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sea-rd'><code>++sea:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sig-rd'><code>++sig:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sqt-rd'><code>++sqt:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sub-rd'><code>++sub:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sun-rd'><code>++sun:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toi-rd'><code>++toi:rd</code></a>
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rh'><code>++rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#add-rh' data-tippy-content="Add (half-precision float)"><code>++add:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rh' data-tippy-content="fn to half-precision float"><code>++bit:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#div-rh'><code>++div:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#drg-rh'><code>++drg:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#equ-rh'><code>++equ:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#exp-rh'><code>++exp:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fma-rh'><code>++fma:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fos-rh'><code>++fos:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#grd-rh'><code>++grd:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gte-rh'><code>++gte:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gth-rh'><code>++gth:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lte-rh'><code>++lte:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lth-rh'><code>++lth:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ma-rh'><code>++ma:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#mul-rh'><code>++mul:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#san-rh'><code>++san:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sea-rh'><code>++sea:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sig-rh'><code>++sig:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sqt-rh'><code>++sqt:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sub-rh'><code>++sub:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sun-rh'><code>++sun:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#toi-rh'><code>++toi:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#tos-rh'><code>++tos:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rh'><code>++rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rh' data-tippy-content="Add (half-precision float)"><code>++add:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rh' data-tippy-content="fn to half-precision float"><code>++bit:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rh'><code>++div:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rh'><code>++drg:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rh'><code>++equ:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rh'><code>++exp:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rh'><code>++fma:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fos-rh'><code>++fos:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rh'><code>++grd:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rh'><code>++gte:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rh'><code>++gth:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rh'><code>++lte:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rh'><code>++lth:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rh'><code>++ma:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rh'><code>++mul:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-rh'><code>++san:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sea-rh'><code>++sea:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sig-rh'><code>++sig:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sqt-rh'><code>++sqt:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sub-rh'><code>++sub:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sun-rh'><code>++sun:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toi-rh'><code>++toi:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#tos-rh'><code>++tos:rh</code></a>
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rs'><code>++rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#add-rs' data-tippy-content="Add (single-precision float)"><code>++add:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rs' data-tippy-content="fn to single-precision float"><code>++bit:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#div-rs'><code>++div:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#drg-rs'><code>++drg:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#equ-rs'><code>++equ:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#exp-rs'><code>++exp:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fma-rs'><code>++fma:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#grd-rs'><code>++grd:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gte-rs'><code>++gte:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gth-rs'><code>++gth:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lte-rs'><code>++lte:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lth-rs'><code>++lth:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ma-rs'><code>++ma:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#mul-rs'><code>++mul:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#san-rs'><code>++san:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sea-rs'><code>++sea:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sig-rs'><code>++sig:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sqt-rs'><code>++sqt:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sub-rs'><code>++sub:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sun-rs'><code>++sun:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#toi-rs'><code>++toi:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rs'><code>++rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rs' data-tippy-content="Add (single-precision float)"><code>++add:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rs' data-tippy-content="fn to single-precision float"><code>++bit:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rs'><code>++div:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rs'><code>++drg:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rs'><code>++equ:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rs'><code>++exp:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rs'><code>++fma:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rs'><code>++grd:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rs'><code>++gte:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rs'><code>++gth:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rs'><code>++lte:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rs'><code>++lth:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rs'><code>++ma:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rs'><code>++mul:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-rs'><code>++san:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sea-rs'><code>++sea:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sig-rs'><code>++sig:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sqt-rs'><code>++sqt:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sub-rs'><code>++sub:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sun-rs'><code>++sun:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toi-rs'><code>++toi:rs</code></a>
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rq'><code>++rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#add-rq' data-tippy-content="Add (quad-precision float)"><code>++add:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rq' data-tippy-content="fn to quad-precision float"><code>++bit:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#div-rq'><code>++div:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#drg-rq'><code>++drg:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#equ-rq'><code>++equ:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#exp-rq'><code>++exp:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fma-rq'><code>++fma:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#grd-rq'><code>++grd:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gte-rq'><code>++gte:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gth-rq'><code>++gth:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lte-rq'><code>++lte:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lth-rq'><code>++lth:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ma-rq'><code>++ma:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#mul-rq'><code>++mul:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#san-rq'><code>++san:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sea-rq'><code>++sea:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sig-rq'><code>++sig:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sqt-rq'><code>++sqt:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sub-rq'><code>++sub:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sun-rq'><code>++sun:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#toi-rq'><code>++toi:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rq'><code>++rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rq' data-tippy-content="Add (quad-precision float)"><code>++add:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rq' data-tippy-content="fn to quad-precision float"><code>++bit:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rq'><code>++div:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rq'><code>++drg:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rq'><code>++equ:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rq'><code>++exp:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rq'><code>++fma:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rq'><code>++grd:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rq'><code>++gte:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rq'><code>++gth:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rq'><code>++lte:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rq'><code>++lth:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rq'><code>++ma:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rq'><code>++mul:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-rq'><code>++san:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sea-rq'><code>++sea:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sig-rq'><code>++sig:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sqt-rq'><code>++sqt:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sub-rq'><code>++sub:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sun-rq'><code>++sun:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toi-rq'><code>++toi:rq</code></a>
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rlyd'><code>++rlyd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rlyh'><code>++rlyh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rlyq'><code>++rlyq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rlys'><code>++rlys</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ryld'><code>++ryld</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rylh'><code>++rylh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rylq'><code>++rylq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ryls'><code>++ryls</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rlyd'><code>++rlyd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rlyh'><code>++rlyh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rlyq'><code>++rlyq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rlys'><code>++rlys</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ryld'><code>++ryld</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rylh'><code>++rylh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rylq'><code>++rylq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ryls'><code>++ryls</code></a>
 
 ### 3c: urbit time
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yo'><code>++yo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#cet-yo' data-tippy-content="Days in a century"><code>++cet:yo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#day-yo' data-tippy-content="Seconds in day"><code>++day:yo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#era-yo'><code>++era:yo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#hor-yo'><code>++hor:yo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#jes-yo'><code>++jes:yo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#mit-yo'><code>++mit:yo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#moh-yo'><code>++moh:yo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#moy-yo'><code>++moy:yo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#qad-yo'><code>++qad:yo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yer-yo'><code>++yer:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yo'><code>++yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#cet-yo' data-tippy-content="Days in a century"><code>++cet:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#day-yo' data-tippy-content="Seconds in day"><code>++day:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#era-yo'><code>++era:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#hor-yo'><code>++hor:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#jes-yo'><code>++jes:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#mit-yo'><code>++mit:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#moh-yo'><code>++moh:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#moy-yo'><code>++moy:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#qad-yo'><code>++qad:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yer-yo'><code>++yer:yo</code></a>
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yall'><code>++yall</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yawn'><code>++yawn</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#year'><code>++year</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yell'><code>++yell</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yelp'><code>++yelp</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yore'><code>++yore</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yule'><code>++yule</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yall'><code>++yall</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yawn'><code>++yawn</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#year'><code>++year</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yell'><code>++yell</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yelp'><code>++yelp</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yore'><code>++yore</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yule'><code>++yule</code></a>
 
 ### 3d: SHA hash family
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#og'><code>++og</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#rad-og'><code>++rad:og</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#rads-og'><code>++rads:og</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#raw-og'><code>++raw:og</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#raws-og'><code>++raws:og</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#og'><code>++og</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#rad-og'><code>++rad:og</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#rads-og'><code>++rads:og</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#raw-og'><code>++raw:og</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#raws-og'><code>++raws:og</code></a>
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shad'><code>++shad</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shaf'><code>++shaf</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shal'><code>++shal</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#sham'><code>++sham</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shan'><code>++shan</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shas'><code>++shas</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shaw'><code>++shaw</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shax'><code>++shax</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shay'><code>++shay</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shaz'><code>++shaz</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shad'><code>++shad</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shaf'><code>++shaf</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shal'><code>++shal</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#sham'><code>++sham</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shan'><code>++shan</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shas'><code>++shas</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shaw'><code>++shaw</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shax'><code>++shax</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shay'><code>++shay</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shaz'><code>++shaz</code></a>
 
 ### 3e: AES encryption
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3e.md'>_(removed)_</a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3e/'>_(removed)_</a>
 
 ### 3f: scrambling
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#ob'><code>++ob</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#feen-ob'><code>++feen:ob</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#fend-ob'><code>++fend:ob</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#fice-ob'><code>++fice:ob</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#raku-ob'><code>++raku:ob</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#rund-ob'><code>++rund:ob</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#rynd-ob'><code>++rynd:ob</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#teil-ob'><code>++teil:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#ob'><code>++ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#feen-ob'><code>++feen:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#fend-ob'><code>++fend:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#fice-ob'><code>++fice:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#raku-ob'><code>++raku:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#rund-ob'><code>++rund:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#rynd-ob'><code>++rynd:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#teil-ob'><code>++teil:ob</code></a>
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#un'><code>++un</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#wred-un'><code>++wred:un</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#wren-un'><code>++wren:un</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#xafo-un'><code>++xafo:un</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#xaro-un'><code>++xaro:un</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#zaft-un'><code>++zaft:un</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#zart-un'><code>++zart:un</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#zyft-un'><code>++zyft:un</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#zyrt-un'><code>++zyrt:un</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#un'><code>++un</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#wred-un'><code>++wred:un</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#wren-un'><code>++wren:un</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#xafo-un'><code>++xafo:un</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#xaro-un'><code>++xaro:un</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#zaft-un'><code>++zaft:un</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#zart-un'><code>++zart:un</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#zyft-un'><code>++zyft:un</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#zyrt-un'><code>++zyrt:un</code></a>
 
 ### 3g: molds and mold builders
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#coin' data-tippy-content="Noun-literal syntax cases"><code>++coin</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#dime'><code>++dime</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#edge'><code>++edge</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#hair'><code>++hair</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#like'><code>++like</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#nail'><code>++nail</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#path'><code>++path</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#pint'><code>++pint</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#rule'><code>++rule</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#spot'><code>++spot</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#tone'><code>++tone</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#toon'><code>++toon</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#wonk'><code>++wonk</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#coin' data-tippy-content="Noun-literal syntax cases"><code>++coin</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#dime'><code>++dime</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#edge'><code>++edge</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#hair'><code>++hair</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#like'><code>++like</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#nail'><code>++nail</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#path'><code>++path</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#pint'><code>++pint</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#rule'><code>++rule</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#spot'><code>++spot</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#tone'><code>++tone</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#toon'><code>++toon</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#wonk'><code>++wonk</code></a>
 
 ### 4a: exotic bases
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4a.md#po'><code>++po</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4a.md#ind-po'><code>++ind:po</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4a.md#ins-po'><code>++ins:po</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4a.md#tod-po'><code>++tod:po</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4a.md#tos-po'><code>++tos:po</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#po'><code>++po</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#ind-po'><code>++ind:po</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#ins-po'><code>++ins:po</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#tod-po'><code>++tod:po</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#tos-po'><code>++tos:po</code></a>
 
 ### 4b: text processing
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#at' data-tippy-content="(Undocumented)"><code>++at</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#r-at'><code>++r:at</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rf-at'><code>++rf:at</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rn-at'><code>++rn:at</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rt-at'><code>++rt:at</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rta-at'><code>++rta:at</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rtam-at'><code>++rtam:at</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rub-at'><code>++rub:at</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rud-at'><code>++rud:at</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rum-at'><code>++rum:at</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rup-at'><code>++rup:at</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#ruv-at'><code>++ruv:at</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rux-at'><code>++rux:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#at' data-tippy-content="(Undocumented)"><code>++at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#r-at'><code>++r:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rf-at'><code>++rf:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rn-at'><code>++rn:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rt-at'><code>++rt:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rta-at'><code>++rta:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rtam-at'><code>++rtam:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rub-at'><code>++rub:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rud-at'><code>++rud:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rum-at'><code>++rum:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rup-at'><code>++rup:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#ruv-at'><code>++ruv:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rux-at'><code>++rux:at</code></a>
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#cass' data-tippy-content="To lowercase"><code>++cass</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#crip' data-tippy-content="Tape to cord"><code>++crip</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#cuss' data-tippy-content="To uppercase"><code>++cuss</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#mesc'><code>++mesc</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#runt'><code>++runt</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#sand'><code>++sand</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#sane'><code>++sane</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#teff'><code>++teff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#trim'><code>++trim</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#trip'><code>++trip</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#tuba'><code>++tuba</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#tufa'><code>++tufa</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#tuft'><code>++tuft</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#turf'><code>++turf</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#wack'><code>++wack</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#wick'><code>++wick</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#woad'><code>++woad</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#wood'><code>++wood</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#cass' data-tippy-content="To lowercase"><code>++cass</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#crip' data-tippy-content="Tape to cord"><code>++crip</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#cuss' data-tippy-content="To uppercase"><code>++cuss</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#mesc'><code>++mesc</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#runt'><code>++runt</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#sand'><code>++sand</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#sane'><code>++sane</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#teff'><code>++teff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#trim'><code>++trim</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#trip'><code>++trip</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#tuba'><code>++tuba</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#tufa'><code>++tufa</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#tuft'><code>++tuft</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#turf'><code>++turf</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#wack'><code>++wack</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#wick'><code>++wick</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#woad'><code>++woad</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#wood'><code>++wood</code></a>
 
 ### 4c: tank printer
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#re'><code>++re</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#din-re'><code>++din:re</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#fit-re'><code>++fit:re</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#ram-re'><code>++ram:re</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#rig-re'><code>++rig:re</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#wig-re'><code>++wig:re</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#win-re'><code>++win:re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#re'><code>++re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#din-re'><code>++din:re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#fit-re'><code>++fit:re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#ram-re'><code>++ram:re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#rig-re'><code>++rig:re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#wig-re'><code>++wig:re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#win-re'><code>++win:re</code></a>
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#shep'><code>++shep</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#shop'><code>++shop</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#show'><code>++show</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#shep'><code>++shep</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#shop'><code>++shop</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#show'><code>++show</code></a>
 
 ### 4d: parsing (tracing)
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4d.md#last'><code>++last</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4d.md#lust'><code>++lust</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4d/#last'><code>++last</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4d/#lust'><code>++lust</code></a>
 
 ### 4e: parsing (combinators)
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#bend' data-tippy-content="Conditional composer"><code>++bend</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#comp' data-tippy-content="Arbitrary compose"><code>++comp</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#fail'><code>++fail</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#glue'><code>++glue</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#less'><code>++less</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#pfix'><code>++pfix</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#plug'><code>++plug</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#pose'><code>++pose</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#sfix'><code>++sfix</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#simu'><code>++simu</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#bend' data-tippy-content="Conditional composer"><code>++bend</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#comp' data-tippy-content="Arbitrary compose"><code>++comp</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#fail'><code>++fail</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#glue'><code>++glue</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#less'><code>++less</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#pfix'><code>++pfix</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#plug'><code>++plug</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#pose'><code>++pose</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#sfix'><code>++sfix</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#simu'><code>++simu</code></a>
 
 ### 4f: parsing (rule builders)
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#bass' data-tippy-content="Parser modifier (LSB-ordered ++list as atom of ++base)"><code>++bass</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#boss' data-tippy-content="Parser modifier: LSB"><code>++boss</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#cold' data-tippy-content="Replace with constant"><code>++cold</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#cook' data-tippy-content="Apply gate"><code>++cook</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#easy'><code>++easy</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#full'><code>++full</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#funk'><code>++funk</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#here'><code>++here</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#ifix'><code>++ifix</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#jest'><code>++jest</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#just'><code>++just</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#knee'><code>++knee</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#mask'><code>++mask</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#more'><code>++more</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#most'><code>++most</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#next'><code>++next</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#plus'><code>++plus</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#sear'><code>++sear</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#shim'><code>++shim</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#slug'><code>++slug</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#stag'><code>++stag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#star'><code>++star</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#stet'><code>++stet</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#stew'><code>++stew</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#stir'><code>++stir</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#stun'><code>++stun</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#bass' data-tippy-content="Parser modifier (LSB-ordered ++list as atom of ++base)"><code>++bass</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#boss' data-tippy-content="Parser modifier: LSB"><code>++boss</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#cold' data-tippy-content="Replace with constant"><code>++cold</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#cook' data-tippy-content="Apply gate"><code>++cook</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#easy'><code>++easy</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#full'><code>++full</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#funk'><code>++funk</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#here'><code>++here</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#ifix'><code>++ifix</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#jest'><code>++jest</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#just'><code>++just</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#knee'><code>++knee</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#mask'><code>++mask</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#more'><code>++more</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#most'><code>++most</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#next'><code>++next</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#plus'><code>++plus</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#sear'><code>++sear</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#shim'><code>++shim</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#slug'><code>++slug</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#stag'><code>++stag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#star'><code>++star</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#stet'><code>++stet</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#stew'><code>++stew</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#stir'><code>++stir</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#stun'><code>++stun</code></a>
 
 ### 4g: parsing (outside caller)
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4g.md#rash'><code>++rash</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4g.md#rush'><code>++rush</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4g.md#rust'><code>++rust</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4g.md#scan'><code>++scan</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rash'><code>++rash</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rush'><code>++rush</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rust'><code>++rust</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#scan'><code>++scan</code></a>
 
 ### 4h: parsing (ascii glyphs)
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#ace' data-tippy-content="Parse space"><code>++ace</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#bar' data-tippy-content="Parse | (bar)"><code>++bar</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#bas' data-tippy-content="Parse \ (bas)"><code>++bas</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#buc' data-tippy-content="Parse $ (buc)"><code>++buc</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#cab' data-tippy-content="Parse _ (cab)"><code>++cab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#cen' data-tippy-content="Parse % (cen)"><code>++cen</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#col' data-tippy-content="Parse : (col)"><code>++col</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#com' data-tippy-content="Parse , (comma)"><code>++com</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#doq'><code>++doq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#dot'><code>++dot</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#fas'><code>++fas</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#gal'><code>++gal</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#gar'><code>++gar</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#hax'><code>++hax</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#hep'><code>++hep</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#kel'><code>++kel</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#ker'><code>++ker</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#ket'><code>++ket</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#lus'><code>++lus</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#pam'><code>++pam</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#pat'><code>++pat</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#pel'><code>++pel</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#per'><code>++per</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#sel'><code>++sel</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#sem'><code>++sem</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#ser'><code>++ser</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#sig'><code>++sig</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#soq'><code>++soq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#tar'><code>++tar</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#tec'><code>++tec</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#tis'><code>++tis</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#wut'><code>++wut</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#zap'><code>++zap</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ace' data-tippy-content="Parse space"><code>++ace</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#bar' data-tippy-content="Parse | (bar)"><code>++bar</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#bas' data-tippy-content="Parse \ (bas)"><code>++bas</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#buc' data-tippy-content="Parse $ (buc)"><code>++buc</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#cab' data-tippy-content="Parse _ (cab)"><code>++cab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#cen' data-tippy-content="Parse % (cen)"><code>++cen</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#col' data-tippy-content="Parse : (col)"><code>++col</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#com' data-tippy-content="Parse , (comma)"><code>++com</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#doq'><code>++doq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#dot'><code>++dot</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#fas'><code>++fas</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#gal'><code>++gal</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#gar'><code>++gar</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#hax'><code>++hax</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#hep'><code>++hep</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#kel'><code>++kel</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ker'><code>++ker</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ket'><code>++ket</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#lus'><code>++lus</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pam'><code>++pam</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pat'><code>++pat</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pel'><code>++pel</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#per'><code>++per</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#sel'><code>++sel</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#sem'><code>++sem</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ser'><code>++ser</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#sig'><code>++sig</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#soq'><code>++soq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#tar'><code>++tar</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#tec'><code>++tec</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#tis'><code>++tis</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#wut'><code>++wut</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#zap'><code>++zap</code></a>
 
 ### 4i: parsing (useful idioms)
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#alf' data-tippy-content="Parse alphabetic characters"><code>++alf</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#aln' data-tippy-content="Parse alphanumeric characters"><code>++aln</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#alp' data-tippy-content="Parse alphanumeric characters and -"><code>++alp</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#bet' data-tippy-content="Parse hep and lus axis syntax"><code>++bet</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#bin' data-tippy-content="Binary to atom"><code>++bin</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#but' data-tippy-content="Parse binary digit"><code>++but</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#cit' data-tippy-content="Octal digit"><code>++cit</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#dem'><code>++dem</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#dit'><code>++dit</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#dog'><code>++dog</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#doh'><code>++doh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#dun'><code>++dun</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#duz'><code>++duz</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#gah'><code>++gah</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#gap'><code>++gap</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#gaq'><code>++gaq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#gaw'><code>++gaw</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#gay'><code>++gay</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#gon'><code>++gon</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#gul'><code>++gul</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#hex'><code>++hex</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#hig'><code>++hig</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#hit'><code>++hit</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#iny'><code>++iny</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#low'><code>++low</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#mes'><code>++mes</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#nix'><code>++nix</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#nud'><code>++nud</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#prn'><code>++prn</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#qit'><code>++qit</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#qut'><code>++qut</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#soz'><code>++soz</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#sym'><code>++sym</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#ven'><code>++ven</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#vit'><code>++vit</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#vul'><code>++vul</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#alf' data-tippy-content="Parse alphabetic characters"><code>++alf</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#aln' data-tippy-content="Parse alphanumeric characters"><code>++aln</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#alp' data-tippy-content="Parse alphanumeric characters and -"><code>++alp</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#bet' data-tippy-content="Parse hep and lus axis syntax"><code>++bet</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#bin' data-tippy-content="Binary to atom"><code>++bin</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#but' data-tippy-content="Parse binary digit"><code>++but</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#cit' data-tippy-content="Octal digit"><code>++cit</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dem'><code>++dem</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dit'><code>++dit</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dog'><code>++dog</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#doh'><code>++doh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dun'><code>++dun</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#duz'><code>++duz</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gah'><code>++gah</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gap'><code>++gap</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gaq'><code>++gaq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gaw'><code>++gaw</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gay'><code>++gay</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gon'><code>++gon</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gul'><code>++gul</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hex'><code>++hex</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hig'><code>++hig</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hit'><code>++hit</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#iny'><code>++iny</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#low'><code>++low</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#mes'><code>++mes</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#nix'><code>++nix</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#nud'><code>++nud</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#prn'><code>++prn</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#qit'><code>++qit</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#qut'><code>++qut</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#soz'><code>++soz</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#sym'><code>++sym</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#ven'><code>++ven</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#vit'><code>++vit</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#vul'><code>++vul</code></a>
 
 ### 4j: parsing (bases and base digits)
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#ab' data-tippy-content="Primitive parser engine"><code>++ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#bix-ab' data-tippy-content="Parse hex pair"><code>++bix:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#hif-ab'><code>++hif:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#huf-ab'><code>++huf:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#hyf-ab'><code>++hyf:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#pev-ab'><code>++pev:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#pew-ab'><code>++pew:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#piv-ab'><code>++piv:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#piw-ab'><code>++piw:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#qeb-ab'><code>++qeb:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#qex-ab'><code>++qex:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#qib-ab'><code>++qib:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#qix-ab'><code>++qix:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#seb-ab'><code>++seb:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sed-ab'><code>++sed:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sev-ab'><code>++sev:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sew-ab'><code>++sew:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sex-ab'><code>++sex:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sib-ab'><code>++sib:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sid-ab'><code>++sid:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#siv-ab'><code>++siv:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#siw-ab'><code>++siw:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#six-ab'><code>++six:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sov-ab'><code>++sov:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sow-ab'><code>++sow:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sox-ab'><code>++sox:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#ted-ab'><code>++ted:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#tid-ab'><code>++tid:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#til-ab'><code>++til:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#tip-ab'><code>++tip:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#tiq-ab'><code>++tiq:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#urs-ab'><code>++urs:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#urt-ab'><code>++urt:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#voy-ab'><code>++voy:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ab' data-tippy-content="Primitive parser engine"><code>++ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#bix-ab' data-tippy-content="Parse hex pair"><code>++bix:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hif-ab'><code>++hif:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#huf-ab'><code>++huf:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hyf-ab'><code>++hyf:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#pev-ab'><code>++pev:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#pew-ab'><code>++pew:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#piv-ab'><code>++piv:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#piw-ab'><code>++piw:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qeb-ab'><code>++qeb:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qex-ab'><code>++qex:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qib-ab'><code>++qib:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qix-ab'><code>++qix:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#seb-ab'><code>++seb:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sed-ab'><code>++sed:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sev-ab'><code>++sev:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sew-ab'><code>++sew:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sex-ab'><code>++sex:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sib-ab'><code>++sib:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sid-ab'><code>++sid:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#siv-ab'><code>++siv:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#siw-ab'><code>++siw:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#six-ab'><code>++six:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sov-ab'><code>++sov:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sow-ab'><code>++sow:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sox-ab'><code>++sox:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ted-ab'><code>++ted:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#tid-ab'><code>++tid:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#til-ab'><code>++til:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#tip-ab'><code>++tip:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#tiq-ab'><code>++tiq:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#urs-ab'><code>++urs:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#urt-ab'><code>++urt:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#voy-ab'><code>++voy:ab</code></a>
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#ag' data-tippy-content="Top-level atom parser engine"><code>++ag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#ape-ag' data-tippy-content="Parse 0 or rule"><code>++ape:ag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#bay-ag' data-tippy-content="Parses binary number"><code>++bay:ag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#bip-ag' data-tippy-content="Parse IPv6"><code>++bip:ag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#dem-ag'><code>++dem:ag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#dim-ag'><code>++dim:ag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#dum-ag'><code>++dum:ag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#fed-ag'><code>++fed:ag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#hex-ag'><code>++hex:ag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#lip-ag'><code>++lip:ag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#viz-ag'><code>++viz:ag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#vum-ag'><code>++vum:ag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#wiz-ag'><code>++wiz:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ag' data-tippy-content="Top-level atom parser engine"><code>++ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ape-ag' data-tippy-content="Parse 0 or rule"><code>++ape:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#bay-ag' data-tippy-content="Parses binary number"><code>++bay:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#bip-ag' data-tippy-content="Parse IPv6"><code>++bip:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dem-ag'><code>++dem:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dim-ag'><code>++dim:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dum-ag'><code>++dum:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#fed-ag'><code>++fed:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hex-ag'><code>++hex:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#lip-ag'><code>++lip:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#viz-ag'><code>++viz:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#vum-ag'><code>++vum:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#wiz-ag'><code>++wiz:ag</code></a>
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#mu'><code>++mu</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#zag-mu'><code>++zag:mu</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#zig-mu'><code>++zig:mu</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#zug-mu'><code>++zug:mu</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#mu'><code>++mu</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#zag-mu'><code>++zag:mu</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#zig-mu'><code>++zig:mu</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#zug-mu'><code>++zug:mu</code></a>
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#ne'><code>++ne</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#d-ne' data-tippy-content="Render decimal"><code>++d:ne</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#v-ne'><code>++v:ne</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#w-ne'><code>++w:ne</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#x-ne'><code>++x:ne</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ne'><code>++ne</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#d-ne' data-tippy-content="Render decimal"><code>++d:ne</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#v-ne'><code>++v:ne</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#w-ne'><code>++w:ne</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#x-ne'><code>++x:ne</code></a>
 
 ### 4k: parsing (atom printing)
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4k.md#co' data-tippy-content="Literal rendering engine"><code>++co</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4k.md#rear-co'><code>++rear:co</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4k.md#rend-co'><code>++rend:co</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4k.md#rent-co'><code>++rent:co</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#co' data-tippy-content="Literal rendering engine"><code>++co</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rear-co'><code>++rear:co</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rend-co'><code>++rend:co</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rent-co'><code>++rent:co</code></a>
 
 ### 4l: parsing (atom parsing)
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#so'><code>++so</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#bisk-so' data-tippy-content="Parse odor-atom pair"><code>++bisk:so</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#crub-so' data-tippy-content="Parse @da, @dr, @p, @t"><code>++crub:so</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#nuck-so'><code>++nuck:so</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#nusk-so'><code>++nusk:so</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#perd-so'><code>++perd:so</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#royl-so'><code>++royl:so</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#royl-cell-so'><code>++royl-cell:so</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#tash-so'><code>++tash:so</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#twid-so'><code>++twid:so</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#zust-so'><code>++zust:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#so'><code>++so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#bisk-so' data-tippy-content="Parse odor-atom pair"><code>++bisk:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#crub-so' data-tippy-content="Parse @da, @dr, @p, @t"><code>++crub:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#nuck-so'><code>++nuck:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#nusk-so'><code>++nusk:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#perd-so'><code>++perd:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#royl-so'><code>++royl:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#royl-cell-so'><code>++royl-cell:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#tash-so'><code>++tash:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#twid-so'><code>++twid:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#zust-so'><code>++zust:so</code></a>
 
 ### 4m: parsing (formatting functions)
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#scot'><code>++scot</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#scow'><code>++scow</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#slat'><code>++slat</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#slav'><code>++slav</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#slaw'><code>++slaw</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#slay'><code>++slay</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#smyt'><code>++smyt</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#spat'><code>++spat</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#spud'><code>++spud</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#stab'><code>++stab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#scot'><code>++scot</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#scow'><code>++scow</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#slat'><code>++slat</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#slav'><code>++slav</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#slaw'><code>++slaw</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#slay'><code>++slay</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#smyt'><code>++smyt</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#spat'><code>++spat</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#spud'><code>++spud</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4m/#stab'><code>++stab</code></a>
 
 ### 4n: parsing (virtualization)
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4n.md#mack'><code>++mack</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4n.md#mink'><code>++mink</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4n.md#mock'><code>++mock</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4n.md#mong'><code>++mong</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4n.md#mook'><code>++mook</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4n.md#mule'><code>++mule</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4n.md#mute'><code>++mute</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mack'><code>++mack</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mink'><code>++mink</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mock'><code>++mock</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mong'><code>++mong</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mook'><code>++mook</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mule'><code>++mule</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mute'><code>++mute</code></a>
 
 ### 4o: parsing (molds)
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#abel' data-tippy-content="Compiler alias"><code>++abel</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#aura' data-tippy-content="'Type' of atom"><code>++aura</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#axis' data-tippy-content="Nock axis"><code>++axis</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#base' data-tippy-content="Base type"><code>++base</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#bean' data-tippy-content="Boolean"><code>++bean</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#beer' data-tippy-content="Tape builder"><code>++beer</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#beet' data-tippy-content="XML interpolation cases"><code>++beet</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#chum' data-tippy-content="Jet hint information"><code>++chum</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#coil' data-tippy-content="Tuple of core information"><code>++coil</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#foot'><code>++foot</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#limb'><code>++limb</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#line'><code>++line</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#metl'><code>++metl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#nock'><code>++nock</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#noun'><code>++noun</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#null'><code>++null</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#port'><code>++port</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#span'><code>++span</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#tiki'><code>++tiki</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#toga'><code>++toga</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#tone'><code>++tone</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#tuna'><code>++tuna</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#tusk'><code>++tusk</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#tyke'><code>++tyke</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#typo'><code>++typo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#tyre'><code>++tyre</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#vase'><code>++vase</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#vise'><code>++vise</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#wing'><code>++wing</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#abel' data-tippy-content="Compiler alias"><code>++abel</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#aura' data-tippy-content="'Type' of atom"><code>++aura</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#axis' data-tippy-content="Nock axis"><code>++axis</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#base' data-tippy-content="Base type"><code>++base</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#bean' data-tippy-content="Boolean"><code>++bean</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#beer' data-tippy-content="Tape builder"><code>++beer</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#beet' data-tippy-content="XML interpolation cases"><code>++beet</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#chum' data-tippy-content="Jet hint information"><code>++chum</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#coil' data-tippy-content="Tuple of core information"><code>++coil</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#foot'><code>++foot</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#limb'><code>++limb</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#line'><code>++line</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#metl'><code>++metl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#nock'><code>++nock</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#noun'><code>++noun</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#null'><code>++null</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#port'><code>++port</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#span'><code>++span</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#tiki'><code>++tiki</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#toga'><code>++toga</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#tone'><code>++tone</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#tuna'><code>++tuna</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#tusk'><code>++tusk</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#tyke'><code>++tyke</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#typo'><code>++typo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#tyre'><code>++tyre</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#vase'><code>++vase</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#vise'><code>++vise</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#wing'><code>++wing</code></a>
 
 ### 5a: compiler utilities
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/5a.md'>_(To be documented)_</a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/5a/'>_(To be documented)_</a>
 
 ### 5b: macro expansion
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/5b.md'>_(To be documented)_</a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/5b/'>_(To be documented)_</a>
 
 ### 5c: compiler backend and prettyprinter
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/5c.md'>_(To be documented)_</a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/5c/'>_(To be documented)_</a>
 
 ### 5d: parser
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/5d.md'>_(To be documented)_</a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/5d/'>_(To be documented)_</a>
 
 ### 5e: caching compiler
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/5e.md'>_(To be documented)_</a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/5e/'>_(To be documented)_</a>
 
 ### 5f: molds and mold builders
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/5f.md#mane'><code>++mane</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/5f.md#manx'><code>++manx</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/5f.md#marl'><code>++marl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/5f.md#mars'><code>++mars</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/5f.md#mart'><code>++mart</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/5f.md#marx'><code>++marx</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/5f.md#pass'><code>++pass</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/5f.md#ring'><code>++ring</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/5f.md#time'><code>++time</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/5f/#mane'><code>++mane</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/5f/#manx'><code>++manx</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/5f/#marl'><code>++marl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/5f/#mars'><code>++mars</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/5f/#mart'><code>++mart</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/5f/#marx'><code>++marx</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/5f/#pass'><code>++pass</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/5f/#ring'><code>++ring</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/5f/#time'><code>++time</code></a>
 
 ### 5g: profiling support
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/5g.md'>_(To be documented)_</a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/5g/'>_(To be documented)_</a>

--- a/reference/library/_index.md
+++ b/reference/library/_index.md
@@ -13,528 +13,528 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### a
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ab' data-tippy-content="Primitive parser engine"><code>++ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#abs-fl' data-tippy-content="Absolute value"><code>++abs:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#abs-si' data-tippy-content="Absolute value (signed integer)"><code>++abs:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#abel' data-tippy-content="Compiler alias"><code>++abel</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ace' data-tippy-content="Parse space"><code>++ace</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#add' data-tippy-content="Add"><code>++add</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-ff' data-tippy-content="Add (floating point)"><code>++add:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-fl' data-tippy-content="Add (with exact/rounded flag)"><code>++add:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#add-ja' data-tippy-content="Prepend to list"><code>+-add:ja</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rd' data-tippy-content="Add (double-precision float)"><code>++add:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rh' data-tippy-content="Add (half-precision float)"><code>++add:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rs' data-tippy-content="Add (single-precision float)"><code>++add:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rq' data-tippy-content="Add (quad-precision float)"><code>++add:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ag' data-tippy-content="Top-level atom parser engine"><code>++ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#alf' data-tippy-content="Parse alphabetic characters"><code>++alf</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#all-by' data-tippy-content="Logical AND (map and wet gate)"><code>+-all:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#all-in' data-tippy-content="Logical AND (set and wet gate)"><code>+-all:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#aln' data-tippy-content="Parse alphanumeric characters"><code>++aln</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#alp' data-tippy-content="Parse alphanumeric characters and -"><code>++alp</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#any-by' data-tippy-content="Logical OR (map and wet gate)"><code>+-any:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#any-in' data-tippy-content="Logical OR (set and gate)"><code>+-any:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#aor' data-tippy-content="Alphabetical order"><code>++aor</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ape-ag' data-tippy-content="Parse 0 or rule"><code>++ape:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#apt-by' data-tippy-content="Check correctness (map)"><code>+-apt:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#apt-in' data-tippy-content="Check correctness (set)"><code>+-apt:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#at' data-tippy-content="(Undocumented)"><code>++at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#aura' data-tippy-content="'Type' of atom"><code>++aura</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#axis' data-tippy-content="Nock axis"><code>++axis</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ab' title="Primitive parser engine"><code>++ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#abs-fl' title="Absolute value"><code>++abs:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#abs-si' title="Absolute value (signed integer)"><code>++abs:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#abel' title="Compiler alias"><code>++abel</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ace' title="Parse space"><code>++ace</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#add' title="Add"><code>++add</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-ff' title="Add (floating point)"><code>++add:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-fl' title="Add (with exact/rounded flag)"><code>++add:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#add-ja' title="Prepend to list"><code>+-add:ja</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rd' title="Add (double-precision float)"><code>++add:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rh' title="Add (half-precision float)"><code>++add:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rs' title="Add (single-precision float)"><code>++add:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rq' title="Add (quad-precision float)"><code>++add:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ag' title="Top-level atom parser engine"><code>++ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#alf' title="Parse alphabetic characters"><code>++alf</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#all-by' title="Logical AND (map and wet gate)"><code>+-all:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#all-in' title="Logical AND (set and wet gate)"><code>+-all:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#aln' title="Parse alphanumeric characters"><code>++aln</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#alp' title="Parse alphanumeric characters and -"><code>++alp</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#any-by' title="Logical OR (map and wet gate)"><code>+-any:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#any-in' title="Logical OR (set and gate)"><code>+-any:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#aor' title="Alphabetical order"><code>++aor</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ape-ag' title="Parse 0 or rule"><code>++ape:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#apt-by' title="Check correctness (map)"><code>+-apt:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#apt-in' title="Check correctness (set)"><code>+-apt:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#at' title="(Undocumented)"><code>++at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#aura' title="'Type' of atom"><code>++aura</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#axis' title="Nock axis"><code>++axis</code></a>
 
 ### b
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#bal-to' data-tippy-content="Balance queue"><code>+-bal:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#bar' data-tippy-content="Parse | (bar)"><code>++bar</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#bas' data-tippy-content="Parse \ (bas)"><code>++bas</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#base' data-tippy-content="Base type"><code>++base</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#bass' data-tippy-content="Parser modifier (LSB-ordered ++list as atom of ++base)"><code>++bass</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#bay-ag' data-tippy-content="Parses binary number"><code>++bay:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#bean' data-tippy-content="Boolean"><code>++bean</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#beer' data-tippy-content="Tape builder"><code>++beer</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#beet' data-tippy-content="XML interpolation cases"><code>++beet</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#bend' data-tippy-content="Conditional composer"><code>++bend</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#bet' data-tippy-content="Parse hep and lus axis syntax"><code>++bet</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#bex' data-tippy-content="Binary exponent"><code>++bex</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bif-ff' data-tippy-content="Converts from fn to @r"><code>++bif:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#bif-by' data-tippy-content="Bifurcate map"><code>+-bif:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#bif-in' data-tippy-content="Bifurcate set"><code>+-bif:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#biff' data-tippy-content="Unit as argument"><code>++biff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#bin' data-tippy-content="Binary to atom"><code>++bin</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#bind' data-tippy-content="Non-unit function to unit, producing unit"><code>++bind</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#bip-ag' data-tippy-content="Parse IPv6"><code>++bip:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-ff' data-tippy-content="fn to @r with rounding"><code>++bit:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rd' data-tippy-content="fn to double-precision binary float"><code>++bit:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rh' data-tippy-content="fn to half-precision float"><code>++bit:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rs' data-tippy-content="fn to single-precision float"><code>++bit:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rq' data-tippy-content="fn to quad-precision float"><code>++bit:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#bix-ab' data-tippy-content="Parse hex pair"><code>++bix:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#bisk-so' data-tippy-content="Parse odor-atom pair"><code>++bisk:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#bloq' data-tippy-content="Blocksize"><code>++bloq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#bond' data-tippy-content="Replace null"><code>++bond</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#boss' data-tippy-content="Parser modifier: LSB"><code>++boss</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#both' data-tippy-content="Group unit values into pair"><code>++both</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#buc' data-tippy-content="Parse $ (buc)"><code>++buc</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#but' data-tippy-content="Parse binary digit"><code>++but</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#bal-to' title="Balance queue"><code>+-bal:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#bar' title="Parse | (bar)"><code>++bar</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#bas' title="Parse \ (bas)"><code>++bas</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#base' title="Base type"><code>++base</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#bass' title="Parser modifier (LSB-ordered ++list as atom of ++base)"><code>++bass</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#bay-ag' title="Parses binary number"><code>++bay:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#bean' title="Boolean"><code>++bean</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#beer' title="Tape builder"><code>++beer</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#beet' title="XML interpolation cases"><code>++beet</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#bend' title="Conditional composer"><code>++bend</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#bet' title="Parse hep and lus axis syntax"><code>++bet</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#bex' title="Binary exponent"><code>++bex</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bif-ff' title="Converts from fn to @r"><code>++bif:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#bif-by' title="Bifurcate map"><code>+-bif:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#bif-in' title="Bifurcate set"><code>+-bif:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#biff' title="Unit as argument"><code>++biff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#bin' title="Binary to atom"><code>++bin</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#bind' title="Non-unit function to unit, producing unit"><code>++bind</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#bip-ag' title="Parse IPv6"><code>++bip:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-ff' title="fn to @r with rounding"><code>++bit:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rd' title="fn to double-precision binary float"><code>++bit:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rh' title="fn to half-precision float"><code>++bit:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rs' title="fn to single-precision float"><code>++bit:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rq' title="fn to quad-precision float"><code>++bit:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#bix-ab' title="Parse hex pair"><code>++bix:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#bisk-so' title="Parse odor-atom pair"><code>++bisk:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#bloq' title="Blocksize"><code>++bloq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#bond' title="Replace null"><code>++bond</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#boss' title="Parser modifier: LSB"><code>++boss</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#both' title="Group unit values into pair"><code>++both</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#buc' title="Parse $ (buc)"><code>++buc</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#but' title="Parse binary digit"><code>++but</code></a>
 
 ### c
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#cab' data-tippy-content="Parse _ (cab)"><code>++cab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#can' data-tippy-content="Assemble"><code>++can</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#cap' data-tippy-content="Tree head"><code>++cap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#cass' data-tippy-content="To lowercase"><code>++cass</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#cat' data-tippy-content="Concatenate"><code>++cat</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#cen' data-tippy-content="Parse % (cen)"><code>++cen</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#cet-yo' data-tippy-content="Days in a century"><code>++cet:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#char' data-tippy-content="Character"><code>++char</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#chum' data-tippy-content="Jet hint information"><code>++chum</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#cit' data-tippy-content="Octal digit"><code>++cit</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#clap' data-tippy-content="Apply function to two units"><code>++clap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#cmp-si' data-tippy-content="Compare (signed integer)"><code>++cmp:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#co' data-tippy-content="Literal rendering engine"><code>++co</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#coil' data-tippy-content="Tuple of core information"><code>++coil</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#coin' data-tippy-content="Noun-literal syntax cases"><code>++coin</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#col' data-tippy-content="Parse : (col)"><code>++col</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#cold' data-tippy-content="Replace with constant"><code>++cold</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#com' data-tippy-content="Parse , (com)"><code>++com</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#comp' data-tippy-content="Arbitrary compose"><code>++comp</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#con' data-tippy-content="Binary OR"><code>++con</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#cook' data-tippy-content="Apply gate"><code>++cook</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#cord' data-tippy-content="UTF-8 text"><code>++cord</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#cork' data-tippy-content="Compose forward"><code>++cork</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#corl' data-tippy-content="Compose backward"><code>++corl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#crip' data-tippy-content="Tape to cord"><code>++crip</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#crub-so' data-tippy-content="Parse @da, @dr, @p, @t"><code>++crub:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#cue' data-tippy-content="Unpack atom to noun"><code>++cue</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#curr' data-tippy-content="Right-curry a gate"><code>++curr</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#cury' data-tippy-content="Curry left a gate"><code>++cury</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#cuss' data-tippy-content="To uppercase"><code>++cuss</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#cut' data-tippy-content="Slice"><code>++cut</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#cab' title="Parse _ (cab)"><code>++cab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#can' title="Assemble"><code>++can</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#cap' title="Tree head"><code>++cap</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#cass' title="To lowercase"><code>++cass</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#cat' title="Concatenate"><code>++cat</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#cen' title="Parse % (cen)"><code>++cen</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#cet-yo' title="Days in a century"><code>++cet:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#char' title="Character"><code>++char</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#chum' title="Jet hint information"><code>++chum</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#cit' title="Octal digit"><code>++cit</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#clap' title="Apply function to two units"><code>++clap</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#cmp-si' title="Compare (signed integer)"><code>++cmp:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#co' title="Literal rendering engine"><code>++co</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#coil' title="Tuple of core information"><code>++coil</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#coin' title="Noun-literal syntax cases"><code>++coin</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#col' title="Parse : (col)"><code>++col</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#cold' title="Replace with constant"><code>++cold</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#com' title="Parse , (com)"><code>++com</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#comp' title="Arbitrary compose"><code>++comp</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#con' title="Binary OR"><code>++con</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#cook' title="Apply gate"><code>++cook</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#cord' title="UTF-8 text"><code>++cord</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#cork' title="Compose forward"><code>++cork</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#corl' title="Compose backward"><code>++corl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#crip' title="Tape to cord"><code>++crip</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#crub-so' title="Parse @da, @dr, @p, @t"><code>++crub:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#cue' title="Unpack atom to noun"><code>++cue</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#curr' title="Right-curry a gate"><code>++curr</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#cury' title="Curry left a gate"><code>++cury</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#cuss' title="To uppercase"><code>++cuss</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#cut' title="Slice"><code>++cut</code></a>
 
 ### d
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#d-ne' data-tippy-content="Render decimal"><code>++d:ne</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#date' data-tippy-content="Point in time"><code>++date</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#day-yo' data-tippy-content="Seconds in day"><code>++day:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#dec' data-tippy-content="Decrement"><code>++dec</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#def-by' data-tippy-content="Difference (map)"><code>+-def:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#del-by' data-tippy-content="Delete (map)"><code>+-del:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#del-in' data-tippy-content="Delete (set)"><code>+-del:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#del-ju' data-tippy-content="Delete (jug)"><code>+-del:ju</code></a>
-    <a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dem' data-tippy-content="Decimal to atom"><code>++dem</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dem-ag' data-tippy-content="Parse decmal with dots"><code>++dem:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#den-fl' data-tippy-content="Denormalizes (floating point)"><code>++den:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#dep-by' data-tippy-content="Difference as patch (map)"><code>+-dep:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#dep-to' data-tippy-content="Maximum depth (queue)"><code>+-dep:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#dif-fe' data-tippy-content="Difference between atoms (modular basis)"><code>++dif:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dif-fo' data-tippy-content='Subtraction (modular base)'><code>++dif:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#dif-in' data-tippy-content='Difference (set)'><code>+-dif:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dif-si' data-tippy-content="Subtraction (signed integer)"><code>++dif:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#dig-by' data-tippy-content="Address of key (map)"><code>+-dig:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#dig-in' data-tippy-content="Address of a in set"><code>+-dig:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dim-ag' data-tippy-content="Parse decimal number"><code>++dim:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#dime' data-tippy-content="Aura-atom pair"><code>++dime</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#din-re' data-tippy-content="(Undocumented)"><code>++din:re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#dis' data-tippy-content="Binary AND (atoms)"><code>++dis</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dit' data-tippy-content="Decimal digit"><code>++dit</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#div' data-tippy-content="Divide"><code>++div</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-ff' data-tippy-content="Divide (IEEE float)"><code>++div:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-fl' data-tippy-content="Divide (signed and unsigned integer cell)"><code>++div:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rd' data-tippy-content="Double precision float"><code>++div:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rh' data-tippy-content="Divide (half-precision float)"><code>++div:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rs' data-tippy-content="Divide (single-precision float)"><code>++div:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rq' data-tippy-content="Divide (quad-precision float)"><code>++div:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dog' data-tippy-content="Optional gap"><code>++dog</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#doh' data-tippy-content="@p separator"><code>++doh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#doq' data-tippy-content="Parse double quote"><code>++doq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#dor' data-tippy-content="Numeric order"><code>++dor</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#dot' data-tippy-content="Parse period"><code>++dot</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-ff' data-tippy-content="@r to decimal float"><code>++drg:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-fl' data-tippy-content="Get printable decimal (signed and unsigned integer cell)"><code>++drg:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rd' data-tippy-content="@rd to decimal float"><code>++drg:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rh' data-tippy-content="@rh to decimal float"><code>++drg:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rs' data-tippy-content="@rs to decimal float"><code>++drg:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rq' data-tippy-content="@rq to decimal float"><code>++drg:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#drop' data-tippy-content="Unit to list"><code>++drop</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dul-si' data-tippy-content="Modulus (signed integer)"><code>++dul:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dum-ag' data-tippy-content="Parse decimal with leading zero"><code>++dum:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dun' data-tippy-content="-- to ~"><code>++dun</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#duz' data-tippy-content="== to ~"><code>++duz</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#dvr' data-tippy-content="Divide (with remainder)"><code>++dvr</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#d-ne' title="Render decimal"><code>++d:ne</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#date' title="Point in time"><code>++date</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#day-yo' title="Seconds in day"><code>++day:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#dec' title="Decrement"><code>++dec</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#def-by' title="Difference (map)"><code>+-def:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#del-by' title="Delete (map)"><code>+-del:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#del-in' title="Delete (set)"><code>+-del:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#del-ju' title="Delete (jug)"><code>+-del:ju</code></a>
+    <a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dem' title="Decimal to atom"><code>++dem</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dem-ag' title="Parse decmal with dots"><code>++dem:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#den-fl' title="Denormalizes (floating point)"><code>++den:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#dep-by' title="Difference as patch (map)"><code>+-dep:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#dep-to' title="Maximum depth (queue)"><code>+-dep:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#dif-fe' title="Difference between atoms (modular basis)"><code>++dif:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dif-fo' title='Subtraction (modular base)'><code>++dif:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#dif-in' title='Difference (set)'><code>+-dif:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dif-si' title="Subtraction (signed integer)"><code>++dif:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#dig-by' title="Address of key (map)"><code>+-dig:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#dig-in' title="Address of a in set"><code>+-dig:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dim-ag' title="Parse decimal number"><code>++dim:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#dime' title="Aura-atom pair"><code>++dime</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#din-re' title="(Undocumented)"><code>++din:re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#dis' title="Binary AND (atoms)"><code>++dis</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dit' title="Decimal digit"><code>++dit</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#div' title="Divide"><code>++div</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-ff' title="Divide (IEEE float)"><code>++div:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-fl' title="Divide (signed and unsigned integer cell)"><code>++div:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rd' title="Double precision float"><code>++div:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rh' title="Divide (half-precision float)"><code>++div:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rs' title="Divide (single-precision float)"><code>++div:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rq' title="Divide (quad-precision float)"><code>++div:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dog' title="Optional gap"><code>++dog</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#doh' title="@p separator"><code>++doh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#doq' title="Parse double quote"><code>++doq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#dor' title="Numeric order"><code>++dor</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#dot' title="Parse period"><code>++dot</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-ff' title="@r to decimal float"><code>++drg:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-fl' title="Get printable decimal (signed and unsigned integer cell)"><code>++drg:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rd' title="@rd to decimal float"><code>++drg:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rh' title="@rh to decimal float"><code>++drg:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rs' title="@rs to decimal float"><code>++drg:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rq' title="@rq to decimal float"><code>++drg:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#drop' title="Unit to list"><code>++drop</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dul-si' title="Modulus (signed integer)"><code>++dul:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dum-ag' title="Parse decimal with leading zero"><code>++dum:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dun' title="-- to ~"><code>++dun</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#duz' title="== to ~"><code>++duz</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#dvr' title="Divide (with remainder)"><code>++dvr</code></a>
 
 ### e
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ead-fl' data-tippy-content="Exact add"><code>++ead:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#each' data-tippy-content="Mold of fork between two types"><code>++each</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#easy' data-tippy-content="Always parse"><code>++easy</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#edge' data-tippy-content="Parsing location metadata"><code>++edge</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#egcd' data-tippy-content="Extended Euclidean algorithm"><code>++egcd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emn-fl' data-tippy-content="Minimum exponent"><code>++emn:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emu-fl' data-tippy-content="Exact multiply"><code>++emu:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emx-fl' data-tippy-content="Maximum exponent"><code>++emx:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#end' data-tippy-content="Tail"><code>++end</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-ff' data-tippy-content="Equals (IEEE float)"><code>++equ:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-fl' data-tippy-content="Equals (signed and unsigned integer cell)"><code>++equ:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rd' data-tippy-content="Equals (double-precision float)"><code>++equ:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rh' data-tippy-content="Equals (half-precision float)"><code>++equ:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rs' data-tippy-content="Equals (single-precision float)"><code>++equ:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rq' data-tippy-content="Equals (quad-precision float)"><code>++equ:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#era-yo' data-tippy-content="Leap-year period"><code>++era:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-ff' data-tippy-content="Get exponent (IEEE float)"><code>++exp:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#exp-fo' data-tippy-content="Exponent (modular base)"><code>++exp:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rd' data-tippy-content="Exponent (@rd)"><code>++exp:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rh' data-tippy-content="Exponent (half-precision float)"><code>++exp:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rs' data-tippy-content="Exponent (@rs)"><code>++exp:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rq' data-tippy-content="Exponent (quad-precision float)"><code>++exp:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ead-fl' title="Exact add"><code>++ead:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#each' title="Mold of fork between two types"><code>++each</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#easy' title="Always parse"><code>++easy</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#edge' title="Parsing location metadata"><code>++edge</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#egcd' title="Extended Euclidean algorithm"><code>++egcd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emn-fl' title="Minimum exponent"><code>++emn:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emu-fl' title="Exact multiply"><code>++emu:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emx-fl' title="Maximum exponent"><code>++emx:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#end' title="Tail"><code>++end</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-ff' title="Equals (IEEE float)"><code>++equ:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-fl' title="Equals (signed and unsigned integer cell)"><code>++equ:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rd' title="Equals (double-precision float)"><code>++equ:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rh' title="Equals (half-precision float)"><code>++equ:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rs' title="Equals (single-precision float)"><code>++equ:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rq' title="Equals (quad-precision float)"><code>++equ:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#era-yo' title="Leap-year period"><code>++era:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-ff' title="Get exponent (IEEE float)"><code>++exp:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#exp-fo' title="Exponent (modular base)"><code>++exp:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rd' title="Exponent (@rd)"><code>++exp:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rh' title="Exponent (half-precision float)"><code>++exp:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rs' title="Exponent (@rs)"><code>++exp:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rq' title="Exponent (quad-precision float)"><code>++exp:rq</code></a>
 
 ### f
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#fail' data-tippy-content="Never parse"><code>++fail</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#fall' data-tippy-content="Give unit a default value"><code>++fall</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#fand' data-tippy-content="All indices in list"><code>++fand</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#fas' data-tippy-content="Parse / (fas)"><code>++fas</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#fe' data-tippy-content="Modulo bloq"><code>++fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#fed-ag' data-tippy-content="Parse @p"><code>++fed:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#feen-ob' data-tippy-content="Conceal structure v2"><code>++feen:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#fend-ob' data-tippy-content="Restore structure v2"><code>++fend:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#fice-ob' data-tippy-content="Feistel-like cipher"><code>++fice:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#fil' data-tippy-content="Fill bloqstream"><code>++fil</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#find' data-tippy-content="First index in list"><code>++find</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#fit-re' data-tippy-content="Fit on one line test"><code>++fit:re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fli-fl' data-tippy-content="Flip sign"><code>++fli:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#flop' data-tippy-content="Reverse list"><code>++flop</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-ff' data-tippy-content="Fused multiply-add (IEEE float)"><code>++fma:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-fl' data-tippy-content="Fused multiply-add"><code>++fma:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rd' data-tippy-content="Fused multiply-add (@rd)"><code>++fma:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rh' data-tippy-content="Fused multiply-add (half-precision float)"><code>++fma:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rs' data-tippy-content="Fused multiply-add (single-precision float)"><code>++fma:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rq' data-tippy-content="Fused multiply-add (quad-precision float)"><code>++fma:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#fnv' data-tippy-content="FNV scrambler"><code>++fnv</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fo' data-tippy-content="Modulo prime"><code>++fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#foot' data-tippy-content="Cases of arms by variance model"><code>++foot</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fos-rh' data-tippy-content="@rs to @rh"><code>++fos:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fra-fo' data-tippy-content="Divide (modular base)"><code>++fra:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fra-si' data-tippy-content="Divide (signed integer)"><code>++fra:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#full' data-tippy-content="Parse to end"><code>++full</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#funk' data-tippy-content="Add to tape"><code>++funk</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#fail' title="Never parse"><code>++fail</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#fall' title="Give unit a default value"><code>++fall</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#fand' title="All indices in list"><code>++fand</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#fas' title="Parse / (fas)"><code>++fas</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#fe' title="Modulo bloq"><code>++fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#fed-ag' title="Parse @p"><code>++fed:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#feen-ob' title="Conceal structure v2"><code>++feen:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#fend-ob' title="Restore structure v2"><code>++fend:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#fice-ob' title="Feistel-like cipher"><code>++fice:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#fil' title="Fill bloqstream"><code>++fil</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#find' title="First index in list"><code>++find</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#fit-re' title="Fit on one line test"><code>++fit:re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fli-fl' title="Flip sign"><code>++fli:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#flop' title="Reverse list"><code>++flop</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-ff' title="Fused multiply-add (IEEE float)"><code>++fma:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-fl' title="Fused multiply-add"><code>++fma:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rd' title="Fused multiply-add (@rd)"><code>++fma:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rh' title="Fused multiply-add (half-precision float)"><code>++fma:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rs' title="Fused multiply-add (single-precision float)"><code>++fma:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rq' title="Fused multiply-add (quad-precision float)"><code>++fma:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#fnv' title="FNV scrambler"><code>++fnv</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fo' title="Modulo prime"><code>++fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#foot' title="Cases of arms by variance model"><code>++foot</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fos-rh' title="@rs to @rh"><code>++fos:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fra-fo' title="Divide (modular base)"><code>++fra:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fra-si' title="Divide (signed integer)"><code>++fra:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#full' title="Parse to end"><code>++full</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#funk' title="Add to tape"><code>++funk</code></a>
 
 ### g
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gah' data-tippy-content="New line or ''"><code>++gah</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#gal' data-tippy-content="Parse < (gal)"><code>++gal</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gap' data-tippy-content="Plural whitespace"><code>++gap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gaq' data-tippy-content="End of line"><code>++gaq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#gar' data-tippy-content="Parse > (gar)"><code>++gar</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#gas-by' data-tippy-content="Concatenate (map)"><code>+-gas:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#gas-in' data-tippy-content="Concatenate (set)"><code>+-gas:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#gas-to' data-tippy-content="Push list into queue"><code>+-gas:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#gate' data-tippy-content="Function"><code>++gate</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gaw' data-tippy-content="Classic whitespace"><code>++gaw</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gay' data-tippy-content="Optional gap"><code>++gay</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#get-by' data-tippy-content="Grab unit value"><code>+-get:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#get-ja' data-tippy-content="Grab value by key"><code>+-get:ja</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#get-ju' data-tippy-content="Retrieve set"><code>+-get:ju</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#get-to' data-tippy-content="Head-tail pair"><code>+-get:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#glue' data-tippy-content="Skip delimiter"><code>++glue</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gon' data-tippy-content="Parse long numbers"><code>++gon</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#gor' data-tippy-content="Hash order"><code>++gor</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#got-by' data-tippy-content="Assert for value (map)"><code>+-got:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-ff' data-tippy-content="Decimal float to @r"><code>++grd:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-fl' data-tippy-content="Decimal to float"><code>++grd:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rd' data-tippy-content="Decimal float to @rd"><code>++grd:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rh' data-tippy-content="Decimal float to @rh"><code>++grd:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rs' data-tippy-content="Decimal float to @rs"><code>++grd:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rq' data-tippy-content="Decimal float to @rq"><code>++grd:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#gte' data-tippy-content="Greater than / equal"><code>++gte</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-ff' data-tippy-content="Greater than / equal (IEEE float)"><code>++gte:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-fl' data-tippy-content="Greater than / equal (producing flag)"><code>++gte:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rd' data-tippy-content="Greater than / equal (double-precision float)"><code>++gte:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rh' data-tippy-content="Greater than / equal (half-precision float)"><code>++gte:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rs' data-tippy-content="Greater than / equal (single-precision float)"><code>++gte:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rq' data-tippy-content="Greater than / equal (quad-precision float)"><code>++gte:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#gth' data-tippy-content="Greater than"><code>++gth</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-ff' data-tippy-content="Greater than (IEEE float)"><code>++gth:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-fl' data-tippy-content="Greater than (producing flag)"><code>++gth:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rd' data-tippy-content="Greater than (double-precision float)"><code>++gth:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rh' data-tippy-content="Greater than (half-precision float)"><code>++gth:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rs' data-tippy-content="Greater than (single-precision float)"><code>++gth:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rq' data-tippy-content="Greater than (quad-precision float)"><code>++gth:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gul' data-tippy-content="Axis syntax < or >"><code>++gul</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#gulf' data-tippy-content="List from range"><code>++gulf</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gah' title="New line or ''"><code>++gah</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#gal' title="Parse < (gal)"><code>++gal</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gap' title="Plural whitespace"><code>++gap</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gaq' title="End of line"><code>++gaq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#gar' title="Parse > (gar)"><code>++gar</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#gas-by' title="Concatenate (map)"><code>+-gas:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#gas-in' title="Concatenate (set)"><code>+-gas:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#gas-to' title="Push list into queue"><code>+-gas:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#gate' title="Function"><code>++gate</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gaw' title="Classic whitespace"><code>++gaw</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gay' title="Optional gap"><code>++gay</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#get-by' title="Grab unit value"><code>+-get:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#get-ja' title="Grab value by key"><code>+-get:ja</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#get-ju' title="Retrieve set"><code>+-get:ju</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#get-to' title="Head-tail pair"><code>+-get:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#glue' title="Skip delimiter"><code>++glue</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gon' title="Parse long numbers"><code>++gon</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#gor' title="Hash order"><code>++gor</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#got-by' title="Assert for value (map)"><code>+-got:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-ff' title="Decimal float to @r"><code>++grd:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-fl' title="Decimal to float"><code>++grd:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rd' title="Decimal float to @rd"><code>++grd:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rh' title="Decimal float to @rh"><code>++grd:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rs' title="Decimal float to @rs"><code>++grd:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rq' title="Decimal float to @rq"><code>++grd:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#gte' title="Greater than / equal"><code>++gte</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-ff' title="Greater than / equal (IEEE float)"><code>++gte:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-fl' title="Greater than / equal (producing flag)"><code>++gte:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rd' title="Greater than / equal (double-precision float)"><code>++gte:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rh' title="Greater than / equal (half-precision float)"><code>++gte:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rs' title="Greater than / equal (single-precision float)"><code>++gte:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rq' title="Greater than / equal (quad-precision float)"><code>++gte:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#gth' title="Greater than"><code>++gth</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-ff' title="Greater than (IEEE float)"><code>++gth:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-fl' title="Greater than (producing flag)"><code>++gth:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rd' title="Greater than (double-precision float)"><code>++gth:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rh' title="Greater than (half-precision float)"><code>++gth:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rs' title="Greater than (single-precision float)"><code>++gth:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rq' title="Greater than (quad-precision float)"><code>++gth:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gul' title="Axis syntax < or >"><code>++gul</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#gulf' title="List from range"><code>++gulf</code></a>
 
 ### h
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#hair' data-tippy-content="Parsing line and column"><code>++hair</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#hard' data-tippy-content="Force remold"><code>++hard</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#has-by' data-tippy-content="Key existence check (map)"><code>+-has:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#has-in' data-tippy-content="Key existence check (set)"><code>+-has:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#has-ju' data-tippy-content="Check contents (jug)"><code>+-has:ju</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#hax' data-tippy-content="Parse # (hax)"><code>++hax</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#head' data-tippy-content="Get head of cell"><code>++head</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#here' data-tippy-content="Place-based apply"><code>++here</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#hep' data-tippy-content="Parse - (hep)"><code>++hep</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hex' data-tippy-content="Hexadecimal to atom"><code>++hex</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hex-ag' data-tippy-content="Parse hexadecimal number"><code>++hex:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hif-ab' data-tippy-content="Parse phonetic pair"><code>++hif:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hig' data-tippy-content="Parse single uppercase letter"><code>++hig</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hit' data-tippy-content="Parse single hexadecimal digit"><code>++hit</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#homo' data-tippy-content="Homogenize list"><code>++homo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#hor' data-tippy-content="Horizontal hash order"><code>++hor</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#hor-yo' data-tippy-content="Seconds in hour"><code>++hor:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#huf-ab' data-tippy-content="Parse two phonetic pairs"><code>++huf:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hyf-ab' data-tippy-content="Parse 8 phonetic bytes"><code>++hyf:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#hair' title="Parsing line and column"><code>++hair</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#hard' title="Force remold"><code>++hard</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#has-by' title="Key existence check (map)"><code>+-has:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#has-in' title="Key existence check (set)"><code>+-has:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#has-ju' title="Check contents (jug)"><code>+-has:ju</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#hax' title="Parse # (hax)"><code>++hax</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#head' title="Get head of cell"><code>++head</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#here' title="Place-based apply"><code>++here</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#hep' title="Parse - (hep)"><code>++hep</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hex' title="Hexadecimal to atom"><code>++hex</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hex-ag' title="Parse hexadecimal number"><code>++hex:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hif-ab' title="Parse phonetic pair"><code>++hif:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hig' title="Parse single uppercase letter"><code>++hig</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hit' title="Parse single hexadecimal digit"><code>++hit</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#homo' title="Homogenize list"><code>++homo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#hor' title="Horizontal hash order"><code>++hor</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#hor-yo' title="Seconds in hour"><code>++hor:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#huf-ab' title="Parse two phonetic pairs"><code>++huf:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hyf-ab' title="Parse 8 phonetic bytes"><code>++hyf:ab</code></a>
 
 ### i
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ibl-fl' data-tippy-content="Integer binary logarithm"><code>++ibl:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#ifix' data-tippy-content="Infix"><code>++ifix</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#ind-po' data-tippy-content="Parse suffix"><code>++ind:po</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#ins-po' data-tippy-content="Parse prefix"><code>++ins:po</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#int-by' data-tippy-content="Intersection (map)"><code>+-int:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#int-in' data-tippy-content="Intersection (set)"><code>+-int:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#inv-fe' data-tippy-content="Inverse order of modular field"><code>++inv:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#inv-fl' data-tippy-content="Inverse"><code>++inv:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#inv-fo' data-tippy-content="Inverse (signed modulus)"><code>++inv:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#iny' data-tippy-content="Indentation block"><code>++iny</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ibl-fl' title="Integer binary logarithm"><code>++ibl:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#ifix' title="Infix"><code>++ifix</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#ind-po' title="Parse suffix"><code>++ind:po</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#ins-po' title="Parse prefix"><code>++ins:po</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#int-by' title="Intersection (map)"><code>+-int:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#int-in' title="Intersection (set)"><code>+-int:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#inv-fe' title="Inverse order of modular field"><code>++inv:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#inv-fl' title="Inverse"><code>++inv:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#inv-fo' title="Inverse (signed modulus)"><code>++inv:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#iny' title="Indentation block"><code>++iny</code></a>
 
 ### j
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#ja' data-tippy-content="Jar engine"><code>++ja</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#jam' data-tippy-content="Pack noun to atom"><code>++jam</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#jar' data-tippy-content="Mold generator (jar)"><code>++jar</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#jes-yo' data-tippy-content="Maximum 64-bit timestamp"><code>++jes:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#jest' data-tippy-content="Match a cord"><code>++jest</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#ju' data-tippy-content="Jug operations"><code>++ju</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#jug' data-tippy-content="Mold generator (jug)"><code>++jug</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#just' data-tippy-content="Match a single character"><code>++just</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#ja' title="Jar engine"><code>++ja</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#jam' title="Pack noun to atom"><code>++jam</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#jar' title="Mold generator (jar)"><code>++jar</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#jes-yo' title="Maximum 64-bit timestamp"><code>++jes:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#jest' title="Match a cord"><code>++jest</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#ju' title="Jug operations"><code>++ju</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#jug' title="Mold generator (jug)"><code>++jug</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#just' title="Match a single character"><code>++just</code></a>
 
 ### k
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#kel' data-tippy-content="Parse { (kel)"><code>++kel</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ker' data-tippy-content="Parse } (ker)"><code>++ker</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ket' data-tippy-content="Parse ^ (ket)"><code>++ket</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#knee' data-tippy-content="Recursive parsers"><code>++knee</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#knot' data-tippy-content="Atom type of ASCII characters"><code>++knot</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#kel' title="Parse { (kel)"><code>++kel</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ker' title="Parse } (ker)"><code>++ker</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ket' title="Parse ^ (ket)"><code>++ket</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#knee' title="Recursive parsers"><code>++knee</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#knot' title="Atom type of ASCII characters"><code>++knot</code></a>
 
 ### l
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4d/#last' data-tippy-content="Further trace"><code>++last</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#le-nl' data-tippy-content="Construct list from null-terminated noun"><code>++le:nl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#lent' data-tippy-content="List length"><code>++lent</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#levy' data-tippy-content="Logical AND on list"><code>++levy</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lfe-fl' data-tippy-content="Maximum"><code>++lfe:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lfn-fl' data-tippy-content="Largest normal float"><code>++lfn:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#lien' data-tippy-content="Logical OR on list"><code>++lien</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#lift' data-tippy-content="Curried bind"><code>++lift</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#like' data-tippy-content="Generic edge"><code>++like</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#limb' data-tippy-content="Reference into subject by name/axis"><code>++limb</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#limo' data-tippy-content="Construct list from null-terminated tuple"><code>++limo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#line' data-tippy-content="(Undocumented)"><code>++line</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#lip-ag' data-tippy-content="Parse IPv4 address"><code>++lip:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#list' data-tippy-content="Mold constructor (list)"><code>++list</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#lone' data-tippy-content="Mold generator (face on mold)"><code>++lone</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#lor' data-tippy-content="Leg order"><code>++lor</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#low' data-tippy-content="Parse lowercase letter"><code>++low</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#lsh' data-tippy-content="Left-shift"><code>++lsh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#lte' data-tippy-content="Less than / equal (atom)"><code>++lte</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-ff' data-tippy-content="Less than / equal (IEEE float)"><code>++lte:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-fl' data-tippy-content="Less than / equal (producing flag)"><code>++lte:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rd' data-tippy-content="Less than / equal (double-precision float)"><code>++lte:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rh' data-tippy-content="Less than / equal (half-precision float)"><code>++lte:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rs' data-tippy-content="Less than / equal (single-precision float)"><code>++lte:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rq' data-tippy-content="Less than / equal (quad-precision float)"><code>++lte:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#lth' data-tippy-content="Less than (atom)"><code>++lth</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-ff' data-tippy-content="Less than (IEEE float)"><code>++lth:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-fl' data-tippy-content="Less than (signed and unsigned integer cell)"><code>++lth:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rd' data-tippy-content="Less than (double-precision float)"><code>++lth:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rh' data-tippy-content="Less than (half-precision float)"><code>++lth:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rs' data-tippy-content="Less than (single-precision float)"><code>++lth:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rq' data-tippy-content="Less than (quad-precision float)"><code>++lth:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lug-fl' data-tippy-content="Central rounding mechanism"><code>++lug:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#lus' data-tippy-content="Parse + (lus)"><code>++lus</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4d/#lust' data-tippy-content="Detect new line"><code>++lust</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#less' data-tippy-content="Parse unless"><code>++less</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#ly' data-tippy-content="List from raw noun"><code>++ly</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4d/#last' title="Further trace"><code>++last</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#le-nl' title="Construct list from null-terminated noun"><code>++le:nl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#lent' title="List length"><code>++lent</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#levy' title="Logical AND on list"><code>++levy</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lfe-fl' title="Maximum"><code>++lfe:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lfn-fl' title="Largest normal float"><code>++lfn:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#lien' title="Logical OR on list"><code>++lien</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#lift' title="Curried bind"><code>++lift</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#like' title="Generic edge"><code>++like</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#limb' title="Reference into subject by name/axis"><code>++limb</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#limo' title="Construct list from null-terminated tuple"><code>++limo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#line' title="(Undocumented)"><code>++line</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#lip-ag' title="Parse IPv4 address"><code>++lip:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#list' title="Mold constructor (list)"><code>++list</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#lone' title="Mold generator (face on mold)"><code>++lone</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#lor' title="Leg order"><code>++lor</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#low' title="Parse lowercase letter"><code>++low</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#lsh' title="Left-shift"><code>++lsh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#lte' title="Less than / equal (atom)"><code>++lte</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-ff' title="Less than / equal (IEEE float)"><code>++lte:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-fl' title="Less than / equal (producing flag)"><code>++lte:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rd' title="Less than / equal (double-precision float)"><code>++lte:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rh' title="Less than / equal (half-precision float)"><code>++lte:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rs' title="Less than / equal (single-precision float)"><code>++lte:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rq' title="Less than / equal (quad-precision float)"><code>++lte:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#lth' title="Less than (atom)"><code>++lth</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-ff' title="Less than (IEEE float)"><code>++lth:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-fl' title="Less than (signed and unsigned integer cell)"><code>++lth:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rd' title="Less than (double-precision float)"><code>++lth:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rh' title="Less than (half-precision float)"><code>++lth:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rs' title="Less than (single-precision float)"><code>++lth:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rq' title="Less than (quad-precision float)"><code>++lth:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lug-fl' title="Central rounding mechanism"><code>++lug:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#lus' title="Parse + (lus)"><code>++lus</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4d/#lust' title="Detect new line"><code>++lust</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#less' title="Parse unless"><code>++less</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#ly' title="List from raw noun"><code>++ly</code></a>
 
 ### m
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rd' data-tippy-content="Initialize ff (rd core)"><code>++ma:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rh' data-tippy-content="Initialize ff (rh core)"><code>++ma:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rs' data-tippy-content="Initialize ff (rs core)"><code>++ma:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rq' data-tippy-content="Initialize ff (rq core)"><code>++ma:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mack' data-tippy-content="Nock subject to unit"><code>++mack</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2l/#malt' data-tippy-content="Map from list"><code>++malt</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#map' data-tippy-content="Mold generator (map)"><code>++map</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#mar-by' data-tippy-content="Assert and add (map)"><code>+-mar:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#mas' data-tippy-content="Address within head/tail"><code>++mas</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#mask' data-tippy-content="Match character"><code>++mask</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#mat' data-tippy-content="Length-encode"><code>++mat</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#mate' data-tippy-content="Choose"><code>++mate</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#max' data-tippy-content="Maximum"><code>++max</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#me-ff' data-tippy-content="Minimum exponent of ff"><code>++me:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#mean' data-tippy-content="Crash and printf"><code>++mean</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#mes' data-tippy-content="Parse hexabyte"><code>++mes</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#mesc' data-tippy-content="Escape special characters"><code>++mesc</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#met' data-tippy-content="Measure"><code>++met</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#metl' data-tippy-content="(Undocumented)"><code>++metl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#min' data-tippy-content="Minimum (atom)"><code>++min</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mink' data-tippy-content="Mock (virtual Nock) interpreter"><code>++mink</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#mit-yo' data-tippy-content="Seconds in minute"><code>++mit:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#mix' data-tippy-content="Binary XOR (atom)"><code>++mix</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mock' data-tippy-content="Compute formula on subject with hint"><code>++mock</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#mod' data-tippy-content="Modulus (atom)"><code>++mod</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#moh-yo' data-tippy-content="Days in month"><code>++moh:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2l/#molt' data-tippy-content="Map from pair list"><code>++molt</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mong' data-tippy-content="Slam gate with sample"><code>++mong</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mook' data-tippy-content="Intelligently render crash annotation"><code>++mook</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#more' data-tippy-content="Parse list with delimiter"><code>++more</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#most' data-tippy-content="Parse list of at least one match"><code>++most</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#moy-yo' data-tippy-content="Days in months of leap-year"><code>++moy:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#mu' data-tippy-content="Core used to scramble 16-bit atoms"><code>++mu</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#mug' data-tippy-content="FNV-1a scrambler"><code>++mug</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#muk' data-tippy-content="Standard MurmurHash3"><code>++muk</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#mul' data-tippy-content="Multiply (atom)"><code>++mul</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-ff' data-tippy-content="Multiply (IEEE float)"><code>++mul:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-fl' data-tippy-content="Multiply (signed and unsigned integer cell)"><code>++mul:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rd' data-tippy-content="Multiply (double-precision float)"><code>++mul:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rh' data-tippy-content="Multiply (quad-precision float)"><code>++mul:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rs' data-tippy-content="Multiply (single-precision float)"><code>++mul:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rq' data-tippy-content="Multiply (quad-precision float)"><code>++mul:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mule' data-tippy-content="Typed virtual"><code>++mule</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mute' data-tippy-content="Untyped virtual"><code>++mute</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#mum' data-tippy-content="31-bit MurmurHash3 scrambler"><code>++mum</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#murn' data-tippy-content="Maybe transform"><code>++murn</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#my' data-tippy-content="Map from raw noun"><code>++my</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#my-nl' data-tippy-content="Construct map from null-terminated noun"><code>++my:nl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rd' title="Initialize ff (rd core)"><code>++ma:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rh' title="Initialize ff (rh core)"><code>++ma:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rs' title="Initialize ff (rs core)"><code>++ma:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rq' title="Initialize ff (rq core)"><code>++ma:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mack' title="Nock subject to unit"><code>++mack</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2l/#malt' title="Map from list"><code>++malt</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#map' title="Mold generator (map)"><code>++map</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#mar-by' title="Assert and add (map)"><code>+-mar:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#mas' title="Address within head/tail"><code>++mas</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#mask' title="Match character"><code>++mask</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#mat' title="Length-encode"><code>++mat</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#mate' title="Choose"><code>++mate</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#max' title="Maximum"><code>++max</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#me-ff' title="Minimum exponent of ff"><code>++me:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#mean' title="Crash and printf"><code>++mean</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#mes' title="Parse hexabyte"><code>++mes</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#mesc' title="Escape special characters"><code>++mesc</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#met' title="Measure"><code>++met</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#metl' title="(Undocumented)"><code>++metl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#min' title="Minimum (atom)"><code>++min</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mink' title="Mock (virtual Nock) interpreter"><code>++mink</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#mit-yo' title="Seconds in minute"><code>++mit:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#mix' title="Binary XOR (atom)"><code>++mix</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mock' title="Compute formula on subject with hint"><code>++mock</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#mod' title="Modulus (atom)"><code>++mod</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#moh-yo' title="Days in month"><code>++moh:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2l/#molt' title="Map from pair list"><code>++molt</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mong' title="Slam gate with sample"><code>++mong</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mook' title="Intelligently render crash annotation"><code>++mook</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#more' title="Parse list with delimiter"><code>++more</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#most' title="Parse list of at least one match"><code>++most</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#moy-yo' title="Days in months of leap-year"><code>++moy:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#mu' title="Core used to scramble 16-bit atoms"><code>++mu</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#mug' title="FNV-1a scrambler"><code>++mug</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#muk' title="Standard MurmurHash3"><code>++muk</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#mul' title="Multiply (atom)"><code>++mul</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-ff' title="Multiply (IEEE float)"><code>++mul:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-fl' title="Multiply (signed and unsigned integer cell)"><code>++mul:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rd' title="Multiply (double-precision float)"><code>++mul:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rh' title="Multiply (quad-precision float)"><code>++mul:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rs' title="Multiply (single-precision float)"><code>++mul:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rq' title="Multiply (quad-precision float)"><code>++mul:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mule' title="Typed virtual"><code>++mule</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mute' title="Untyped virtual"><code>++mute</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#mum' title="31-bit MurmurHash3 scrambler"><code>++mum</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#murn' title="Maybe transform"><code>++murn</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#my' title="Map from raw noun"><code>++my</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#my-nl' title="Construct map from null-terminated noun"><code>++my:nl</code></a>
 
 ### n
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#nail' data-tippy-content="Location, remainder of parsed text"><code>++nail</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#nap-to' data-tippy-content="Remove head of queue"><code>+-nap:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ne' data-tippy-content="Digit rendering engine"><code>++ne</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ned-fl' data-tippy-content="Require float"><code>++ned:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#need' data-tippy-content="Unwrap unit"><code>++need</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#net-fe' data-tippy-content="Flip endianness"><code>++net:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#new-si' data-tippy-content="Atom to @s"><code>++new:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#next' data-tippy-content="Consume character"><code>++next</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#nip-to' data-tippy-content="Remove root of queue"><code>+-nip:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#nix' data-tippy-content="Parse letters and -"><code>++nix</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#nl' data-tippy-content="Noun to container operations"><code>++nl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#nock' data-tippy-content="Virtual machine (see Nock)"><code>++nock</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#not' data-tippy-content="Binary NOT (atom)"><code>++not</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#noun' data-tippy-content="(Undocumented)"><code>++noun</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#nuck-so' data-tippy-content="Top-level coin parser"><code>++nuck:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#nud' data-tippy-content="Parse numeric character"><code>++nud</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#null' data-tippy-content="(Undocumented)"><code>++null</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#nusk-so' data-tippy-content="Parse coin literal with escapes"><code>++nusk:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#nail' title="Location, remainder of parsed text"><code>++nail</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#nap-to' title="Remove head of queue"><code>+-nap:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ne' title="Digit rendering engine"><code>++ne</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ned-fl' title="Require float"><code>++ned:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#need' title="Unwrap unit"><code>++need</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#net-fe' title="Flip endianness"><code>++net:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#new-si' title="Atom to @s"><code>++new:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#next' title="Consume character"><code>++next</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#nip-to' title="Remove root of queue"><code>+-nip:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#nix' title="Parse letters and -"><code>++nix</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#nl' title="Noun to container operations"><code>++nl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#nock' title="Virtual machine (see Nock)"><code>++nock</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#not' title="Binary NOT (atom)"><code>++not</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#noun' title="(Undocumented)"><code>++noun</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#nuck-so' title="Top-level coin parser"><code>++nuck:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#nud' title="Parse numeric character"><code>++nud</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#null' title="(Undocumented)"><code>++null</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#nusk-so' title="Parse coin literal with escapes"><code>++nusk:so</code></a>
 
 ### o
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#ob' data-tippy-content="Reversible scrambling v2"><code>++ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#og' data-tippy-content="Container arm for SHA-256 powered RNG"><code>++og</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#old-si' data-tippy-content="Sign and absolute value"><code>++old:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#oust' data-tippy-content="Remove from list"><code>++oust</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#out-fe' data-tippy-content="Maximum integer value"><code>++out:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#ob' title="Reversible scrambling v2"><code>++ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#og' title="Container arm for SHA-256 powered RNG"><code>++og</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#old-si' title="Sign and absolute value"><code>++old:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#oust' title="Remove from list"><code>++oust</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#out-fe' title="Maximum integer value"><code>++out:fe</code></a>
 
 ### p
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#pa-ff' data-tippy-content="Initialize fl from ff core"><code>++pa:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#pair' data-tippy-content="Mold of pair of types"><code>++pair</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pam' data-tippy-content="Parse & (pam)"><code>++pam</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pat' data-tippy-content="Parse @ (pat)"><code>++pat</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#path' data-tippy-content="Filesystem path"><code>++path</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#peg' data-tippy-content="Address within address"><code>++peg</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pel' data-tippy-content="Parse ( (pel)"><code>++pel</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#per' data-tippy-content="Parse ) (per)"><code>++per</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#perd-so' data-tippy-content="Parses dime/tiple without standard prefixes"><code>++perd:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#pev-ab' data-tippy-content="Parse <=5 in base 32"><code>++pev:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#pew-ab' data-tippy-content="Parse <= 5 in base 64"><code>++pew:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#pfix' data-tippy-content="Discard first rule"><code>++pfix</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#pint' data-tippy-content="Parsing range"><code>++pint</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#piv-ab' data-tippy-content="Parse 5 digits in base 32"><code>++piv:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#piw-ab' data-tippy-content="Parse 5 digits in base 64"><code>++piw:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#plug' data-tippy-content="Parse to tuple"><code>++plug</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#plus' data-tippy-content="List of at least one match"><code>++plus</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#po' data-tippy-content="Phonetic base"><code>++po</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#pole' data-tippy-content="Mold generator of faceless list"><code>++pole</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#port' data-tippy-content="(Undocumented)"><code>++port</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#pose' data-tippy-content="Parse options"><code>++pose</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2g/#pow' data-tippy-content="Computes a to the power of b"><code>++pow</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#prc-fl' data-tippy-content="Force precision of 2 or greater (floating point)"><code>++prc:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#prn' data-tippy-content="Parse any printable character"><code>++prn</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#pro-fo' data-tippy-content="Multiplies b and c modulo a"><code>++pro:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#pro-si' data-tippy-content="Multiply to signed integer"><code>++pro:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#put-by' data-tippy-content="Add key-value pair (map)"><code>+-put:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#put-in' data-tippy-content="Put b in a (set)"><code>+-put:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#put-ju' data-tippy-content="Add key-set pair (jar)"><code>+-put:ju</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#put-to' data-tippy-content="Insert into queue"><code>+-put:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#pa-ff' title="Initialize fl from ff core"><code>++pa:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#pair' title="Mold of pair of types"><code>++pair</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pam' title="Parse & (pam)"><code>++pam</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pat' title="Parse @ (pat)"><code>++pat</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#path' title="Filesystem path"><code>++path</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#peg' title="Address within address"><code>++peg</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pel' title="Parse ( (pel)"><code>++pel</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#per' title="Parse ) (per)"><code>++per</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#perd-so' title="Parses dime/tiple without standard prefixes"><code>++perd:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#pev-ab' title="Parse <=5 in base 32"><code>++pev:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#pew-ab' title="Parse <= 5 in base 64"><code>++pew:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#pfix' title="Discard first rule"><code>++pfix</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#pint' title="Parsing range"><code>++pint</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#piv-ab' title="Parse 5 digits in base 32"><code>++piv:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#piw-ab' title="Parse 5 digits in base 64"><code>++piw:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#plug' title="Parse to tuple"><code>++plug</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#plus' title="List of at least one match"><code>++plus</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#po' title="Phonetic base"><code>++po</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#pole' title="Mold generator of faceless list"><code>++pole</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#port' title="(Undocumented)"><code>++port</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#pose' title="Parse options"><code>++pose</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2g/#pow' title="Computes a to the power of b"><code>++pow</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#prc-fl' title="Force precision of 2 or greater (floating point)"><code>++prc:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#prn' title="Parse any printable character"><code>++prn</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#pro-fo' title="Multiplies b and c modulo a"><code>++pro:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#pro-si' title="Multiply to signed integer"><code>++pro:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#put-by' title="Add key-value pair (map)"><code>+-put:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#put-in' title="Put b in a (set)"><code>+-put:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#put-ju' title="Add key-set pair (jar)"><code>+-put:ju</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#put-to' title="Insert into queue"><code>+-put:to</code></a>
 
 ### q
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#qad-yo' data-tippy-content="Seconds in 4 years"><code>++qad:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qeb-ab' data-tippy-content="Parse <=4 binary digits"><code>++qeb:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#qeu' data-tippy-content="Mold generator (queue)"><code>++qeu</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qex-ab' data-tippy-content="Parse <=4 hexadecimal digits"><code>++qex:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qib-ab' data-tippy-content="Parse 4 binary digits"><code>++qib:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#qit' data-tippy-content="Parse character to cord atom"><code>++qit</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qix-ab' data-tippy-content="Parse 4 hexadecimal digits"><code>++qix:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#quip' data-tippy-content="Mold generator (tuple of list and type)"><code>++quip</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#qut' data-tippy-content="Parse cord"><code>++qut</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#qad-yo' title="Seconds in 4 years"><code>++qad:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qeb-ab' title="Parse <=4 binary digits"><code>++qeb:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#qeu' title="Mold generator (queue)"><code>++qeu</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qex-ab' title="Parse <=4 hexadecimal digits"><code>++qex:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qib-ab' title="Parse 4 binary digits"><code>++qib:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#qit' title="Parse character to cord atom"><code>++qit</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qix-ab' title="Parse 4 hexadecimal digits"><code>++qix:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#quip' title="Mold generator (tuple of list and type)"><code>++quip</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#qut' title="Parse cord"><code>++qut</code></a>
 
 ### r
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#r-at' data-tippy-content="(Undocumented)"><code>++r:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#rad-og' data-tippy-content="Random in range"><code>++rad:og</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#rads-og' data-tippy-content="Random continuation"><code>++rads:og</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#raku-ob' data-tippy-content="Key list"><code>++raku:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#ram-re' data-tippy-content="Flatten tank to tape"><code>++ram:re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rap' data-tippy-content="Assemble non-zero"><code>++rap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rash' data-tippy-content="Parse or crash"><code>++rash</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rau-fl' data-tippy-content="Various roundings (floating point)"><code>++rau:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#raw-og' data-tippy-content="Random bits"><code>++raw:og</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#raws-og' data-tippy-content="Random bits continuation"><code>++raws:og</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#re' data-tippy-content="Pretty-printing engine (tank)"><code>++re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rear-co' data-tippy-content="Prepend and render atom as tape"><code>++rear:co</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#reap' data-tippy-content="Replicate (list)"><code>++reap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#reel' data-tippy-content="Right fold (list)"><code>++reel</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#rem-si' data-tippy-content="Remainder (signed integer)"><code>++rem:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rend-co' data-tippy-content="Render coin lot as tape"><code>++rend:co</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rent-co' data-tippy-content="Render coin lot as span"><code>++rent:co</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rep' data-tippy-content="Assemble single"><code>++rep</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rep-by' data-tippy-content="Replace by product (map)"><code>+-rep:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#rep-in' data-tippy-content="Accumulate elements (set)"><code>+-rep:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rf-at' data-tippy-content="(Undocumented)"><code>++rf:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rib-by' data-tippy-content="Replace values with accumulator (map)"><code>+-rib:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#rig-re' data-tippy-content="Wrap tape in / (tank)"><code>++rig:re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rip' data-tippy-content="Disassemble"><code>++rip</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rn-at' data-tippy-content="(Undocumented)"><code>++rn:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rol-fe' data-tippy-content="Roll left"><code>++rol:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#roll' data-tippy-content="Left fold (list)"><code>++roll</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#r-at' title="(Undocumented)"><code>++r:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#rad-og' title="Random in range"><code>++rad:og</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#rads-og' title="Random continuation"><code>++rads:og</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#raku-ob' title="Key list"><code>++raku:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#ram-re' title="Flatten tank to tape"><code>++ram:re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rap' title="Assemble non-zero"><code>++rap</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rash' title="Parse or crash"><code>++rash</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rau-fl' title="Various roundings (floating point)"><code>++rau:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#raw-og' title="Random bits"><code>++raw:og</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#raws-og' title="Random bits continuation"><code>++raws:og</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#re' title="Pretty-printing engine (tank)"><code>++re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rear-co' title="Prepend and render atom as tape"><code>++rear:co</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#reap' title="Replicate (list)"><code>++reap</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#reel' title="Right fold (list)"><code>++reel</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#rem-si' title="Remainder (signed integer)"><code>++rem:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rend-co' title="Render coin lot as tape"><code>++rend:co</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rent-co' title="Render coin lot as span"><code>++rent:co</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rep' title="Assemble single"><code>++rep</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rep-by' title="Replace by product (map)"><code>+-rep:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#rep-in' title="Accumulate elements (set)"><code>+-rep:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rf-at' title="(Undocumented)"><code>++rf:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rib-by' title="Replace values with accumulator (map)"><code>+-rib:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#rig-re' title="Wrap tape in / (tank)"><code>++rig:re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rip' title="Disassemble"><code>++rip</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rn-at' title="(Undocumented)"><code>++rn:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rol-fe' title="Roll left"><code>++rol:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#roll' title="Left fold (list)"><code>++roll</code></a>
 <code>++rood</code>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#ror-fe' data-tippy-content="Roll right"><code>++ror:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rou-fl' data-tippy-content="Round to nearest float with 113-bit significand"><code>++rou:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#royl-so' data-tippy-content="Parse dime float"><code>++royl:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#royl-cell-so' data-tippy-content="(Undocumented)"><code>++royl-cell:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rsh' data-tippy-content="Right-shift"><code>++rsh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rt-at' data-tippy-content="(Undocumented)"><code>++rt:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rta-at' data-tippy-content="(Undocumented)"><code>++rta:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rtam-at' data-tippy-content="(Undocumented)"><code>++rtam:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#rub' data-tippy-content="Length-decode"><code>++rub</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rub-at' data-tippy-content="(Undocumented)"><code>++rub:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rud-at' data-tippy-content="(Undocumented)"><code>++rud:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#rule' data-tippy-content="Parsing rule (match this with _)"><code>++rule</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rum-at' data-tippy-content="(Undocumented)"><code>++rum:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#run-by' data-tippy-content="Transform values (map)"><code>+-run:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#run-in' data-tippy-content="Apply gate to set"><code>+-run:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#rund-ob' data-tippy-content="Reverse single Feistel-like"><code>++rund:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#runt' data-tippy-content="Prepend n times"><code>++runt</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rup-at' data-tippy-content="(Undocumented)"><code>++rup:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rush' data-tippy-content="Parse or null"><code>++rush</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rust' data-tippy-content="Parse tape or null"><code>++rust</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rut-by' data-tippy-content="Transform nodes (map)"><code>+-rut:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#ruv-at' data-tippy-content="(Undocumented)"><code>++ruv:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rux-at' data-tippy-content="(Undocumented)"><code>++rux:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#rynd-ob' data-tippy-content="Reverse Feistel-like cipher"><code>++rynd:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#ror-fe' title="Roll right"><code>++ror:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rou-fl' title="Round to nearest float with 113-bit significand"><code>++rou:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#royl-so' title="Parse dime float"><code>++royl:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#royl-cell-so' title="(Undocumented)"><code>++royl-cell:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rsh' title="Right-shift"><code>++rsh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rt-at' title="(Undocumented)"><code>++rt:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rta-at' title="(Undocumented)"><code>++rta:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rtam-at' title="(Undocumented)"><code>++rtam:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#rub' title="Length-decode"><code>++rub</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rub-at' title="(Undocumented)"><code>++rub:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rud-at' title="(Undocumented)"><code>++rud:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#rule' title="Parsing rule (match this with _)"><code>++rule</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rum-at' title="(Undocumented)"><code>++rum:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#run-by' title="Transform values (map)"><code>+-run:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#run-in' title="Apply gate to set"><code>+-run:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#rund-ob' title="Reverse single Feistel-like"><code>++rund:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#runt' title="Prepend n times"><code>++runt</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rup-at' title="(Undocumented)"><code>++rup:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rush' title="Parse or null"><code>++rush</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rust' title="Parse tape or null"><code>++rust</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rut-by' title="Transform nodes (map)"><code>+-rut:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#ruv-at' title="(Undocumented)"><code>++ruv:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rux-at' title="(Undocumented)"><code>++rux:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#rynd-ob' title="Reverse Feistel-like cipher"><code>++rynd:ob</code></a>
 
 ### s
 
@@ -811,36 +811,36 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 1a: basic arithmetic
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#add' data-tippy-content="Add"><code>++add</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#dec' data-tippy-content="Decrement"><code>++dec</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#div' data-tippy-content="Divide"><code>++div</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#dvr' data-tippy-content="Divide (with remainder)"><code>++dvr</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#gte' data-tippy-content="Greater than / equal"><code>++gte</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#gth' data-tippy-content="Greater than"><code>++gth</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#lte' data-tippy-content="Less than / equal (atom)"><code>++lte</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#lth' data-tippy-content="Less than (atom)"><code>++lth</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#max' data-tippy-content="Maximum"><code>++max</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#min' data-tippy-content="Minimum (atom)"><code>++min</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#mod' data-tippy-content="Modulus (atom)"><code>++mod</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#mul' data-tippy-content="Multiply (atom)"><code>++mul</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#add' title="Add"><code>++add</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#dec' title="Decrement"><code>++dec</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#div' title="Divide"><code>++div</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#dvr' title="Divide (with remainder)"><code>++dvr</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#gte' title="Greater than / equal"><code>++gte</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#gth' title="Greater than"><code>++gth</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#lte' title="Less than / equal (atom)"><code>++lte</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#lth' title="Less than (atom)"><code>++lth</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#max' title="Maximum"><code>++max</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#min' title="Minimum (atom)"><code>++min</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#mod' title="Modulus (atom)"><code>++mod</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#mul' title="Multiply (atom)"><code>++mul</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#sub'><code>++sub</code></a>
 
 ### 1b: tree addressing
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#cap' data-tippy-content="Tree head"><code>++cap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#mas' data-tippy-content="Address within head/tail"><code>++mas</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#peg' data-tippy-content="Address within address"><code>++peg</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#cap' title="Tree head"><code>++cap</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#mas' title="Address within head/tail"><code>++mas</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#peg' title="Address within address"><code>++peg</code></a>
 
 ### 1c: molds and mold builders
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#bloq' data-tippy-content="Blocksize"><code>++bloq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#each' data-tippy-content="Mold of fork between two types"><code>++each</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#gate' data-tippy-content="Function"><code>++gate</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#list' data-tippy-content="Mold constructor (list)"><code>++list</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#lone' data-tippy-content="Mold generator (face on mold)"><code>++lone</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#pair' data-tippy-content="Mold of pair of types"><code>++pair</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#pole' data-tippy-content="Mold generator of faceless list"><code>++pole</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#quip' data-tippy-content="Mold generator (tuple of list and type)"><code>++quip</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#bloq' title="Blocksize"><code>++bloq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#each' title="Mold of fork between two types"><code>++each</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#gate' title="Function"><code>++gate</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#list' title="Mold constructor (list)"><code>++list</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#lone' title="Mold generator (face on mold)"><code>++lone</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#pair' title="Mold of pair of types"><code>++pair</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#pole' title="Mold generator of faceless list"><code>++pole</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#quip' title="Mold generator (tuple of list and type)"><code>++quip</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#trap'><code>++trap</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#tree'><code>++tree</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#trel'><code>++trel</code></a>
@@ -848,34 +848,34 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 2a: unit logic
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#biff' data-tippy-content="Unit as argument"><code>++biff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#bind' data-tippy-content="Non-unit function to unit, producing unit"><code>++bind</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#bond' data-tippy-content="Replace null"><code>++bond</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#both' data-tippy-content="Group unit values into pair"><code>++both</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#clap' data-tippy-content="Apply function to two units"><code>++clap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#drop' data-tippy-content="Unit to list"><code>++drop</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#fall' data-tippy-content="Give unit a default value"><code>++fall</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#lift' data-tippy-content="Curried bind"><code>++lift</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#mate' data-tippy-content="Choose"><code>++mate</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#need' data-tippy-content="Unwrap unit"><code>++need</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#biff' title="Unit as argument"><code>++biff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#bind' title="Non-unit function to unit, producing unit"><code>++bind</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#bond' title="Replace null"><code>++bond</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#both' title="Group unit values into pair"><code>++both</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#clap' title="Apply function to two units"><code>++clap</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#drop' title="Unit to list"><code>++drop</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#fall' title="Give unit a default value"><code>++fall</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#lift' title="Curried bind"><code>++lift</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#mate' title="Choose"><code>++mate</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#need' title="Unwrap unit"><code>++need</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#some'><code>++some</code></a>
 
 ### 2b: list logic
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#fand' data-tippy-content="All indices in list"><code>++fand</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#find' data-tippy-content="First index in list"><code>++find</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#flop' data-tippy-content="Reverse list"><code>++flop</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#gulf' data-tippy-content="List from range"><code>++gulf</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#homo' data-tippy-content="Homogenize list"><code>++homo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#lent' data-tippy-content="List length"><code>++lent</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#levy' data-tippy-content="Logical AND on list"><code>++levy</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#lien' data-tippy-content="Logical OR on list"><code>++lien</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#limo' data-tippy-content="Construct list from null-terminated tuple"><code>++limo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#murn' data-tippy-content="Maybe transform"><code>++murn</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#oust' data-tippy-content="Remove from list"><code>++oust</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#reap' data-tippy-content="Replicate (list)"><code>++reap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#reel' data-tippy-content="Right fold (list)"><code>++reel</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#roll' data-tippy-content="Left fold (list)"><code>++roll</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#fand' title="All indices in list"><code>++fand</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#find' title="First index in list"><code>++find</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#flop' title="Reverse list"><code>++flop</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#gulf' title="List from range"><code>++gulf</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#homo' title="Homogenize list"><code>++homo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#lent' title="List length"><code>++lent</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#levy' title="Logical AND on list"><code>++levy</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#lien' title="Logical OR on list"><code>++lien</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#limo' title="Construct list from null-terminated tuple"><code>++limo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#murn' title="Maybe transform"><code>++murn</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#oust' title="Remove from list"><code>++oust</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#reap' title="Replicate (list)"><code>++reap</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#reel' title="Right fold (list)"><code>++reel</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#roll' title="Left fold (list)"><code>++roll</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#scag'><code>++scag</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#skid'><code>++skid</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#skim'><code>++skim</code></a>
@@ -894,75 +894,75 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 2c: bit arithmetic
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#fe' data-tippy-content="Modulo bloq"><code>++fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#dif-fe' data-tippy-content="Difference between atoms (modular basis)"><code>++dif:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#inv-fe' data-tippy-content="Inverse order of modular field"><code>++inv:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#net-fe' data-tippy-content="Flip endianness"><code>++net:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#out-fe' data-tippy-content="Maximum integer value"><code>++out:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rol-fe' data-tippy-content="Roll left"><code>++rol:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#ror-fe' data-tippy-content="Roll right"><code>++ror:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#fe' title="Modulo bloq"><code>++fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#dif-fe' title="Difference between atoms (modular basis)"><code>++dif:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#inv-fe' title="Inverse order of modular field"><code>++inv:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#net-fe' title="Flip endianness"><code>++net:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#out-fe' title="Maximum integer value"><code>++out:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rol-fe' title="Roll left"><code>++rol:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#ror-fe' title="Roll right"><code>++ror:fe</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#sit-fe'><code>++sit:fe</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#sum-fe'><code>++sum:fe</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#bex' data-tippy-content="Binary exponent"><code>++bex</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#can' data-tippy-content="Assemble"><code>++can</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#cat' data-tippy-content="Concatenate"><code>++cat</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#cut' data-tippy-content="Slice"><code>++cut</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#end' data-tippy-content="Tail"><code>++end</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#fil' data-tippy-content="Fill bloqstream"><code>++fil</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#lsh' data-tippy-content="Left-shift"><code>++lsh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#met' data-tippy-content="Measure"><code>++met</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rap' data-tippy-content="Assemble non-zero"><code>++rap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rep' data-tippy-content="Assemble single"><code>++rep</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rip' data-tippy-content="Disassemble"><code>++rip</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rsh' data-tippy-content="Right-shift"><code>++rsh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#bex' title="Binary exponent"><code>++bex</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#can' title="Assemble"><code>++can</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#cat' title="Concatenate"><code>++cat</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#cut' title="Slice"><code>++cut</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#end' title="Tail"><code>++end</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#fil' title="Fill bloqstream"><code>++fil</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#lsh' title="Left-shift"><code>++lsh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#met' title="Measure"><code>++met</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rap' title="Assemble non-zero"><code>++rap</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rep' title="Assemble single"><code>++rep</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rip' title="Disassemble"><code>++rip</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rsh' title="Right-shift"><code>++rsh</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#swp'><code>++swp</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#xeb'><code>++xeb</code></a>
 
 ### 2d: bit logic
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#con' data-tippy-content="Binary OR"><code>++con</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#dis' data-tippy-content="Binary AND (atoms)"><code>++dis</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#mix' data-tippy-content="Binary XOR (atom)"><code>++mix</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#not' data-tippy-content="Binary NOT (atom)"><code>++not</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#con' title="Binary OR"><code>++con</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#dis' title="Binary AND (atoms)"><code>++dis</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#mix' title="Binary XOR (atom)"><code>++mix</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#not' title="Binary NOT (atom)"><code>++not</code></a>
 
 ### 2e: insecure hashing
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#fnv' data-tippy-content="FNV scrambler"><code>++fnv</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#mug' data-tippy-content="FNV-1a scrambler"><code>++mug</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#muk' data-tippy-content="Standard MurmurHash3"><code>++muk</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#mum' data-tippy-content="31-bit MurmurHash3 scrambler"><code>++mum</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#fnv' title="FNV scrambler"><code>++fnv</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#mug' title="FNV-1a scrambler"><code>++mug</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#muk' title="Standard MurmurHash3"><code>++muk</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#mum' title="31-bit MurmurHash3 scrambler"><code>++mum</code></a>
 
 ### 2f: noun ordering
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#aor' data-tippy-content="Alphabetical order"><code>++aor</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#dor' data-tippy-content="Numeric order"><code>++dor</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#gor' data-tippy-content="Hash order"><code>++gor</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#hor' data-tippy-content="Horizontal hash order"><code>++hor</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#lor' data-tippy-content="Leg order"><code>++lor</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#aor' title="Alphabetical order"><code>++aor</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#dor' title="Numeric order"><code>++dor</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#gor' title="Hash order"><code>++gor</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#hor' title="Horizontal hash order"><code>++hor</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#lor' title="Leg order"><code>++lor</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#vor'><code>++vor</code></a>
 
 ### 2g: unsigned powers
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2g/#pow' data-tippy-content="Computes a to the power of b"><code>++pow</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2g/#pow' title="Computes a to the power of b"><code>++pow</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2g/#sqt'><code>++sqt</code></a>
 
 ### 2h: set logic
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#in'><code>++in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#all-in' data-tippy-content="Logical AND (set and wet gate)"><code>+-all:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#any-in' data-tippy-content="Logical OR (set and gate)"><code>+-any:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#apt-in' data-tippy-content="Check correctness (set)"><code>+-apt:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#bif-in' data-tippy-content="Bifurcate set"><code>+-bif:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#del-in' data-tippy-content="Delete (set)"><code>+-del:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#dif-in' data-tippy-content='Difference (set)'><code>+-dif:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#dig-in' data-tippy-content="Address of a in set"><code>+-dig:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#gas-in' data-tippy-content="Concatenate (set)"><code>+-gas:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#has-in' data-tippy-content="Key existence check (set)"><code>+-has:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#int-in' data-tippy-content="Intersection (set)"><code>+-int:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#put-in' data-tippy-content="Put b in a (set)"><code>+-put:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#rep-in' data-tippy-content="Accumulate elements (set)"><code>+-rep:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#run-in' data-tippy-content="Apply gate to set"><code>+-run:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#all-in' title="Logical AND (set and wet gate)"><code>+-all:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#any-in' title="Logical OR (set and gate)"><code>+-any:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#apt-in' title="Check correctness (set)"><code>+-apt:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#bif-in' title="Bifurcate set"><code>+-bif:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#del-in' title="Delete (set)"><code>+-del:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#dif-in' title='Difference (set)'><code>+-dif:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#dig-in' title="Address of a in set"><code>+-dig:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#gas-in' title="Concatenate (set)"><code>+-gas:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#has-in' title="Key existence check (set)"><code>+-has:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#int-in' title="Intersection (set)"><code>+-int:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#put-in' title="Put b in a (set)"><code>+-put:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#rep-in' title="Accumulate elements (set)"><code>+-rep:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#run-in' title="Apply gate to set"><code>+-run:in</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#tap-in'><code>+-tap:in</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#uni-in'><code>+-uni:in</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#wyt-in'><code>+-wyt:in</code></a>
@@ -970,25 +970,25 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### 2i: map logic
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#by'><code>++by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#all-by' data-tippy-content="Logical AND (map and wet gate)"><code>+-all:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#any-by' data-tippy-content="Logical OR (map and wet gate)"><code>+-any:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#apt-by' data-tippy-content="Check correctness (map)"><code>+-apt:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#bif-by' data-tippy-content="Bifurcate map"><code>+-bif:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#def-by' data-tippy-content="Difference (map)"><code>+-def:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#del-by' data-tippy-content="Delete (map)"><code>+-del:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#dep-by' data-tippy-content="Difference as patch (map)"><code>+-dep:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#dig-by' data-tippy-content="Address of key (map)"><code>+-dig:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#gas-by' data-tippy-content="Concatenate (map)"><code>+-gas:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#get-by' data-tippy-content="Grab unit value"><code>+-get:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#got-by' data-tippy-content="Assert for value (map)"><code>+-got:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#has-by' data-tippy-content="Key existence check (map)"><code>+-has:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#int-by' data-tippy-content="Intersection (map)"><code>+-int:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#mar-by' data-tippy-content="Assert and add (map)"><code>+-mar:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#put-by' data-tippy-content="Add key-value pair (map)"><code>+-put:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rep-by' data-tippy-content="Replace by product (map)"><code>+-rep:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rib-by' data-tippy-content="Replace values with accumulator (map)"><code>+-rib:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#run-by' data-tippy-content="Transform values (map)"><code>+-run:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rut-by' data-tippy-content="Transform nodes (map)"><code>+-rut:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#all-by' title="Logical AND (map and wet gate)"><code>+-all:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#any-by' title="Logical OR (map and wet gate)"><code>+-any:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#apt-by' title="Check correctness (map)"><code>+-apt:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#bif-by' title="Bifurcate map"><code>+-bif:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#def-by' title="Difference (map)"><code>+-def:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#del-by' title="Delete (map)"><code>+-del:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#dep-by' title="Difference as patch (map)"><code>+-dep:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#dig-by' title="Address of key (map)"><code>+-dig:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#gas-by' title="Concatenate (map)"><code>+-gas:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#get-by' title="Grab unit value"><code>+-get:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#got-by' title="Assert for value (map)"><code>+-got:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#has-by' title="Key existence check (map)"><code>+-has:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#int-by' title="Intersection (map)"><code>+-int:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#mar-by' title="Assert and add (map)"><code>+-mar:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#put-by' title="Add key-value pair (map)"><code>+-put:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rep-by' title="Replace by product (map)"><code>+-rep:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rib-by' title="Replace values with accumulator (map)"><code>+-rib:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#run-by' title="Transform values (map)"><code>+-run:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rut-by' title="Transform nodes (map)"><code>+-rut:by</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#tap-by'><code>+-tap:by</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#uni-by'><code>+-uni:by</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#urn-by'><code>+-urn:by</code></a>
@@ -996,57 +996,57 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 2j: jar and jug logic
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#ja' data-tippy-content="Jar engine"><code>++ja</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#add-ja' data-tippy-content="Prepend to list"><code>+-add:ja</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#get-ja' data-tippy-content="Grab value by key"><code>+-get:ja</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#ja' title="Jar engine"><code>++ja</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#add-ja' title="Prepend to list"><code>+-add:ja</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#get-ja' title="Grab value by key"><code>+-get:ja</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#ju' data-tippy-content="Jug operations"><code>++ju</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#del-ju' data-tippy-content="Delete (jug)"><code>+-del:ju</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#get-ju' data-tippy-content="Retrieve set"><code>+-get:ju</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#has-ju' data-tippy-content="Check contents (jug)"><code>+-has:ju</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#put-ju' data-tippy-content="Add key-set pair (jar)"><code>+-put:ju</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#ju' title="Jug operations"><code>++ju</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#del-ju' title="Delete (jug)"><code>+-del:ju</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#get-ju' title="Retrieve set"><code>+-get:ju</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#has-ju' title="Check contents (jug)"><code>+-has:ju</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#put-ju' title="Add key-set pair (jar)"><code>+-put:ju</code></a>
 
 ### 2k: queue logic
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#to'><code>++to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#bal-to' data-tippy-content="Balance queue"><code>+-bal:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#dep-to' data-tippy-content="Maximum depth (queue)"><code>+-dep:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#gas-to' data-tippy-content="Push list into queue"><code>+-gas:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#get-to' data-tippy-content="Head-tail pair"><code>+-get:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#nap-to' data-tippy-content="Remove head of queue"><code>+-nap:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#nip-to' data-tippy-content="Remove root of queue"><code>+-nip:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#put-to' data-tippy-content="Insert into queue"><code>+-put:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#bal-to' title="Balance queue"><code>+-bal:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#dep-to' title="Maximum depth (queue)"><code>+-dep:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#gas-to' title="Push list into queue"><code>+-gas:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#get-to' title="Head-tail pair"><code>+-get:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#nap-to' title="Remove head of queue"><code>+-nap:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#nip-to' title="Remove root of queue"><code>+-nip:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#put-to' title="Insert into queue"><code>+-put:to</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#tap-to'><code>+-tap:to</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#top-to'><code>+-top:to</code></a>
 
 ### 2l: container from container
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2l/#malt' data-tippy-content="Map from list"><code>++malt</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2l/#molt' data-tippy-content="Map from pair list"><code>++molt</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2l/#malt' title="Map from list"><code>++malt</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2l/#molt' title="Map from pair list"><code>++molt</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2l/#silt'><code>++silt</code></a>
 
 ### 2m: container from noun
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#nl' data-tippy-content="Noun to container operations"><code>++nl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#le-nl' data-tippy-content="Construct list from null-terminated noun"><code>++le:nl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#my-nl' data-tippy-content="Construct map from null-terminated noun"><code>++my:nl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#nl' title="Noun to container operations"><code>++nl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#le-nl' title="Construct list from null-terminated noun"><code>++le:nl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#my-nl' title="Construct map from null-terminated noun"><code>++my:nl</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#si-nl'><code>++si:nl</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#snag-nl'><code>++snag:nl</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#weld-nl'><code>++weld:nl</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#ly' data-tippy-content="List from raw noun"><code>++ly</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#my' data-tippy-content="Map from raw noun"><code>++my</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#ly' title="List from raw noun"><code>++ly</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#my' title="Map from raw noun"><code>++my</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#sy'><code>++sy</code></a>
 
 ### 2n: functional hacks
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#cork' data-tippy-content="Compose forward"><code>++cork</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#corl' data-tippy-content="Compose backward"><code>++corl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#curr' data-tippy-content="Right-curry a gate"><code>++curr</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#cury' data-tippy-content="Curry left a gate"><code>++cury</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#hard' data-tippy-content="Force remold"><code>++hard</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#head' data-tippy-content="Get head of cell"><code>++head</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#mean' data-tippy-content="Crash and printf"><code>++mean</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#cork' title="Compose forward"><code>++cork</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#corl' title="Compose backward"><code>++corl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#curr' title="Right-curry a gate"><code>++curr</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#cury' title="Curry left a gate"><code>++cury</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#hard' title="Force remold"><code>++hard</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#head' title="Get head of cell"><code>++head</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#mean' title="Crash and printf"><code>++mean</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#same'><code>++same</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#slog'><code>++slog</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#soft'><code>++soft</code></a>
@@ -1055,25 +1055,25 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 2o: normalizing containers
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#jar' data-tippy-content="Mold generator (jar)"><code>++jar</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#jug' data-tippy-content="Mold generator (jug)"><code>++jug</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#map' data-tippy-content="Mold generator (map)"><code>++map</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#qeu' data-tippy-content="Mold generator (queue)"><code>++qeu</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#jar' title="Mold generator (jar)"><code>++jar</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#jug' title="Mold generator (jug)"><code>++jug</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#map' title="Mold generator (map)"><code>++map</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#qeu' title="Mold generator (queue)"><code>++qeu</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#set'><code>++set</code></a>
 
 ### 2p: serialization
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#cue' data-tippy-content="Unpack atom to noun"><code>++cue</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#jam' data-tippy-content="Pack noun to atom"><code>++jam</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#mat' data-tippy-content="Length-encode"><code>++mat</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#rub' data-tippy-content="Length-decode"><code>++rub</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#cue' title="Unpack atom to noun"><code>++cue</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#jam' title="Pack noun to atom"><code>++jam</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#mat' title="Length-encode"><code>++mat</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#rub' title="Length-decode"><code>++rub</code></a>
 
 ### 2q: molds and mold builders
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#char' data-tippy-content="Character"><code>++char</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#cord' data-tippy-content="UTF-8 text"><code>++cord</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#date' data-tippy-content="Point in time"><code>++date</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#knot' data-tippy-content="Atom type of ASCII characters"><code>++knot</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#char' title="Character"><code>++char</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#cord' title="UTF-8 text"><code>++cord</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#date' title="Point in time"><code>++date</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#knot' title="Atom type of ASCII characters"><code>++knot</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#tang'><code>++tang</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#tank'><code>++tank</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2q/#tape'><code>++tape</code></a>
@@ -1084,30 +1084,30 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 3a: modular and signed ints
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fo' data-tippy-content="Modulo prime"><code>++fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dif-fo' data-tippy-content='Subtraction (modular base)'><code>++dif:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#exp-fo' data-tippy-content="Exponent (modular base)"><code>++exp:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fra-fo' data-tippy-content="Divide (modular base)"><code>++fra:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#inv-fo' data-tippy-content="Inverse (signed modulus)"><code>++inv:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#pro-fo' data-tippy-content="Multiplies b and c modulo a"><code>++pro:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fo' title="Modulo prime"><code>++fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dif-fo' title='Subtraction (modular base)'><code>++dif:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#exp-fo' title="Exponent (modular base)"><code>++exp:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fra-fo' title="Divide (modular base)"><code>++fra:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#inv-fo' title="Inverse (signed modulus)"><code>++inv:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#pro-fo' title="Multiplies b and c modulo a"><code>++pro:fo</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#sit-fo'><code>++sit:fo</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#sum-fo'><code>++sum:fo</code></a>
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#si'><code>++si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#abs-si' data-tippy-content="Absolute value (signed integer)"><code>++abs:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#cmp-si' data-tippy-content="Compare (signed integer)"><code>++cmp:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dif-si' data-tippy-content="Subtraction (signed integer)"><code>++dif:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dul-si' data-tippy-content="Modulus (signed integer)"><code>++dul:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fra-si' data-tippy-content="Divide (signed integer)"><code>++fra:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#new-si' data-tippy-content="Atom to @s"><code>++new:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#old-si' data-tippy-content="Sign and absolute value"><code>++old:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#pro-si' data-tippy-content="Multiply to signed integer"><code>++pro:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#rem-si' data-tippy-content="Remainder (signed integer)"><code>++rem:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#abs-si' title="Absolute value (signed integer)"><code>++abs:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#cmp-si' title="Compare (signed integer)"><code>++cmp:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dif-si' title="Subtraction (signed integer)"><code>++dif:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dul-si' title="Modulus (signed integer)"><code>++dul:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fra-si' title="Divide (signed integer)"><code>++fra:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#new-si' title="Atom to @s"><code>++new:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#old-si' title="Sign and absolute value"><code>++old:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#pro-si' title="Multiply to signed integer"><code>++pro:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#rem-si' title="Remainder (signed integer)"><code>++rem:si</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#sum-si'><code>++sum:si</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#sun-si'><code>++sun:si</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#syn-si'><code>++syn:si</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#egcd' data-tippy-content="Extended Euclidean algorithm"><code>++egcd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#egcd' title="Extended Euclidean algorithm"><code>++egcd</code></a>
 
 ### 3b: floating point
 
@@ -1116,22 +1116,22 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rn'><code>++rn</code></a>
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ff'><code>++ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-ff' data-tippy-content="Add (floating point)"><code>++add:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bif-ff' data-tippy-content="Converts from fn to @r"><code>++bif:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-ff' data-tippy-content="fn to @r with rounding"><code>++bit:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-ff' data-tippy-content="Divide (IEEE float)"><code>++div:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-ff' data-tippy-content="@r to decimal float"><code>++drg:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-ff' data-tippy-content="Equals (IEEE float)"><code>++equ:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-ff' data-tippy-content="Get exponent (IEEE float)"><code>++exp:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-ff' data-tippy-content="Fused multiply-add (IEEE float)"><code>++fma:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-ff' data-tippy-content="Decimal float to @r"><code>++grd:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-ff' data-tippy-content="Greater than / equal (IEEE float)"><code>++gte:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-ff' data-tippy-content="Greater than (IEEE float)"><code>++gth:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-ff' data-tippy-content="Less than / equal (IEEE float)"><code>++lte:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-ff' data-tippy-content="Less than (IEEE float)"><code>++lth:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#me-ff' data-tippy-content="Minimum exponent of ff"><code>++me:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-ff' data-tippy-content="Multiply (IEEE float)"><code>++mul:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#pa-ff' data-tippy-content="Initialize fl from ff core"><code>++pa:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-ff' title="Add (floating point)"><code>++add:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bif-ff' title="Converts from fn to @r"><code>++bif:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-ff' title="fn to @r with rounding"><code>++bit:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-ff' title="Divide (IEEE float)"><code>++div:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-ff' title="@r to decimal float"><code>++drg:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-ff' title="Equals (IEEE float)"><code>++equ:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-ff' title="Get exponent (IEEE float)"><code>++exp:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-ff' title="Fused multiply-add (IEEE float)"><code>++fma:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-ff' title="Decimal float to @r"><code>++grd:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-ff' title="Greater than / equal (IEEE float)"><code>++gte:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-ff' title="Greater than (IEEE float)"><code>++gth:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-ff' title="Less than / equal (IEEE float)"><code>++lte:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-ff' title="Less than (IEEE float)"><code>++lth:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#me-ff' title="Minimum exponent of ff"><code>++me:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-ff' title="Multiply (IEEE float)"><code>++mul:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#pa-ff' title="Initialize fl from ff core"><code>++pa:ff</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-ff'><code>++san:ff</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sb-ff'><code>++sb:ff</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sea-ff'><code>++sea:ff</code></a>
@@ -1142,33 +1142,33 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toi-ff'><code>++toi:ff</code></a>
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fl'><code>++fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#abs-fl' data-tippy-content="Absolute value"><code>++abs:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-fl' data-tippy-content="Add (with exact/rounded flag)"><code>++add:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#den-fl' data-tippy-content="Denormalizes (floating point)"><code>++den:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-fl' data-tippy-content="Divide (signed and unsigned integer cell)"><code>++div:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-fl' data-tippy-content="Get printable decimal (signed and unsigned integer cell)"><code>++drg:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ead-fl' data-tippy-content="Exact add"><code>++ead:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emn-fl' data-tippy-content="Minimum exponent"><code>++emn:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emu-fl' data-tippy-content="Exact multiply"><code>++emu:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emx-fl' data-tippy-content="Maximum exponent"><code>++emx:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-fl' data-tippy-content="Equals (signed and unsigned integer cell)"><code>++equ:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fli-fl' data-tippy-content="Flip sign"><code>++fli:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-fl' data-tippy-content="Fused multiply-add"><code>++fma:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-fl' data-tippy-content="Decimal to float"><code>++grd:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-fl' data-tippy-content="Greater than / equal (producing flag)"><code>++gte:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-fl' data-tippy-content="Greater than (producing flag)"><code>++gth:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ibl-fl' data-tippy-content="Integer binary logarithm"><code>++ibl:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#inv-fl' data-tippy-content="Inverse"><code>++inv:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lfe-fl' data-tippy-content="Maximum"><code>++lfe:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lfn-fl' data-tippy-content="Largest normal float"><code>++lfn:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-fl' data-tippy-content="Less than / equal (producing flag)"><code>++lte:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-fl' data-tippy-content="Less than (signed and unsigned integer cell)"><code>++lth:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lug-fl' data-tippy-content="Central rounding mechanism"><code>++lug:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-fl' data-tippy-content="Multiply (signed and unsigned integer cell)"><code>++mul:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ned-fl' data-tippy-content="Require float"><code>++ned:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#prc-fl' data-tippy-content="Force precision of 2 or greater (floating point)"><code>++prc:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rau-fl' data-tippy-content="Various roundings (floating point)"><code>++rau:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rou-fl' data-tippy-content="Round to nearest float with 113-bit significand"><code>++rou:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#abs-fl' title="Absolute value"><code>++abs:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-fl' title="Add (with exact/rounded flag)"><code>++add:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#den-fl' title="Denormalizes (floating point)"><code>++den:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-fl' title="Divide (signed and unsigned integer cell)"><code>++div:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-fl' title="Get printable decimal (signed and unsigned integer cell)"><code>++drg:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ead-fl' title="Exact add"><code>++ead:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emn-fl' title="Minimum exponent"><code>++emn:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emu-fl' title="Exact multiply"><code>++emu:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#emx-fl' title="Maximum exponent"><code>++emx:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-fl' title="Equals (signed and unsigned integer cell)"><code>++equ:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fli-fl' title="Flip sign"><code>++fli:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-fl' title="Fused multiply-add"><code>++fma:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-fl' title="Decimal to float"><code>++grd:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-fl' title="Greater than / equal (producing flag)"><code>++gte:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-fl' title="Greater than (producing flag)"><code>++gth:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ibl-fl' title="Integer binary logarithm"><code>++ibl:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#inv-fl' title="Inverse"><code>++inv:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lfe-fl' title="Maximum"><code>++lfe:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lfn-fl' title="Largest normal float"><code>++lfn:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-fl' title="Less than / equal (producing flag)"><code>++lte:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-fl' title="Less than (signed and unsigned integer cell)"><code>++lth:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lug-fl' title="Central rounding mechanism"><code>++lug:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-fl' title="Multiply (signed and unsigned integer cell)"><code>++mul:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ned-fl' title="Require float"><code>++ned:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#prc-fl' title="Force precision of 2 or greater (floating point)"><code>++prc:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rau-fl' title="Various roundings (floating point)"><code>++rau:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rou-fl' title="Round to nearest float with 113-bit significand"><code>++rou:fl</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-fl'><code>++san:fl</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#shf-fl'><code>++shf:fl</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#spd-fl'><code>++spd:fl</code></a>
@@ -1185,20 +1185,20 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#zer-fl'><code>++zer:fl</code></a>
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rd'><code>++rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rd' data-tippy-content="Add (double-precision float)"><code>++add:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rd' data-tippy-content="fn to double-precision binary float"><code>++bit:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rd' data-tippy-content="Double precision float"><code>++div:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rd' data-tippy-content="@rd to decimal float"><code>++drg:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rd' data-tippy-content="Equals (double-precision float)"><code>++equ:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rd' data-tippy-content="Exponent (@rd)"><code>++exp:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rd' data-tippy-content="Fused multiply-add (@rd)"><code>++fma:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rd' data-tippy-content="Decimal float to @rd"><code>++grd:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rd' data-tippy-content="Greater than / equal (double-precision float)"><code>++gte:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rd' data-tippy-content="Greater than (double-precision float)"><code>++gth:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rd' data-tippy-content="Less than / equal (double-precision float)"><code>++lte:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rd' data-tippy-content="Less than (double-precision float)"><code>++lth:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rd' data-tippy-content="Initialize ff (rd core)"><code>++ma:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rd' data-tippy-content="Multiply (double-precision float)"><code>++mul:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rd' title="Add (double-precision float)"><code>++add:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rd' title="fn to double-precision binary float"><code>++bit:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rd' title="Double precision float"><code>++div:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rd' title="@rd to decimal float"><code>++drg:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rd' title="Equals (double-precision float)"><code>++equ:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rd' title="Exponent (@rd)"><code>++exp:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rd' title="Fused multiply-add (@rd)"><code>++fma:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rd' title="Decimal float to @rd"><code>++grd:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rd' title="Greater than / equal (double-precision float)"><code>++gte:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rd' title="Greater than (double-precision float)"><code>++gth:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rd' title="Less than / equal (double-precision float)"><code>++lte:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rd' title="Less than (double-precision float)"><code>++lth:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rd' title="Initialize ff (rd core)"><code>++ma:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rd' title="Multiply (double-precision float)"><code>++mul:rd</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-rd'><code>++san:rd</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sea-rd'><code>++sea:rd</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sig-rd'><code>++sig:rd</code></a>
@@ -1208,21 +1208,21 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toi-rd'><code>++toi:rd</code></a>
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rh'><code>++rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rh' data-tippy-content="Add (half-precision float)"><code>++add:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rh' data-tippy-content="fn to half-precision float"><code>++bit:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rh' data-tippy-content="Divide (half-precision float)"><code>++div:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rh' data-tippy-content="@rh to decimal float"><code>++drg:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rh' data-tippy-content="Equals (half-precision float)"><code>++equ:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rh' data-tippy-content="Exponent (half-precision float)"><code>++exp:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rh' data-tippy-content="Fused multiply-add (half-precision float)"><code>++fma:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fos-rh' data-tippy-content="@rs to @rh"><code>++fos:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rh' data-tippy-content="Decimal float to @rh"><code>++grd:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rh' data-tippy-content="Greater than / equal (half-precision float)"><code>++gte:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rh' data-tippy-content="Greater than (half-precision float)"><code>++gth:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rh' data-tippy-content="Less than / equal (half-precision float)"><code>++lte:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rh' data-tippy-content="Less than (half-precision float)"><code>++lth:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rh' data-tippy-content="Initialize ff (rh core)"><code>++ma:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rh' data-tippy-content="Multiply (quad-precision float)"><code>++mul:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rh' title="Add (half-precision float)"><code>++add:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rh' title="fn to half-precision float"><code>++bit:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rh' title="Divide (half-precision float)"><code>++div:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rh' title="@rh to decimal float"><code>++drg:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rh' title="Equals (half-precision float)"><code>++equ:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rh' title="Exponent (half-precision float)"><code>++exp:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rh' title="Fused multiply-add (half-precision float)"><code>++fma:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fos-rh' title="@rs to @rh"><code>++fos:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rh' title="Decimal float to @rh"><code>++grd:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rh' title="Greater than / equal (half-precision float)"><code>++gte:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rh' title="Greater than (half-precision float)"><code>++gth:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rh' title="Less than / equal (half-precision float)"><code>++lte:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rh' title="Less than (half-precision float)"><code>++lth:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rh' title="Initialize ff (rh core)"><code>++ma:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rh' title="Multiply (quad-precision float)"><code>++mul:rh</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-rh'><code>++san:rh</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sea-rh'><code>++sea:rh</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sig-rh'><code>++sig:rh</code></a>
@@ -1233,20 +1233,20 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#tos-rh'><code>++tos:rh</code></a>
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rs'><code>++rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rs' data-tippy-content="Add (single-precision float)"><code>++add:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rs' data-tippy-content="fn to single-precision float"><code>++bit:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rs' data-tippy-content="Divide (single-precision float)"><code>++div:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rs' data-tippy-content="@rs to decimal float"><code>++drg:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rs' data-tippy-content="Equals (single-precision float)"><code>++equ:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rs' data-tippy-content="Exponent (@rs)"><code>++exp:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rs' data-tippy-content="Fused multiply-add (single-precision float)"><code>++fma:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rs' data-tippy-content="Decimal float to @rs"><code>++grd:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rs' data-tippy-content="Greater than / equal (single-precision float)"><code>++gte:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rs' data-tippy-content="Greater than (single-precision float)"><code>++gth:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rs' data-tippy-content="Less than / equal (single-precision float)"><code>++lte:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rs' data-tippy-content="Less than (single-precision float)"><code>++lth:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rs' data-tippy-content="Initialize ff (rs core)"><code>++ma:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rs' data-tippy-content="Multiply (single-precision float)"><code>++mul:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rs' title="Add (single-precision float)"><code>++add:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rs' title="fn to single-precision float"><code>++bit:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rs' title="Divide (single-precision float)"><code>++div:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rs' title="@rs to decimal float"><code>++drg:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rs' title="Equals (single-precision float)"><code>++equ:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rs' title="Exponent (@rs)"><code>++exp:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rs' title="Fused multiply-add (single-precision float)"><code>++fma:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rs' title="Decimal float to @rs"><code>++grd:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rs' title="Greater than / equal (single-precision float)"><code>++gte:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rs' title="Greater than (single-precision float)"><code>++gth:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rs' title="Less than / equal (single-precision float)"><code>++lte:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rs' title="Less than (single-precision float)"><code>++lth:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rs' title="Initialize ff (rs core)"><code>++ma:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rs' title="Multiply (single-precision float)"><code>++mul:rs</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-rs'><code>++san:rs</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sea-rs'><code>++sea:rs</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sig-rs'><code>++sig:rs</code></a>
@@ -1256,20 +1256,20 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#toi-rs'><code>++toi:rs</code></a>
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rq'><code>++rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rq' data-tippy-content="Add (quad-precision float)"><code>++add:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rq' data-tippy-content="fn to quad-precision float"><code>++bit:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rq' data-tippy-content="Divide (quad-precision float)"><code>++div:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rq' data-tippy-content="@rq to decimal float"><code>++drg:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rq' data-tippy-content="Equals (quad-precision float)"><code>++equ:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rq' data-tippy-content="Exponent (quad-precision float)"><code>++exp:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rq' data-tippy-content="Fused multiply-add (quad-precision float)"><code>++fma:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rq' data-tippy-content="Decimal float to @rq"><code>++grd:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rq' data-tippy-content="Greater than / equal (quad-precision float)"><code>++gte:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rq' data-tippy-content="Greater than (quad-precision float)"><code>++gth:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rq' data-tippy-content="Less than / equal (quad-precision float)"><code>++lte:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rq' data-tippy-content="Less than (quad-precision float)"><code>++lth:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rq' data-tippy-content="Initialize ff (rq core)"><code>++ma:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rq' data-tippy-content="Multiply (quad-precision float)"><code>++mul:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#add-rq' title="Add (quad-precision float)"><code>++add:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#bit-rq' title="fn to quad-precision float"><code>++bit:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#div-rq' title="Divide (quad-precision float)"><code>++div:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#drg-rq' title="@rq to decimal float"><code>++drg:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#equ-rq' title="Equals (quad-precision float)"><code>++equ:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#exp-rq' title="Exponent (quad-precision float)"><code>++exp:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#fma-rq' title="Fused multiply-add (quad-precision float)"><code>++fma:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rq' title="Decimal float to @rq"><code>++grd:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rq' title="Greater than / equal (quad-precision float)"><code>++gte:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rq' title="Greater than (quad-precision float)"><code>++gth:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rq' title="Less than / equal (quad-precision float)"><code>++lte:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rq' title="Less than (quad-precision float)"><code>++lth:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rq' title="Initialize ff (rq core)"><code>++ma:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rq' title="Multiply (quad-precision float)"><code>++mul:rq</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-rq'><code>++san:rq</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sea-rq'><code>++sea:rq</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sig-rq'><code>++sig:rq</code></a>
@@ -1290,15 +1290,15 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### 3c: urbit time
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yo'><code>++yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#cet-yo' data-tippy-content="Days in a century"><code>++cet:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#day-yo' data-tippy-content="Seconds in day"><code>++day:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#era-yo' data-tippy-content="Leap-year period"><code>++era:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#hor-yo' data-tippy-content="Seconds in hour"><code>++hor:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#jes-yo' data-tippy-content="Maximum 64-bit timestamp"><code>++jes:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#mit-yo' data-tippy-content="Seconds in minute"><code>++mit:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#moh-yo' data-tippy-content="Days in month"><code>++moh:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#moy-yo' data-tippy-content="Days in months of leap-year"><code>++moy:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#qad-yo' data-tippy-content="Seconds in 4 years"><code>++qad:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#cet-yo' title="Days in a century"><code>++cet:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#day-yo' title="Seconds in day"><code>++day:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#era-yo' title="Leap-year period"><code>++era:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#hor-yo' title="Seconds in hour"><code>++hor:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#jes-yo' title="Maximum 64-bit timestamp"><code>++jes:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#mit-yo' title="Seconds in minute"><code>++mit:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#moh-yo' title="Days in month"><code>++moh:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#moy-yo' title="Days in months of leap-year"><code>++moy:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#qad-yo' title="Seconds in 4 years"><code>++qad:yo</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yer-yo'><code>++yer:yo</code></a>
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yall'><code>++yall</code></a>
@@ -1311,11 +1311,11 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 3d: SHA hash family
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#og' data-tippy-content="Container arm for SHA-256 powered RNG"><code>++og</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#rad-og' data-tippy-content="Random in range"><code>++rad:og</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#rads-og' data-tippy-content="Random continuation"><code>++rads:og</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#raw-og' data-tippy-content="Random bits"><code>++raw:og</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#raws-og' data-tippy-content="Random bits continuation"><code>++raws:og</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#og' title="Container arm for SHA-256 powered RNG"><code>++og</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#rad-og' title="Random in range"><code>++rad:og</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#rads-og' title="Random continuation"><code>++rads:og</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#raw-og' title="Random bits"><code>++raw:og</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#raws-og' title="Random bits continuation"><code>++raws:og</code></a>
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shad'><code>++shad</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shaf'><code>++shaf</code></a>
@@ -1334,13 +1334,13 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 3f: scrambling
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#ob' data-tippy-content="Reversible scrambling v2"><code>++ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#feen-ob' data-tippy-content="Conceal structure v2"><code>++feen:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#fend-ob' data-tippy-content="Restore structure v2"><code>++fend:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#fice-ob' data-tippy-content="Feistel-like cipher"><code>++fice:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#raku-ob' data-tippy-content="Key list"><code>++raku:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#rund-ob' data-tippy-content="Reverse single Feistel-like"><code>++rund:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#rynd-ob' data-tippy-content="Reverse Feistel-like cipher"><code>++rynd:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#ob' title="Reversible scrambling v2"><code>++ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#feen-ob' title="Conceal structure v2"><code>++feen:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#fend-ob' title="Restore structure v2"><code>++fend:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#fice-ob' title="Feistel-like cipher"><code>++fice:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#raku-ob' title="Key list"><code>++raku:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#rund-ob' title="Reverse single Feistel-like"><code>++rund:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#rynd-ob' title="Reverse Feistel-like cipher"><code>++rynd:ob</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#teil-ob'><code>++teil:ob</code></a>
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#un'><code>++un</code></a>
@@ -1355,15 +1355,15 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 3g: molds and mold builders
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#coin' data-tippy-content="Noun-literal syntax cases"><code>++coin</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#dime' data-tippy-content="Aura-atom pair"><code>++dime</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#edge' data-tippy-content="Parsing location metadata"><code>++edge</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#hair' data-tippy-content="Parsing line and column"><code>++hair</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#like' data-tippy-content="Generic edge"><code>++like</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#nail' data-tippy-content="Location, remainder of parsed text"><code>++nail</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#path' data-tippy-content="Filesystem path"><code>++path</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#pint' data-tippy-content="Parsing range"><code>++pint</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#rule' data-tippy-content="Parsing rule (match this with _)"><code>++rule</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#coin' title="Noun-literal syntax cases"><code>++coin</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#dime' title="Aura-atom pair"><code>++dime</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#edge' title="Parsing location metadata"><code>++edge</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#hair' title="Parsing line and column"><code>++hair</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#like' title="Generic edge"><code>++like</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#nail' title="Location, remainder of parsed text"><code>++nail</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#path' title="Filesystem path"><code>++path</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#pint' title="Parsing range"><code>++pint</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#rule' title="Parsing rule (match this with _)"><code>++rule</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#spot'><code>++spot</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#tone'><code>++tone</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#toon'><code>++toon</code></a>
@@ -1371,33 +1371,33 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 4a: exotic bases
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#po' data-tippy-content="Phonetic base"><code>++po</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#ind-po' data-tippy-content="Parse suffix"><code>++ind:po</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#ins-po' data-tippy-content="Parse prefix"><code>++ins:po</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#po' title="Phonetic base"><code>++po</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#ind-po' title="Parse suffix"><code>++ind:po</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#ins-po' title="Parse prefix"><code>++ins:po</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#tod-po'><code>++tod:po</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#tos-po'><code>++tos:po</code></a>
 
 ### 4b: text processing
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#at' data-tippy-content="(Undocumented)"><code>++at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#r-at' data-tippy-content="(Undocumented)"><code>++r:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rf-at' data-tippy-content="(Undocumented)"><code>++rf:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rn-at' data-tippy-content="(Undocumented)"><code>++rn:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rt-at' data-tippy-content="(Undocumented)"><code>++rt:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rta-at' data-tippy-content="(Undocumented)"><code>++rta:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rtam-at' data-tippy-content="(Undocumented)"><code>++rtam:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rub-at' data-tippy-content="(Undocumented)"><code>++rub:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rud-at' data-tippy-content="(Undocumented)"><code>++rud:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rum-at' data-tippy-content="(Undocumented)"><code>++rum:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rup-at' data-tippy-content="(Undocumented)"><code>++rup:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#ruv-at' data-tippy-content="(Undocumented)"><code>++ruv:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rux-at' data-tippy-content="(Undocumented)"><code>++rux:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#at' title="(Undocumented)"><code>++at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#r-at' title="(Undocumented)"><code>++r:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rf-at' title="(Undocumented)"><code>++rf:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rn-at' title="(Undocumented)"><code>++rn:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rt-at' title="(Undocumented)"><code>++rt:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rta-at' title="(Undocumented)"><code>++rta:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rtam-at' title="(Undocumented)"><code>++rtam:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rub-at' title="(Undocumented)"><code>++rub:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rud-at' title="(Undocumented)"><code>++rud:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rum-at' title="(Undocumented)"><code>++rum:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rup-at' title="(Undocumented)"><code>++rup:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#ruv-at' title="(Undocumented)"><code>++ruv:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rux-at' title="(Undocumented)"><code>++rux:at</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#cass' data-tippy-content="To lowercase"><code>++cass</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#crip' data-tippy-content="Tape to cord"><code>++crip</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#cuss' data-tippy-content="To uppercase"><code>++cuss</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#mesc' data-tippy-content="Escape special characters"><code>++mesc</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#runt' data-tippy-content="Prepend n times"><code>++runt</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#cass' title="To lowercase"><code>++cass</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#crip' title="Tape to cord"><code>++crip</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#cuss' title="To uppercase"><code>++cuss</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#mesc' title="Escape special characters"><code>++mesc</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#runt' title="Prepend n times"><code>++runt</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#sand'><code>++sand</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#sane'><code>++sane</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#teff'><code>++teff</code></a>
@@ -1414,11 +1414,11 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 4c: tank printer
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#re' data-tippy-content="Pretty-printing engine (tank)"><code>++re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#din-re' data-tippy-content="(Undocumented)"><code>++din:re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#fit-re' data-tippy-content="Fit on one line test"><code>++fit:re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#ram-re' data-tippy-content="Flatten tank to tape"><code>++ram:re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#rig-re' data-tippy-content="Wrap tape in / (tank)"><code>++rig:re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#re' title="Pretty-printing engine (tank)"><code>++re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#din-re' title="(Undocumented)"><code>++din:re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#fit-re' title="Fit on one line test"><code>++fit:re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#ram-re' title="Flatten tank to tape"><code>++ram:re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#rig-re' title="Wrap tape in / (tank)"><code>++rig:re</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#wig-re'><code>++wig:re</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#win-re'><code>++win:re</code></a>
 
@@ -1428,41 +1428,41 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 4d: parsing (tracing)
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4d/#last' data-tippy-content="Further trace"><code>++last</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4d/#lust' data-tippy-content="Detect new line"><code>++lust</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4d/#last' title="Further trace"><code>++last</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4d/#lust' title="Detect new line"><code>++lust</code></a>
 
 ### 4e: parsing (combinators)
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#bend' data-tippy-content="Conditional composer"><code>++bend</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#comp' data-tippy-content="Arbitrary compose"><code>++comp</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#fail' data-tippy-content="Never parse"><code>++fail</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#glue' data-tippy-content="Skip delimiter"><code>++glue</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#less' data-tippy-content="Parse unless"><code>++less</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#pfix' data-tippy-content="Discard first rule"><code>++pfix</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#plug' data-tippy-content="Parse to tuple"><code>++plug</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#pose' data-tippy-content="Parse options"><code>++pose</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#bend' title="Conditional composer"><code>++bend</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#comp' title="Arbitrary compose"><code>++comp</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#fail' title="Never parse"><code>++fail</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#glue' title="Skip delimiter"><code>++glue</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#less' title="Parse unless"><code>++less</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#pfix' title="Discard first rule"><code>++pfix</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#plug' title="Parse to tuple"><code>++plug</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#pose' title="Parse options"><code>++pose</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#sfix'><code>++sfix</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#simu'><code>++simu</code></a>
 
 ### 4f: parsing (rule builders)
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#bass' data-tippy-content="Parser modifier (LSB-ordered ++list as atom of ++base)"><code>++bass</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#boss' data-tippy-content="Parser modifier: LSB"><code>++boss</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#cold' data-tippy-content="Replace with constant"><code>++cold</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#cook' data-tippy-content="Apply gate"><code>++cook</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#easy' data-tippy-content="Always parse"><code>++easy</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#full' data-tippy-content="Parse to end"><code>++full</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#funk' data-tippy-content="Add to tape"><code>++funk</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#here' data-tippy-content="Place-based apply"><code>++here</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#ifix' data-tippy-content="Infix"><code>++ifix</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#jest' data-tippy-content="Match a cord"><code>++jest</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#just' data-tippy-content="Match a single character"><code>++just</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#knee' data-tippy-content="Recursive parsers"><code>++knee</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#mask' data-tippy-content="Match character"><code>++mask</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#more' data-tippy-content="Parse list with delimiter"><code>++more</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#most' data-tippy-content="Parse list of at least one match"><code>++most</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#next' data-tippy-content="Consume character"><code>++next</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#plus' data-tippy-content="List of at least one match"><code>++plus</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#bass' title="Parser modifier (LSB-ordered ++list as atom of ++base)"><code>++bass</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#boss' title="Parser modifier: LSB"><code>++boss</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#cold' title="Replace with constant"><code>++cold</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#cook' title="Apply gate"><code>++cook</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#easy' title="Always parse"><code>++easy</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#full' title="Parse to end"><code>++full</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#funk' title="Add to tape"><code>++funk</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#here' title="Place-based apply"><code>++here</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#ifix' title="Infix"><code>++ifix</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#jest' title="Match a cord"><code>++jest</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#just' title="Match a single character"><code>++just</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#knee' title="Recursive parsers"><code>++knee</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#mask' title="Match character"><code>++mask</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#more' title="Parse list with delimiter"><code>++more</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#most' title="Parse list of at least one match"><code>++most</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#next' title="Consume character"><code>++next</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#plus' title="List of at least one match"><code>++plus</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#sear'><code>++sear</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#shim'><code>++shim</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#slug'><code>++slug</code></a>
@@ -1475,36 +1475,36 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 4g: parsing (outside caller)
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rash' data-tippy-content="Parse or crash"><code>++rash</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rush' data-tippy-content="Parse or null"><code>++rush</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rust' data-tippy-content="Parse tape or null"><code>++rust</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rash' title="Parse or crash"><code>++rash</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rush' title="Parse or null"><code>++rush</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rust' title="Parse tape or null"><code>++rust</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#scan'><code>++scan</code></a>
 
 ### 4h: parsing (ascii glyphs)
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ace' data-tippy-content="Parse space"><code>++ace</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#bar' data-tippy-content="Parse | (bar)"><code>++bar</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#bas' data-tippy-content="Parse \ (bas)"><code>++bas</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#buc' data-tippy-content="Parse $ (buc)"><code>++buc</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#cab' data-tippy-content="Parse _ (cab)"><code>++cab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#cen' data-tippy-content="Parse % (cen)"><code>++cen</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#col' data-tippy-content="Parse : (col)"><code>++col</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#com' data-tippy-content="Parse , (comma)"><code>++com</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#doq' data-tippy-content="Parse double quote"><code>++doq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#dot' data-tippy-content="Parse period"><code>++dot</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#fas' data-tippy-content="Parse / (fas)"><code>++fas</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#gal' data-tippy-content="Parse < (gal)"><code>++gal</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#gar' data-tippy-content="Parse > (gar)"><code>++gar</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#hax' data-tippy-content="Parse # (hax)"><code>++hax</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#hep' data-tippy-content="Parse - (hep)"><code>++hep</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#kel' data-tippy-content="Parse { (kel)"><code>++kel</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ker' data-tippy-content="Parse } (ker)"><code>++ker</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ket' data-tippy-content="Parse ^ (ket)"><code>++ket</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#lus' data-tippy-content="Parse + (lus)"><code>++lus</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pam' data-tippy-content="Parse & (pam)"><code>++pam</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pat' data-tippy-content="Parse @ (pat)"><code>++pat</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pel' data-tippy-content="Parse ( (pel)"><code>++pel</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#per' data-tippy-content="Parse ) (per)"><code>++per</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ace' title="Parse space"><code>++ace</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#bar' title="Parse | (bar)"><code>++bar</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#bas' title="Parse \ (bas)"><code>++bas</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#buc' title="Parse $ (buc)"><code>++buc</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#cab' title="Parse _ (cab)"><code>++cab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#cen' title="Parse % (cen)"><code>++cen</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#col' title="Parse : (col)"><code>++col</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#com' title="Parse , (comma)"><code>++com</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#doq' title="Parse double quote"><code>++doq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#dot' title="Parse period"><code>++dot</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#fas' title="Parse / (fas)"><code>++fas</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#gal' title="Parse < (gal)"><code>++gal</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#gar' title="Parse > (gar)"><code>++gar</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#hax' title="Parse # (hax)"><code>++hax</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#hep' title="Parse - (hep)"><code>++hep</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#kel' title="Parse { (kel)"><code>++kel</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ker' title="Parse } (ker)"><code>++ker</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ket' title="Parse ^ (ket)"><code>++ket</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#lus' title="Parse + (lus)"><code>++lus</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pam' title="Parse & (pam)"><code>++pam</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pat' title="Parse @ (pat)"><code>++pat</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pel' title="Parse ( (pel)"><code>++pel</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#per' title="Parse ) (per)"><code>++per</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#sel'><code>++sel</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#sem'><code>++sem</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ser'><code>++ser</code></a>
@@ -1518,37 +1518,37 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 4i: parsing (useful idioms)
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#alf' data-tippy-content="Parse alphabetic characters"><code>++alf</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#aln' data-tippy-content="Parse alphanumeric characters"><code>++aln</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#alp' data-tippy-content="Parse alphanumeric characters and -"><code>++alp</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#bet' data-tippy-content="Parse hep and lus axis syntax"><code>++bet</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#bin' data-tippy-content="Binary to atom"><code>++bin</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#but' data-tippy-content="Parse binary digit"><code>++but</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#cit' data-tippy-content="Octal digit"><code>++cit</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dem' data-tippy-content="Decimal to atom"><code>++dem</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dit' data-tippy-content="Decimal digit"><code>++dit</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dog' data-tippy-content="Optional gap"><code>++dog</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#doh' data-tippy-content="@p separator"><code>++doh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dun' data-tippy-content="-- to ~"><code>++dun</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#duz' data-tippy-content="== to ~"><code>++duz</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gah' data-tippy-content="New line or ''"><code>++gah</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gap' data-tippy-content="Plural whitespace"><code>++gap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gaq' data-tippy-content="End of line"><code>++gaq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gaw' data-tippy-content="Classic whitespace"><code>++gaw</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gay' data-tippy-content="Optional gap"><code>++gay</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gon' data-tippy-content="Parse long numbers"><code>++gon</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gul' data-tippy-content="Axis syntax < or >"><code>++gul</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hex' data-tippy-content="Hexadecimal to atom"><code>++hex</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hig' data-tippy-content="Parse single uppercase letter"><code>++hig</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hit' data-tippy-content="Parse single hexadecimal digit"><code>++hit</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#iny' data-tippy-content="Indentation block"><code>++iny</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#low' data-tippy-content="Parse lowercase letter"><code>++low</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#mes' data-tippy-content="Parse hexabyte"><code>++mes</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#nix' data-tippy-content="Parse letters and -"><code>++nix</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#nud' data-tippy-content="Parse numeric character"><code>++nud</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#prn' data-tippy-content="Parse any printable character"><code>++prn</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#qit' data-tippy-content="Parse character to cord atom"><code>++qit</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#qut' data-tippy-content="Parse cord"><code>++qut</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#alf' title="Parse alphabetic characters"><code>++alf</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#aln' title="Parse alphanumeric characters"><code>++aln</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#alp' title="Parse alphanumeric characters and -"><code>++alp</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#bet' title="Parse hep and lus axis syntax"><code>++bet</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#bin' title="Binary to atom"><code>++bin</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#but' title="Parse binary digit"><code>++but</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#cit' title="Octal digit"><code>++cit</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dem' title="Decimal to atom"><code>++dem</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dit' title="Decimal digit"><code>++dit</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dog' title="Optional gap"><code>++dog</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#doh' title="@p separator"><code>++doh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#dun' title="-- to ~"><code>++dun</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#duz' title="== to ~"><code>++duz</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gah' title="New line or ''"><code>++gah</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gap' title="Plural whitespace"><code>++gap</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gaq' title="End of line"><code>++gaq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gaw' title="Classic whitespace"><code>++gaw</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gay' title="Optional gap"><code>++gay</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gon' title="Parse long numbers"><code>++gon</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#gul' title="Axis syntax < or >"><code>++gul</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hex' title="Hexadecimal to atom"><code>++hex</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hig' title="Parse single uppercase letter"><code>++hig</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hit' title="Parse single hexadecimal digit"><code>++hit</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#iny' title="Indentation block"><code>++iny</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#low' title="Parse lowercase letter"><code>++low</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#mes' title="Parse hexabyte"><code>++mes</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#nix' title="Parse letters and -"><code>++nix</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#nud' title="Parse numeric character"><code>++nud</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#prn' title="Parse any printable character"><code>++prn</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#qit' title="Parse character to cord atom"><code>++qit</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#qut' title="Parse cord"><code>++qut</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#soz'><code>++soz</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#sym'><code>++sym</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#ven'><code>++ven</code></a>
@@ -1557,19 +1557,19 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 4j: parsing (bases and base digits)
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ab' data-tippy-content="Primitive parser engine"><code>++ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#bix-ab' data-tippy-content="Parse hex pair"><code>++bix:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hif-ab' data-tippy-content="Parse phonetic pair"><code>++hif:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#huf-ab' data-tippy-content="Parse two phonetic pairs"><code>++huf:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hyf-ab' data-tippy-content="Parse 8 phonetic bytes"><code>++hyf:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#pev-ab' data-tippy-content="Parse <=5 in base 32"><code>++pev:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#pew-ab' data-tippy-content="Parse <= 5 in base 64"><code>++pew:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#piv-ab' data-tippy-content="Parse 5 digits in base 32"><code>++piv:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#piw-ab' data-tippy-content="Parse 5 digits in base 64"><code>++piw:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qeb-ab' data-tippy-content="Parse <=4 binary digits"><code>++qeb:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qex-ab' data-tippy-content="Parse <=4 hexadecimal digits"><code>++qex:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qib-ab' data-tippy-content="Parse 4 binary digits"><code>++qib:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qix-ab' data-tippy-content="Parse 4 hexadecimal digits"><code>++qix:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ab' title="Primitive parser engine"><code>++ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#bix-ab' title="Parse hex pair"><code>++bix:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hif-ab' title="Parse phonetic pair"><code>++hif:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#huf-ab' title="Parse two phonetic pairs"><code>++huf:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hyf-ab' title="Parse 8 phonetic bytes"><code>++hyf:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#pev-ab' title="Parse <=5 in base 32"><code>++pev:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#pew-ab' title="Parse <= 5 in base 64"><code>++pew:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#piv-ab' title="Parse 5 digits in base 32"><code>++piv:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#piw-ab' title="Parse 5 digits in base 64"><code>++piw:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qeb-ab' title="Parse <=4 binary digits"><code>++qeb:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qex-ab' title="Parse <=4 hexadecimal digits"><code>++qex:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qib-ab' title="Parse 4 binary digits"><code>++qib:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qix-ab' title="Parse 4 hexadecimal digits"><code>++qix:ab</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#seb-ab'><code>++seb:ab</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sed-ab'><code>++sed:ab</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sev-ab'><code>++sev:ab</code></a>
@@ -1592,48 +1592,48 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#urt-ab'><code>++urt:ab</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#voy-ab'><code>++voy:ab</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ag' data-tippy-content="Top-level atom parser engine"><code>++ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ape-ag' data-tippy-content="Parse 0 or rule"><code>++ape:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#bay-ag' data-tippy-content="Parses binary number"><code>++bay:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#bip-ag' data-tippy-content="Parse IPv6"><code>++bip:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dem-ag' data-tippy-content="Parse decmal with dots"><code>++dem:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dim-ag' data-tippy-content="Parse decimal number"><code>++dim:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dum-ag' data-tippy-content="Parse decimal with leading zero"><code>++dum:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#fed-ag' data-tippy-content="Parse @p"><code>++fed:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hex-ag' data-tippy-content="Parse hexadecimal number"><code>++hex:ag</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#lip-ag' data-tippy-content="Parse IPv4 address"><code>++lip:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ag' title="Top-level atom parser engine"><code>++ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ape-ag' title="Parse 0 or rule"><code>++ape:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#bay-ag' title="Parses binary number"><code>++bay:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#bip-ag' title="Parse IPv6"><code>++bip:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dem-ag' title="Parse decmal with dots"><code>++dem:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dim-ag' title="Parse decimal number"><code>++dim:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#dum-ag' title="Parse decimal with leading zero"><code>++dum:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#fed-ag' title="Parse @p"><code>++fed:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hex-ag' title="Parse hexadecimal number"><code>++hex:ag</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#lip-ag' title="Parse IPv4 address"><code>++lip:ag</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#viz-ag'><code>++viz:ag</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#vum-ag'><code>++vum:ag</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#wiz-ag'><code>++wiz:ag</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#mu' data-tippy-content="Core used to scramble 16-bit atoms"><code>++mu</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#mu' title="Core used to scramble 16-bit atoms"><code>++mu</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#zag-mu'><code>++zag:mu</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#zig-mu'><code>++zig:mu</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#zug-mu'><code>++zug:mu</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ne' data-tippy-content="Digit rendering engine"><code>++ne</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#d-ne' data-tippy-content="Render decimal"><code>++d:ne</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ne' title="Digit rendering engine"><code>++ne</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#d-ne' title="Render decimal"><code>++d:ne</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#v-ne'><code>++v:ne</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#w-ne'><code>++w:ne</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#x-ne'><code>++x:ne</code></a>
 
 ### 4k: parsing (atom printing)
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#co' data-tippy-content="Literal rendering engine"><code>++co</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rear-co' data-tippy-content="Prepend and render atom as tape"><code>++rear:co</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rend-co' data-tippy-content="Render coin lot as tape"><code>++rend:co</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rent-co' data-tippy-content="Render coin lot as span"><code>++rent:co</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#co' title="Literal rendering engine"><code>++co</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rear-co' title="Prepend and render atom as tape"><code>++rear:co</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rend-co' title="Render coin lot as tape"><code>++rend:co</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rent-co' title="Render coin lot as span"><code>++rent:co</code></a>
 
 ### 4l: parsing (atom parsing)
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#so'><code>++so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#bisk-so' data-tippy-content="Parse odor-atom pair"><code>++bisk:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#crub-so' data-tippy-content="Parse @da, @dr, @p, @t"><code>++crub:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#nuck-so' data-tippy-content="Top-level coin parser"><code>++nuck:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#nusk-so' data-tippy-content="Parse coin literal with escapes"><code>++nusk:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#perd-so' data-tippy-content="Parses dime/tiple without standard prefixes"><code>++perd:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#royl-so' data-tippy-content="Parse dime float"><code>++royl:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#royl-cell-so' data-tippy-content="(Undocumented)"><code>++royl-cell:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#bisk-so' title="Parse odor-atom pair"><code>++bisk:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#crub-so' title="Parse @da, @dr, @p, @t"><code>++crub:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#nuck-so' title="Top-level coin parser"><code>++nuck:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#nusk-so' title="Parse coin literal with escapes"><code>++nusk:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#perd-so' title="Parses dime/tiple without standard prefixes"><code>++perd:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#royl-so' title="Parse dime float"><code>++royl:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#royl-cell-so' title="(Undocumented)"><code>++royl-cell:so</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#tash-so'><code>++tash:so</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#twid-so'><code>++twid:so</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#zust-so'><code>++zust:so</code></a>
@@ -1653,33 +1653,33 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 4n: parsing (virtualization)
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mack' data-tippy-content="Nock subject to unit"><code>++mack</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mink' data-tippy-content="Mock (virtual Nock) interpreter"><code>++mink</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mock' data-tippy-content="Compute formula on subject with hint"><code>++mock</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mong' data-tippy-content="Slam gate with sample"><code>++mong</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mook' data-tippy-content="Intelligently render crash annotation"><code>++mook</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mule' data-tippy-content="Typed virtual"><code>++mule</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mute' data-tippy-content="Untyped virtual"><code>++mute</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mack' title="Nock subject to unit"><code>++mack</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mink' title="Mock (virtual Nock) interpreter"><code>++mink</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mock' title="Compute formula on subject with hint"><code>++mock</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mong' title="Slam gate with sample"><code>++mong</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mook' title="Intelligently render crash annotation"><code>++mook</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mule' title="Typed virtual"><code>++mule</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mute' title="Untyped virtual"><code>++mute</code></a>
 
 ### 4o: parsing (molds)
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#abel' data-tippy-content="Compiler alias"><code>++abel</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#aura' data-tippy-content="'Type' of atom"><code>++aura</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#axis' data-tippy-content="Nock axis"><code>++axis</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#base' data-tippy-content="Base type"><code>++base</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#bean' data-tippy-content="Boolean"><code>++bean</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#beer' data-tippy-content="Tape builder"><code>++beer</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#beet' data-tippy-content="XML interpolation cases"><code>++beet</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#chum' data-tippy-content="Jet hint information"><code>++chum</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#coil' data-tippy-content="Tuple of core information"><code>++coil</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#foot' data-tippy-content="Cases of arms by variance model"><code>++foot</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#limb' data-tippy-content="Reference into subject by name/axis"><code>++limb</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#line' data-tippy-content="(Undocumented)"><code>++line</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#metl' data-tippy-content="(Undocumented)"><code>++metl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#nock' data-tippy-content="Virtual machine (see Nock)"><code>++nock</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#noun' data-tippy-content="(Undocumented)"><code>++noun</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#null' data-tippy-content="(Undocumented)"><code>++null</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#port' data-tippy-content="(Undocumented)"><code>++port</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#abel' title="Compiler alias"><code>++abel</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#aura' title="'Type' of atom"><code>++aura</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#axis' title="Nock axis"><code>++axis</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#base' title="Base type"><code>++base</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#bean' title="Boolean"><code>++bean</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#beer' title="Tape builder"><code>++beer</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#beet' title="XML interpolation cases"><code>++beet</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#chum' title="Jet hint information"><code>++chum</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#coil' title="Tuple of core information"><code>++coil</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#foot' title="Cases of arms by variance model"><code>++foot</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#limb' title="Reference into subject by name/axis"><code>++limb</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#line' title="(Undocumented)"><code>++line</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#metl' title="(Undocumented)"><code>++metl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#nock' title="Virtual machine (see Nock)"><code>++nock</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#noun' title="(Undocumented)"><code>++noun</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#null' title="(Undocumented)"><code>++null</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#port' title="(Undocumented)"><code>++port</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#span'><code>++span</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#tiki'><code>++tiki</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#toga'><code>++toga</code></a>

--- a/reference/library/_index.md
+++ b/reference/library/_index.md
@@ -538,274 +538,274 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### s
 
-<a class="tooltip" href='/docs/reference/library/2n/#same'><code>++same</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#san-ff'><code>++san:ff</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#san-fl'><code>++san:fl</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#san-rd'><code>++san:rd</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#san-rh'><code>++san:rh</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#san-rs'><code>++san:rs</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#san-rq'><code>++san:rq</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#sand'><code>++sand</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#sane'><code>++sane</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sb-ff'><code>++sb:ff</code></a>
-<a class="tooltip" href='/docs/reference/library/2b/#scag'><code>++scag</code></a>
-<a class="tooltip" href='/docs/reference/library/4g/#scan'><code>++scan</code></a>
-<a class="tooltip" href='/docs/reference/library/4m/#scot'><code>++scot</code></a>
-<a class="tooltip" href='/docs/reference/library/4m/#scow'><code>++scow</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sea-ff'><code>++sea:ff</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sea-rd'><code>++sea:rd</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sea-rh'><code>++sea:rh</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sea-rs'><code>++sea:rs</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sea-rq'><code>++sea:rq</code></a>
-<a class="tooltip" href='/docs/reference/library/4f/#sear'><code>++sear</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#seb-ab'><code>++seb:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#sed-ab'><code>++sed:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4h/#sel'><code>++sel</code></a>
-<a class="tooltip" href='/docs/reference/library/4h/#sem'><code>++sem</code></a>
-<a class="tooltip" href='/docs/reference/library/4h/#ser'><code>++ser</code></a>
-<a class="tooltip" href='/docs/reference/library/2o/#set'><code>++set</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#sev-ab'><code>++sev:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#sew-ab'><code>++sew:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#sex-ab'><code>++sex:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4e/#sfix'><code>++sfix</code></a>
-<a class="tooltip" href='/docs/reference/library/3d/#shad'><code>++shad</code></a>
-<a class="tooltip" href='/docs/reference/library/3d/#shaf'><code>++shaf</code></a>
-<a class="tooltip" href='/docs/reference/library/3d/#shal'><code>++shal</code></a>
-<a class="tooltip" href='/docs/reference/library/3d/#sham'><code>++sham</code></a>
-<a class="tooltip" href='/docs/reference/library/3d/#shan'><code>++shan</code></a>
-<a class="tooltip" href='/docs/reference/library/3d/#shas'><code>++shas</code></a>
-<a class="tooltip" href='/docs/reference/library/3d/#shaw'><code>++shaw</code></a>
-<a class="tooltip" href='/docs/reference/library/3d/#shax'><code>++shax</code></a>
-<a class="tooltip" href='/docs/reference/library/3d/#shay'><code>++shay</code></a>
-<a class="tooltip" href='/docs/reference/library/3d/#shaz'><code>++shaz</code></a>
-<a class="tooltip" href='/docs/reference/library/4c/#shep'><code>++shep</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#shf-fl'><code>++shf:fl</code></a>
-<a class="tooltip" href='/docs/reference/library/4f/#shim'><code>++shim</code></a>
-<a class="tooltip" href='/docs/reference/library/4c/#shop'><code>++shop</code></a>
-<a class="tooltip" href='/docs/reference/library/4c/#show'><code>++show</code></a>
-<a class="tooltip" href='/docs/reference/library/3a/#si'><code>++si</code></a>
-<a class="tooltip" href='/docs/reference/library/2m/#si-nl'><code>++si:nl</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#sib-ab'><code>++sib:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#sid-ab'><code>++sid:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4h/#sig'><code>++sig</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sig-ff'><code>++sig:ff</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sig-rd'><code>++sig:rd</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sig-rh'><code>++sig:rh</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sig-rs'><code>++sig:rs</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sig-rq'><code>++sig:rq</code></a>
-<a class="tooltip" href='/docs/reference/library/2l/#silt'><code>++silt</code></a>
-<a class="tooltip" href='/docs/reference/library/4e/#simu'><code>++simu</code></a>
-<a class="tooltip" href='/docs/reference/library/2c/#sit-fe'><code>++sit:fe</code></a>
-<a class="tooltip" href='/docs/reference/library/3a/#sit-fo'><code>++sit:fo</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#siv-ab'><code>++siv:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#siw-ab'><code>++siw:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#six-ab'><code>++six:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/2b/#skid'><code>++skid</code></a>
-<a class="tooltip" href='/docs/reference/library/2b/#skim'><code>++skim</code></a>
-<a class="tooltip" href='/docs/reference/library/2b/#skip'><code>++skip</code></a>
-<a class="tooltip" href='/docs/reference/library/2b/#slag'><code>++slag</code></a>
-<a class="tooltip" href='/docs/reference/library/4m/#slat'><code>++slat</code></a>
-<a class="tooltip" href='/docs/reference/library/4m/#slav'><code>++slav</code></a>
-<a class="tooltip" href='/docs/reference/library/4m/#slaw'><code>++slaw</code></a>
-<a class="tooltip" href='/docs/reference/library/4m/#slay'><code>++slay</code></a>
-<a class="tooltip" href='/docs/reference/library/2n/#slog'><code>++slog</code></a>
-<a class="tooltip" href='/docs/reference/library/4f/#slug'><code>++slug</code></a>
-<a class="tooltip" href='/docs/reference/library/4m/#smyt'><code>++smyt</code></a>
-<a class="tooltip" href='/docs/reference/library/2b/#snag'><code>++snag</code></a>
-<a class="tooltip" href='/docs/reference/library/2m/#snag-nl'><code>++snag:nl</code></a>
-<a class="tooltip" href='/docs/reference/library/2b/#snoc'><code>++snoc</code></a>
-<a class="tooltip" href='/docs/reference/library/4l/#so'><code>++so</code></a>
-<a class="tooltip" href='/docs/reference/library/2n/#soft'><code>++soft</code></a>
-<a class="tooltip" href='/docs/reference/library/2a/#some'><code>++some</code></a>
-<a class="tooltip" href='/docs/reference/library/4h/#soq'><code>++soq</code></a>
-<a class="tooltip" href='/docs/reference/library/2b/#sort'><code>++sort</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#sov-ab'><code>++sov:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#sow-ab'><code>++sow:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#sox-ab'><code>++sox:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4i/#soz'><code>++soz</code></a>
-<a class="tooltip" href='/docs/reference/library/4o/#span'><code>++span</code></a>
-<a class="tooltip" href='/docs/reference/library/4m/#spat'><code>++spat</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#spd-fl'><code>++spd:fl</code></a>
-<a class="tooltip" href='/docs/reference/library/2b/#spin'><code>++spin</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#spn-fl'><code>++spn:fl</code></a>
-<a class="tooltip" href='/docs/reference/library/3g/#spot'><code>++spot</code></a>
-<a class="tooltip" href='/docs/reference/library/4m/#spud'><code>++spud</code></a>
-<a class="tooltip" href='/docs/reference/library/2b/#spun'><code>++spun</code></a>
-<a class="tooltip" href='/docs/reference/library/2g/#sqt'><code>++sqt</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sqt-ff'><code>++sqt:ff</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sqt-fl'><code>++sqt:fl</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sqt-rd'><code>++sqt:rd</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sqt-rh'><code>++sqt:rh</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sqt-rs'><code>++sqt:rs</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sqt-rq'><code>++sqt:rq</code></a>
-<a class="tooltip" href='/docs/reference/library/4m/#stab'><code>++stab</code></a>
-<a class="tooltip" href='/docs/reference/library/4f/#stag'><code>++stag</code></a>
-<a class="tooltip" href='/docs/reference/library/4f/#star'><code>++star</code></a>
-<a class="tooltip" href='/docs/reference/library/4f/#stet'><code>++stet</code></a>
-<a class="tooltip" href='/docs/reference/library/4f/#stew'><code>++stew</code></a>
-<a class="tooltip" href='/docs/reference/library/4f/#stir'><code>++stir</code></a>
-<a class="tooltip" href='/docs/reference/library/4f/#stun'><code>++stun</code></a>
-<a class="tooltip" href='/docs/reference/library/1a/#sub'><code>++sub</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sub-ff'><code>++sub:ff</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sub-fl'><code>++sub:fl</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sub-rd'><code>++sub:rd</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sub-rh'><code>++sub:rh</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sub-rs'><code>++sub:rs</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sub-rq'><code>++sub:rq</code></a>
-<a class="tooltip" href='/docs/reference/library/2c/#sum-fe'><code>++sum:fe</code></a>
-<a class="tooltip" href='/docs/reference/library/3a/#sum-fo'><code>++sum:fo</code></a>
-<a class="tooltip" href='/docs/reference/library/3a/#sum-si'><code>++sum:si</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sun-ff'><code>++sun:ff</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sun-fl'><code>++sun:fl</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sun-rd'><code>++sun:rd</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sun-rh'><code>++sun:rh</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sun-rs'><code>++sun:rs</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sun-rq'><code>++sun:rq</code></a>
-<a class="tooltip" href='/docs/reference/library/3a/#sun-si'><code>++sun:si</code></a>
-<a class="tooltip" href='/docs/reference/library/2b/#swag'><code>++swag</code></a>
-<a class="tooltip" href='/docs/reference/library/2c/#swp'><code>++swp</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#swr-fl'><code>++swr:fl</code></a>
-<a class="tooltip" href='/docs/reference/library/2m/#sy'><code>++sy</code></a>
-<a class="tooltip" href='/docs/reference/library/4i/#sym'><code>++sym</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#syn-fl'><code>++syn:fl</code></a>
-<a class="tooltip" href='/docs/reference/library/3a/#syn-si'><code>++syn:si</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#same' title="Identity (produces same value)"><code>++same</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#san-ff' title="Signed integer to @r"><code>++san:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#san-fl' title="Signed integer to float"><code>++san:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#san-rd' title="Unsigned integer to @rd"><code>++san:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#san-rh' title="Signed integer to @rh"><code>++san:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#san-rs' title="Signed integer to @rs"><code>++san:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#san-rq' title="Signed integer to @rq"><code>++san:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#sand' title="Soft-cast by odor"><code>++sand</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#sane' title="Check odor validity"><code>++sane</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sb-ff' title="Sign bit"><code>++sb:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#scag' title="Prefix (produce front of list)"><code>++scag</code></a>
+<a class="tooltip" href='/docs/reference/library/4g/#scan' title="Parse tape or crash"><code>++scan</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#scot' title="Render dime as cord"><code>++scot</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#scow' title="Render dime as tape"><code>++scow</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sea-ff' title="Convert from IEEE float to fn"><code>++sea:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sea-rd' title="Convert from double-precision binary float to fn"><code>++sea:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sea-rh' title="Convert from half-precision float to fn"><code>++sea:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sea-rs' title="Convert from single-precision float to fn"><code>++sea:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sea-rq' title="Convert from quad-precision float to fn"><code>++sea:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#sear' title="Conditional ++cook"><code>++sear</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#seb-ab' title="Parse 1"><code>++seb:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sed-ab' title="Parse non-zero decimal digit"><code>++sed:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#sel' title="Parse [ (sel)"><code>++sel</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#sem' title="Parse ; (sem)"><code>++sem</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#ser' title="Parse ] (ser)"><code>++ser</code></a>
+<a class="tooltip" href='/docs/reference/library/2o/#set' title="Mold generator (set)"><code>++set</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sev-ab' title="Parse non-zero base 32 digit"><code>++sev:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sew-ab' title="Parse non-zero base 64 digit"><code>++sew:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sex-ab' title="Parse nonzero hexadecimal digit"><code>++sex:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4e/#sfix' title="Discard second rule"><code>++sfix</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shad' title="Double SHA-256"><code>++shad</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shaf' title="Half SHA-256"><code>++shaf</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shal' title="SHA-512 with length"><code>++shal</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#sham' title="128-bit noun hash"><code>++sham</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shan' title="SHA-1"><code>++shan</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shas' title="Salted hash"><code>++shas</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shaw' title="Hash to nbits"><code>++shaw</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shax' title="SHA-256"><code>++shax</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shay' title="SHA-256 with length"><code>++shay</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shaz' title="SHA-512"><code>++shaz</code></a>
+<a class="tooltip" href='/docs/reference/library/4c/#shep' title="(Undocumented)"><code>++shep</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#shf-fl' title="Shift power"><code>++shf:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#shim' title="Match character within range"><code>++shim</code></a>
+<a class="tooltip" href='/docs/reference/library/4c/#shop' title="(Undocumented)"><code>++shop</code></a>
+<a class="tooltip" href='/docs/reference/library/4c/#show' title="(Undocumented)"><code>++show</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#si' title="Signed integer"><code>++si</code></a>
+<a class="tooltip" href='/docs/reference/library/2m/#si-nl' title="Construct set from null-terminated noun"><code>++si:nl</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sib-ab' title="Parse binary digit"><code>++sib:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sid-ab' title="Parse decimal digit"><code>++sid:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#sig' title="Parse ~ (sig)"><code>++sig</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sig-ff' title="Produce sign of IEEE float"><code>++sig:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sig-rd' title="Produce sign of @rd"><code>++sig:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sig-rh' title="Produce sign of half-precision float"><code>++sig:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sig-rs' title="Produce sign of @rs"><code>++sig:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sig-rq' title="Produce sign of quad-precision float"><code>++sig:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/2l/#silt' title="Produce set from list"><code>++silt</code></a>
+<a class="tooltip" href='/docs/reference/library/4e/#simu' title="First and second"><code>++simu</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#sit-fe' title="Enforce modulo"><code>++sit:fe</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#sit-fo' title="Produce remainder of b modulo a"><code>++sit:fo</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#siv-ab' title="Parse a base 32 digit"><code>++siv:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#siw-ab' title="Parse a base 64 digit"><code>++siw:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#six-ab' title="Parse a hexadecimal digit"><code>++six:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#skid' title="Separate list into two lists from slammed elments"><code>++skid</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#skim' title="Produce list of elements from boolean gate"><code>++skim</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#skip' title="Produce list of elements failing boolean gate"><code>++skip</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#slag' title="Produce all elements from index in list"><code>++slag</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#slat' title="Curried slaw"><code>++slat</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#slav' title="Demand: parse cord with input odor"><code>++slav</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#slaw' title="Parse cord to input odor"><code>++slaw</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#slay' title="Parse cord to coin"><code>++slay</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#slog' title="Deify printf"><code>++slog</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#slug' title="Use gate to parse delimited list"><code>++slug</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#smyt' title="Render path as tank"><code>++smyt</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#snag' title="Produce element at specific index (list)"><code>++snag</code></a>
+<a class="tooltip" href='/docs/reference/library/2m/#snag-nl' title="Produce element from list at specific null-terminated noun"><code>++snag:nl</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#snoc' title="Append noun to list"><code>++snoc</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#so' title="Coin parser engine"><code>++so</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#soft' title="Maybe remold"><code>++soft</code></a>
+<a class="tooltip" href='/docs/reference/library/2a/#some' title="Wrap value in unit"><code>++some</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#soq' title="Parse ' (soq)"><code>++soq</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#sort' title="Quicksort (list)"><code>++sort</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sov-ab' title="Parse base 32 letter"><code>++sov:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sow-ab' title="Parse base 64 letter/symbol"><code>++sow:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sox-ab' title="Parse hexadecimal letter"><code>++sox:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#soz' title="Parse triple single-quote"><code>++soz</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#span' title="ASCII atom"><code>++span</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#spat' title="Render path as cord"><code>++spat</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#spd-fl' title="Produce smallest denormalized float"><code>++spd:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#spin' title="Gate to list (with state)"><code>++spin</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#spn-fl' title="Produce smallest normal float"><code>++spn:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#spot' title="Stack trace line"><code>++spot</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#spud' title="Render path as tape"><code>++spud</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#spun' title="Gate to list (with state)"><code>++spun</code></a>
+<a class="tooltip" href='/docs/reference/library/2g/#sqt' title="Compute square root with remainder"><code>++sqt</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sqt-ff' title="Produce square root of IEEE float"><code>++sqt:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sqt-fl' title="Produce square root from signed and unsigned integer cell"><code>++sqt:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sqt-rd' title="Produce square root of double-precision float"><code>++sqt:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sqt-rh' title="Produce square root of half-precision float"><code>++sqt:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sqt-rs' title="Produce square root of single-precision float"><code>++sqt:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sqt-rq' title="Produce square root of quad-precision float"><code>++sqt:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#stab' title="Parse cord to path"><code>++stab</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#stag' title="Add label"><code>++stag</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#star' title="Produce list of matches"><code>++star</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#stet' title="Add faces to range-parser pairs in list"><code>++stet</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#stew' title="Switch by first"><code>++stew</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#stir' title="Parse repeatedly"><code>++stir</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#stun' title="Parse several times"><code>++stun</code></a>
+<a class="tooltip" href='/docs/reference/library/1a/#sub' title="Subtract"><code>++sub</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sub-ff' title="Subtract from IEEE float"><code>++sub:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sub-fl' title="Subtract from signed and unsigned integer cells"><code>++sub:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sub-rd' title="Subtract from double-precision float"><code>++sub:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sub-rh' title="Subtract from half-precision float"><code>++sub:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sub-rs' title="Subtract from single-precision float"><code>++sub:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sub-rq' title="Subtract from quad-precision float"><code>++sub:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#sum-fe' title="Sum two numbers in modular field"><code>++sum:fe</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#sum-fo' title="Modular sum"><code>++sum:fo</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#sum-si' title="Addition (signed integer)"><code>++sum:si</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sun-ff' title="Unsigned integer to IEEE float"><code>++sun:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sun-fl' title="Unsigned integer to float"><code>++sun:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sun-rd' title="Unsigned integer to double-precision float"><code>++sun:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sun-rh' title="Unsigned integer to half-precision float"><code>++sun:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sun-rs' title="Unsigned integer to single-precision float"><code>++sun:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sun-rq' title="Unsigned integer to quad-precision float"><code>++sun:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#sun-si' title="@u to @s"><code>++sun:si</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#swag' title="Infix (list)"><code>++swag</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#swp' title="Reverse block order"><code>++swp</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#swr-fl' title="Switch rounding mode of floating point"><code>++swr:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/2m/#sy' title="Produce set from null-terminated noun"><code>++sy</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#sym' title="Term"><code>++sym</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#syn-fl' title="Get sign"><code>++syn:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#syn-si' title="Sign test"><code>++syn:si</code></a>
 
 ### t
 
-<a class="tooltip" href='/docs/reference/library/2n/#tail'><code>++tail</code></a>
-<a class="tooltip" href='/docs/reference/library/2k/#tap-to'><code>+-tap:to</code></a>
-<a class="tooltip" href='/docs/reference/library/4h/#tar'><code>++tar</code></a>
-<a class="tooltip" href='/docs/reference/library/2q/#tang'><code>++tang</code></a>
-<a class="tooltip" href='/docs/reference/library/2q/#tank'><code>++tank</code></a>
-<a class="tooltip" href='/docs/reference/library/2i/#tap-by'><code>+-tap:by</code></a>
-<a class="tooltip" href='/docs/reference/library/2h/#tap-in'><code>+-tap:in</code></a>
-<a class="tooltip" href='/docs/reference/library/2q/#tape'><code>++tape</code></a>
-<a class="tooltip" href='/docs/reference/library/2q/#tarp'><code>++tarp</code></a>
-<a class="tooltip" href='/docs/reference/library/4l/#tash-so'><code>++tash:so</code></a>
-<a class="tooltip" href='/docs/reference/library/4h/#tec'><code>++tec</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#ted-ab'><code>++ted:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#teff'><code>++teff</code></a>
-<a class="tooltip" href='/docs/reference/library/3f/#teil-ob'><code>++teil:ob</code></a>
-<a class="tooltip" href='/docs/reference/library/2q/#term'><code>++term</code></a>
-<a class="tooltip" href='/docs/reference/library/2n/#test'><code>++test</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#tid-ab'><code>++tid:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4o/#tiki'><code>++tiki</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#til-ab'><code>++til:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#tip-ab'><code>++tip:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#tiq-ab'><code>++tiq:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4h/#tis'><code>++tis</code></a>
-<a class="tooltip" href='/docs/reference/library/2k/#to'><code>++to</code></a>
-<a class="tooltip" href='/docs/reference/library/4a/#tod-po'><code>++tod:po</code></a>
-<a class="tooltip" href='/docs/reference/library/4o/#toga'><code>++toga</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#toi-ff'><code>++toi:ff</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#toi-fl'><code>++toi:fl</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#toi-rd'><code>++toi:rd</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#toi-rh'><code>++toi:rh</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#toi-rs'><code>++toi:rs</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#toi-rq'><code>++toi:rq</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#toj-fl'><code>++toj:fl</code></a>
-<a class="tooltip" href='/docs/reference/library/3g/#tone'><code>++tone</code></a>
-<a class="tooltip" href='/docs/reference/library/3g/#toon'><code>++toon</code></a>
-<a class="tooltip" href='/docs/reference/library/2k/#top-to'><code>+-top:to</code></a>
-<a class="tooltip" href='/docs/reference/library/4a/#tos-po'><code>++tos:po</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#tos-rh'><code>++tos:rh</code></a>
-<a class="tooltip" href='/docs/reference/library/1c/#trap'><code>++trap</code></a>
-<a class="tooltip" href='/docs/reference/library/1c/#tree'><code>++tree</code></a>
-<a class="tooltip" href='/docs/reference/library/1c/#trel'><code>++trel</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#trim'><code>++trim</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#trip'><code>++trip</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#tuba'><code>++tuba</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#tufa'><code>++tufa</code></a>
-<a class="tooltip" href='/docs/reference/library/4o/#tuna'><code>++tuna</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#tuft'><code>++tuft</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#turf'><code>++turf</code></a>
-<a class="tooltip" href='/docs/reference/library/2b/#turn'><code>++turn</code></a>
-<a class="tooltip" href='/docs/reference/library/4o/#tusk'><code>++tusk</code></a>
-<a class="tooltip" href='/docs/reference/library/4l/#twid-so'><code>++twid:so</code></a>
-<a class="tooltip" href='/docs/reference/library/4o/#tyke'><code>++tyke</code></a>
-<a class="tooltip" href='/docs/reference/library/4o/#typo'><code>++typo</code></a>
-<a class="tooltip" href='/docs/reference/library/4o/#tyre'><code>++tyre</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#tail' title="Get tail of cell"><code>++tail</code></a>
+<a class="tooltip" href='/docs/reference/library/2k/#tap-to' title="Queue to list"><code>+-tap:to</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#tar' title="Parse * (tar)"><code>++tar</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#tang' title="Generic print structure"><code>++tang</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#tank' title="Pretty-printing structure"><code>++tank</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#tap-by' title="Listify pairs"><code>+-tap:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#tap-in' title="Flatten set into list"><code>+-tap:in</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#tape' title="List of characters"><code>++tape</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#tarp' title="Parsed time"><code>++tarp</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#tash-so' title="Parse signed dime"><code>++tash:so</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#tec' title="Parse ` (tec)"><code>++tec</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#ted-ab' title="Parse decimal number with <= 3 digits"><code>++ted:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#teff' title="UTF-8 length"><code>++teff</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#teil-ob' title="Reverse Feistel-like cipher"><code>++teil:ob</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#term' title="Hoon constant"><code>++term</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#test' title="Test for equality"><code>++test</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#tid-ab' title="Parse 3 decimal digits"><code>++tid:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#tiki' title="(Undocumented)"><code>++tiki</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#til-ab' title="Parse 3 lowercase letters"><code>++til:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#tip-ab' title="Leading phonetic byte"><code>++tip:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#tiq-ab' title="Trailing phonetic syllable"><code>++tiq:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#tis' title="Parse = (tis)"><code>++tis</code></a>
+<a class="tooltip" href='/docs/reference/library/2k/#to' title="Queue operations"><code>++to</code></a>
+<a class="tooltip" href='/docs/reference/library/4a/#tod-po' title="Fetch suffix"><code>++tod:po</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#toga' title="Tree of faces"><code>++toga</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#toi-ff' title="Round IEEE float to nearest signed integer"><code>++toi:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#toi-fl' title="Round float to nearest signed integer"><code>++toi:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#toi-rd' title="Round double-precision float to nearest signed integer"><code>++toi:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#toi-rh' title="Round half-precision float to nearest signed integer"><code>++toi:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#toi-rs' title="Round single-precision float to nearest signed integer"><code>++toi:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#toi-rq' title="Round quad-precision float to nearest signed integer"><code>++toi:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#toj-fl' title="Round unsigned and signed integer to float"><code>++toj:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#tone' title="Nock result (error report)"><code>++tone</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#toon' title="Nock result (stack trace)"><code>++toon</code></a>
+<a class="tooltip" href='/docs/reference/library/2k/#top-to' title="Produce head of queue"><code>+-top:to</code></a>
+<a class="tooltip" href='/docs/reference/library/4a/#tos-po' title="Fetch prefix"><code>++tos:po</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#tos-rh' title="Convert half-precision float to single-precision float"><code>++tos:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#trap' title="Core with one arm $"><code>++trap</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#tree' title="Mold generator (tree)"><code>++tree</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#trel' title="Mold generator (tuple of three types)"><code>++trel</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#trim' title="Tape split"><code>++trim</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#trip' title="Cord to tape"><code>++trip</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#tuba' title="UTF-8 to UTF-32 tape"><code>++tuba</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#tufa' title="UTF-32 to UTF-8 tape"><code>++tufa</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#tuna' title="XML template tree"><code>++tuna</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#tuft' title="UTF-32 to UTF-8 text"><code>++tuft</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#turf' title="UTF-8 to UTF-32 cord"><code>++turf</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#turn' title="Gate to list"><code>++turn</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#tusk' title="List of expressions"><code>++tusk</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#twid-so' title="Parse coins without ~ prefix"><code>++twid:so</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#tyke' title="List of 'maybe' hoons"><code>++tyke</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#typo' title="Pointer for ++type"><code>++typo</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#tyre' title="List, term hoon"><code>++tyre</code></a>
 
 ### u
 
-<a class="tooltip" href='/docs/reference/library/3f/#un'><code>++un</code></a>
-<a class="tooltip" href='/docs/reference/library/2i/#uni-by'><code>+-uni:by</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#uni-fl'><code>++uni:fl</code></a>
-<a class="tooltip" href='/docs/reference/library/2h/#uni-in'><code>+-uni:in</code></a>
-<a class="tooltip" href='/docs/reference/library/1c/#unit'><code>++unit</code></a>
-<a class="tooltip" href='/docs/reference/library/2i/#urn-by'><code>+-urn:by</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#urs-ab'><code>++urs:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#urt-ab'><code>++urt:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#un' title="Reversible scrambling"><code>++un</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#uni-by' title="Union (map between keys of two lists)"><code>+-uni:by</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#uni-fl' title="Change representation to odd"><code>++uni:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#uni-in' title="Union (sets)"><code>+-uni:in</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#unit' title="Mold generator (maybe)"><code>++unit</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#urn-by' title="Turn (with key) (map)"><code>+-urn:by</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#urs-ab' title="Parse span characters"><code>++urs:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#urt-ab' title="Parse non-_ span"><code>++urt:ab</code></a>
 
 ### v
 
-<a class="tooltip" href='/docs/reference/library/4j/#v-ne'><code>++v:ne</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#v-ne' title="Render base 32"><code>++v:ne</code></a>
 <code>++vang</code>
-<a class="tooltip" href='/docs/reference/library/4o/#vase'><code>++vase</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#vase' title="Typed data"><code>++vase</code></a>
 <code>++vast</code>
-<a class="tooltip" href='/docs/reference/library/4i/#ven'><code>++ven</code></a>
-<a class="tooltip" href='/docs/reference/library/4o/#vise'><code>++vise</code></a>
-<a class="tooltip" href='/docs/reference/library/4i/#vit'><code>++vit</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#viz-ag'><code>++viz:ag</code></a>
-<a class="tooltip" href='/docs/reference/library/2f/#vor'><code>++vor</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#voy-ab'><code>++voy:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4i/#vul'><code>++vul</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#vum-ag'><code>++vum:ag</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#ven' title="Axis syntax parser"><code>++ven</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#vise' title="Convert during reboot"><code>++vise</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#vit' title="Parse base 64 digit"><code>++vit</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#viz-ag' title="Parse base 32 digit with dot separators"><code>++viz:ag</code></a>
+<a class="tooltip" href='/docs/reference/library/2f/#vor' title="Vertical order"><code>++vor</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#voy-ab' title="Parse bas, soq, or bix"><code>++voy:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#vul' title="Comments to null"><code>++vul</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#vum-ag' title="Parse base 32 string"><code>++vum:ag</code></a>
 
 ### w
 
-<a class="tooltip" href='/docs/reference/library/4j/#w-ne'><code>++w:ne</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#wack'><code>++wack</code></a>
-<a class="tooltip" href='/docs/reference/library/2q/#wain'><code>++wain</code></a>
-<a class="tooltip" href='/docs/reference/library/2q/#wall'><code>++wall</code></a>
-<a class="tooltip" href='/docs/reference/library/2b/#weld'><code>++weld</code></a>
-<a class="tooltip" href='/docs/reference/library/2m/#weld-nl'><code>++weld:nl</code></a>
-<a class="tooltip" href='/docs/reference/library/2b/#welp'><code>++welp</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#wick'><code>++wick</code></a>
-<a class="tooltip" href='/docs/reference/library/4c/#wig-re'><code>++wig:re</code></a>
-<a class="tooltip" href='/docs/reference/library/4c/#win-re'><code>++win:re</code></a>
-<a class="tooltip" href='/docs/reference/library/4o/#wing'><code>++wing</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#wiz-ag'><code>++wiz:ag</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#woad'><code>++woad</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#wood'><code>++wood</code></a>
-<a class="tooltip" href='/docs/reference/library/3g/#wonk'><code>++wonk</code></a>
-<a class="tooltip" href='/docs/reference/library/3f/#wred-un'><code>++wred:un</code></a>
-<a class="tooltip" href='/docs/reference/library/3f/#wren-un'><code>++wren:un</code></a>
-<a class="tooltip" href='/docs/reference/library/4h/#wut'><code>++wut</code></a>
-<a class="tooltip" href='/docs/reference/library/2i/#wyt-by'><code>+-wyt:by</code></a>
-<a class="tooltip" href='/docs/reference/library/2h/#wyt-in'><code>+-wyt:in</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#w-ne' title="Render base 64 digit"><code>++w:ne</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#wack' title="Coin format encode"><code>++wack</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#wain' title="List of cords"><code>++wain</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#wall' title="List of list of characters"><code>++wall</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#weld' title="Concatenate two lists"><code>++weld</code></a>
+<a class="tooltip" href='/docs/reference/library/2m/#weld-nl' title="Concatenate null-terminated nouns"><code>++weld:nl</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#welp' title="Perfect concatenate (lists)"><code>++welp</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#wick' title="Coin format decode"><code>++wick</code></a>
+<a class="tooltip" href='/docs/reference/library/4c/#wig-re' title="++win - render tape"><code>++wig:re</code></a>
+<a class="tooltip" href='/docs/reference/library/4c/#win-re' title="Render at indent"><code>++win:re</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#wing' title="Address in subject"><code>++wing</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#wiz-ag' title="Parse base 64 number"><code>++wiz:ag</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#woad' title="Unescape cord"><code>++woad</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#wood' title="Escape cord"><code>++wood</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#wonk' title="Product from edge"><code>++wonk</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#wred-un' title="Restore structure"><code>++wred:un</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#wren-un' title="Conceal structure"><code>++wren:un</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#wut' title="Parse ? (wut)"><code>++wut</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#wyt-by' title="Produce depth of tree map"><code>+-wyt:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#wyt-in' title="Produce number of elements in set"><code>+-wyt:in</code></a>
 
 ### x
 
-<a class="tooltip" href='/docs/reference/library/4j/#x-ne'><code>++x:ne</code></a>
-<a class="tooltip" href='/docs/reference/library/2c/#xeb'><code>++xeb</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#xpd-fl'><code>++xpd:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#x-ne' title="Render hexadecimal digit as atom of ASCII byte value"><code>++x:ne</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#xeb' title="Binary logarithm"><code>++xeb</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#xpd-fl' title="Expand signed and unsigned integer cell"><code>++xpd:fl</code></a>
 
 ### y
 
-<a class="tooltip" href='/docs/reference/library/3c/#yall'><code>++yall</code></a>
-<a class="tooltip" href='/docs/reference/library/3c/#yawn'><code>++yawn</code></a>
-<a class="tooltip" href='/docs/reference/library/3c/#year'><code>++year</code></a>
-<a class="tooltip" href='/docs/reference/library/3c/#yell'><code>++yell</code></a>
-<a class="tooltip" href='/docs/reference/library/3c/#yelp'><code>++yelp</code></a>
-<a class="tooltip" href='/docs/reference/library/3c/#yer-yo'><code>++yer:yo</code></a>
-<a class="tooltip" href='/docs/reference/library/3c/#yo'><code>++yo</code></a>
-<a class="tooltip" href='/docs/reference/library/3c/#yore'><code>++yore</code></a>
-<a class="tooltip" href='/docs/reference/library/3c/#yule'><code>++yule</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yall' title="Time since beginning of time"><code>++yall</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yawn' title="Days since beginning of time"><code>++yawn</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#year' title="Date to @d"><code>++year</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yell' title="Tarp from atomic date"><code>++yell</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yelp' title="Determine if leap-week"><code>++yelp</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yer-yo' title="Seconds in year"><code>++yer:yo</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yo' title="Time constants core"><code>++yo</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yore' title="Date from atomic date"><code>++yore</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yule' title="Daily time to time atom"><code>++yule</code></a>
 
 ### z
 
-<a class="tooltip" href='/docs/reference/library/3f/#zaft-un'><code>++zaft:un</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#zag-mu'><code>++zag:mu</code></a>
-<a class="tooltip" href='/docs/reference/library/4h/#zap'><code>++zap</code></a>
-<a class="tooltip" href='/docs/reference/library/3f/#zart-un'><code>++zart:un</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#zer-fl'><code>++zer:fl</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#zig-mu'><code>++zig:mu</code></a>
-<a class="tooltip" href='/docs/reference/library/2b/#zing'><code>++zing</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#zug-mu'><code>++zug:mu</code></a>
-<a class="tooltip" href='/docs/reference/library/4l/#zust-so'><code>++zust:so</code></a>
-<a class="tooltip" href='/docs/reference/library/3f/#zyft-un'><code>++zyft:un</code></a>
-<a class="tooltip" href='/docs/reference/library/3f/#zyrt-un'><code>++zyrt:un</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#zaft-un' title="Look up in 255 sub box"><code>++zaft:un</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#zag-mu' title="Add bottom into top"><code>++zag:mu</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#zap' title="Parse ! (zap)"><code>++zap</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#zart-un' title="Reverse look up in 255 sub box"><code>++zart:un</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#zer-fl' title="Produce zero as float"><code>++zer:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#zig-mu' title="Subtract bottom from top"><code>++zig:mu</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#zing' title="Turn lists into single list by promoting elements from sublists"><code>++zing</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#zug-mu' title="Concatenate into atom"><code>++zug:mu</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#zust-so' title="Parse prefixed dimes from IP, loobean, or floating point"><code>++zust:so</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#zyft-un' title="Lookup byte in 256 sub box"><code>++zyft:un</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#zyrt-un' title="Reverse lookup byte in 256 sub box"><code>++zyrt:un</code></a>
 
 ## By Section
 
@@ -823,7 +823,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/1a/#min' title="Minimum (atom)"><code>++min</code></a>
 <a class="tooltip" href='/docs/reference/library/1a/#mod' title="Modulus (atom)"><code>++mod</code></a>
 <a class="tooltip" href='/docs/reference/library/1a/#mul' title="Multiply (atom)"><code>++mul</code></a>
-<a class="tooltip" href='/docs/reference/library/1a/#sub'><code>++sub</code></a>
+<a class="tooltip" href='/docs/reference/library/1a/#sub' title="Subtract"><code>++sub</code></a>
 
 ### 1b: tree addressing
 
@@ -841,10 +841,10 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/1c/#pair' title="Mold of pair of types"><code>++pair</code></a>
 <a class="tooltip" href='/docs/reference/library/1c/#pole' title="Mold generator of faceless list"><code>++pole</code></a>
 <a class="tooltip" href='/docs/reference/library/1c/#quip' title="Mold generator (tuple of list and type)"><code>++quip</code></a>
-<a class="tooltip" href='/docs/reference/library/1c/#trap'><code>++trap</code></a>
-<a class="tooltip" href='/docs/reference/library/1c/#tree'><code>++tree</code></a>
-<a class="tooltip" href='/docs/reference/library/1c/#trel'><code>++trel</code></a>
-<a class="tooltip" href='/docs/reference/library/1c/#unit'><code>++unit</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#trap' title="Core with one arm $"><code>++trap</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#tree' title="Mold generator (tree)"><code>++tree</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#trel' title="Mold generator (tuple of three types)"><code>++trel</code></a>
+<a class="tooltip" href='/docs/reference/library/1c/#unit' title="Mold generator (maybe)"><code>++unit</code></a>
 
 ### 2a: unit logic
 
@@ -858,7 +858,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/2a/#lift' title="Curried bind"><code>++lift</code></a>
 <a class="tooltip" href='/docs/reference/library/2a/#mate' title="Choose"><code>++mate</code></a>
 <a class="tooltip" href='/docs/reference/library/2a/#need' title="Unwrap unit"><code>++need</code></a>
-<a class="tooltip" href='/docs/reference/library/2a/#some'><code>++some</code></a>
+<a class="tooltip" href='/docs/reference/library/2a/#some' title="Wrap value in unit"><code>++some</code></a>
 
 ### 2b: list logic
 
@@ -876,21 +876,21 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/2b/#reap' title="Replicate (list)"><code>++reap</code></a>
 <a class="tooltip" href='/docs/reference/library/2b/#reel' title="Right fold (list)"><code>++reel</code></a>
 <a class="tooltip" href='/docs/reference/library/2b/#roll' title="Left fold (list)"><code>++roll</code></a>
-<a class="tooltip" href='/docs/reference/library/2b/#scag'><code>++scag</code></a>
-<a class="tooltip" href='/docs/reference/library/2b/#skid'><code>++skid</code></a>
-<a class="tooltip" href='/docs/reference/library/2b/#skim'><code>++skim</code></a>
-<a class="tooltip" href='/docs/reference/library/2b/#skip'><code>++skip</code></a>
-<a class="tooltip" href='/docs/reference/library/2b/#slag'><code>++slag</code></a>
-<a class="tooltip" href='/docs/reference/library/2b/#snag'><code>++snag</code></a>
-<a class="tooltip" href='/docs/reference/library/2b/#snoc'><code>++snoc</code></a>
-<a class="tooltip" href='/docs/reference/library/2b/#sort'><code>++sort</code></a>
-<a class="tooltip" href='/docs/reference/library/2b/#spin'><code>++spin</code></a>
-<a class="tooltip" href='/docs/reference/library/2b/#spun'><code>++spun</code></a>
-<a class="tooltip" href='/docs/reference/library/2b/#swag'><code>++swag</code></a>
-<a class="tooltip" href='/docs/reference/library/2b/#turn'><code>++turn</code></a>
-<a class="tooltip" href='/docs/reference/library/2b/#weld'><code>++weld</code></a>
-<a class="tooltip" href='/docs/reference/library/2b/#welp'><code>++welp</code></a>
-<a class="tooltip" href='/docs/reference/library/2b/#zing'><code>++zing</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#scag' title="Prefix (produce front of list)"><code>++scag</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#skid' title="Separate list into two lists from slammed elments"><code>++skid</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#skim' title="Produce list of elements from boolean gate"><code>++skim</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#skip' title="Produce list of elements failing boolean gate"><code>++skip</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#slag' title="Produce all elements from index in list"><code>++slag</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#snag' title="Produce element at specific index (list)"><code>++snag</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#snoc' title="Append noun to list"><code>++snoc</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#sort' title="Quicksort (list)"><code>++sort</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#spin' title="Gate to list (with state)"><code>++spin</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#spun' title="Gate to list (with state)"><code>++spun</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#swag' title="Infix (list)"><code>++swag</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#turn' title="Gate to list"><code>++turn</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#weld' title="Concatenate two lists"><code>++weld</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#welp' title="Perfect concatenate (lists)"><code>++welp</code></a>
+<a class="tooltip" href='/docs/reference/library/2b/#zing' title="Turn lists into single list by promoting elements from sublists"><code>++zing</code></a>
 
 ### 2c: bit arithmetic
 
@@ -901,8 +901,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/2c/#out-fe' title="Maximum integer value"><code>++out:fe</code></a>
 <a class="tooltip" href='/docs/reference/library/2c/#rol-fe' title="Roll left"><code>++rol:fe</code></a>
 <a class="tooltip" href='/docs/reference/library/2c/#ror-fe' title="Roll right"><code>++ror:fe</code></a>
-<a class="tooltip" href='/docs/reference/library/2c/#sit-fe'><code>++sit:fe</code></a>
-<a class="tooltip" href='/docs/reference/library/2c/#sum-fe'><code>++sum:fe</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#sit-fe' title="Enforce modulo"><code>++sit:fe</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#sum-fe' title="Sum two numbers in modular field"><code>++sum:fe</code></a>
 
 <a class="tooltip" href='/docs/reference/library/2c/#bex' title="Binary exponent"><code>++bex</code></a>
 <a class="tooltip" href='/docs/reference/library/2c/#can' title="Assemble"><code>++can</code></a>
@@ -916,8 +916,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/2c/#rep' title="Assemble single"><code>++rep</code></a>
 <a class="tooltip" href='/docs/reference/library/2c/#rip' title="Disassemble"><code>++rip</code></a>
 <a class="tooltip" href='/docs/reference/library/2c/#rsh' title="Right-shift"><code>++rsh</code></a>
-<a class="tooltip" href='/docs/reference/library/2c/#swp'><code>++swp</code></a>
-<a class="tooltip" href='/docs/reference/library/2c/#xeb'><code>++xeb</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#swp' title="Reverse block order"><code>++swp</code></a>
+<a class="tooltip" href='/docs/reference/library/2c/#xeb' title="Binary logarithm"><code>++xeb</code></a>
 
 ### 2d: bit logic
 
@@ -940,12 +940,12 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/2f/#gor' title="Hash order"><code>++gor</code></a>
 <a class="tooltip" href='/docs/reference/library/2f/#hor' title="Horizontal hash order"><code>++hor</code></a>
 <a class="tooltip" href='/docs/reference/library/2f/#lor' title="Leg order"><code>++lor</code></a>
-<a class="tooltip" href='/docs/reference/library/2f/#vor'><code>++vor</code></a>
+<a class="tooltip" href='/docs/reference/library/2f/#vor' title="Vertical order"><code>++vor</code></a>
 
 ### 2g: unsigned powers
 
 <a class="tooltip" href='/docs/reference/library/2g/#pow' title="Computes a to the power of b"><code>++pow</code></a>
-<a class="tooltip" href='/docs/reference/library/2g/#sqt'><code>++sqt</code></a>
+<a class="tooltip" href='/docs/reference/library/2g/#sqt' title="Compute square root with remainder"><code>++sqt</code></a>
 
 ### 2h: set logic
 
@@ -963,9 +963,9 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/2h/#put-in' title="Put b in a (set)"><code>+-put:in</code></a>
 <a class="tooltip" href='/docs/reference/library/2h/#rep-in' title="Accumulate elements (set)"><code>+-rep:in</code></a>
 <a class="tooltip" href='/docs/reference/library/2h/#run-in' title="Apply gate to set"><code>+-run:in</code></a>
-<a class="tooltip" href='/docs/reference/library/2h/#tap-in'><code>+-tap:in</code></a>
-<a class="tooltip" href='/docs/reference/library/2h/#uni-in'><code>+-uni:in</code></a>
-<a class="tooltip" href='/docs/reference/library/2h/#wyt-in'><code>+-wyt:in</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#tap-in' title="Flatten set into list"><code>+-tap:in</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#uni-in' title="Union (sets)"><code>+-uni:in</code></a>
+<a class="tooltip" href='/docs/reference/library/2h/#wyt-in' title="Produce number of elements in set"><code>+-wyt:in</code></a>
 
 ### 2i: map logic
 
@@ -989,10 +989,10 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/2i/#rib-by' title="Replace values with accumulator (map)"><code>+-rib:by</code></a>
 <a class="tooltip" href='/docs/reference/library/2i/#run-by' title="Transform values (map)"><code>+-run:by</code></a>
 <a class="tooltip" href='/docs/reference/library/2i/#rut-by' title="Transform nodes (map)"><code>+-rut:by</code></a>
-<a class="tooltip" href='/docs/reference/library/2i/#tap-by'><code>+-tap:by</code></a>
-<a class="tooltip" href='/docs/reference/library/2i/#uni-by'><code>+-uni:by</code></a>
-<a class="tooltip" href='/docs/reference/library/2i/#urn-by'><code>+-urn:by</code></a>
-<a class="tooltip" href='/docs/reference/library/2i/#wyt-by'><code>+-wyt:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#tap-by' title="Listify pairs"><code>+-tap:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#uni-by' title="Union (map between keys of two lists)"><code>+-uni:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#urn-by' title="Turn (with key) (map)"><code>+-urn:by</code></a>
+<a class="tooltip" href='/docs/reference/library/2i/#wyt-by' title="Produce depth of tree map"><code>+-wyt:by</code></a>
 
 ### 2j: jar and jug logic
 
@@ -1008,7 +1008,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 2k: queue logic
 
-<a class="tooltip" href='/docs/reference/library/2k/#to'><code>++to</code></a>
+<a class="tooltip" href='/docs/reference/library/2k/#to' title="Queue operations"><code>++to</code></a>
 <a class="tooltip" href='/docs/reference/library/2k/#bal-to' title="Balance queue"><code>+-bal:to</code></a>
 <a class="tooltip" href='/docs/reference/library/2k/#dep-to' title="Maximum depth (queue)"><code>+-dep:to</code></a>
 <a class="tooltip" href='/docs/reference/library/2k/#gas-to' title="Push list into queue"><code>+-gas:to</code></a>
@@ -1016,27 +1016,27 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/2k/#nap-to' title="Remove head of queue"><code>+-nap:to</code></a>
 <a class="tooltip" href='/docs/reference/library/2k/#nip-to' title="Remove root of queue"><code>+-nip:to</code></a>
 <a class="tooltip" href='/docs/reference/library/2k/#put-to' title="Insert into queue"><code>+-put:to</code></a>
-<a class="tooltip" href='/docs/reference/library/2k/#tap-to'><code>+-tap:to</code></a>
-<a class="tooltip" href='/docs/reference/library/2k/#top-to'><code>+-top:to</code></a>
+<a class="tooltip" href='/docs/reference/library/2k/#tap-to' title="Queue to list"><code>+-tap:to</code></a>
+<a class="tooltip" href='/docs/reference/library/2k/#top-to' title="Produce head of queue"><code>+-top:to</code></a>
 
 ### 2l: container from container
 
 <a class="tooltip" href='/docs/reference/library/2l/#malt' title="Map from list"><code>++malt</code></a>
 <a class="tooltip" href='/docs/reference/library/2l/#molt' title="Map from pair list"><code>++molt</code></a>
-<a class="tooltip" href='/docs/reference/library/2l/#silt'><code>++silt</code></a>
+<a class="tooltip" href='/docs/reference/library/2l/#silt' title="Produce set from list"><code>++silt</code></a>
 
 ### 2m: container from noun
 
 <a class="tooltip" href='/docs/reference/library/2m/#nl' title="Noun to container operations"><code>++nl</code></a>
 <a class="tooltip" href='/docs/reference/library/2m/#le-nl' title="Construct list from null-terminated noun"><code>++le:nl</code></a>
 <a class="tooltip" href='/docs/reference/library/2m/#my-nl' title="Construct map from null-terminated noun"><code>++my:nl</code></a>
-<a class="tooltip" href='/docs/reference/library/2m/#si-nl'><code>++si:nl</code></a>
-<a class="tooltip" href='/docs/reference/library/2m/#snag-nl'><code>++snag:nl</code></a>
-<a class="tooltip" href='/docs/reference/library/2m/#weld-nl'><code>++weld:nl</code></a>
+<a class="tooltip" href='/docs/reference/library/2m/#si-nl' title="Construct set from null-terminated noun"><code>++si:nl</code></a>
+<a class="tooltip" href='/docs/reference/library/2m/#snag-nl' title="Produce element from list at specific null-terminated noun"><code>++snag:nl</code></a>
+<a class="tooltip" href='/docs/reference/library/2m/#weld-nl' title="Concatenate null-terminated nouns"><code>++weld:nl</code></a>
 
 <a class="tooltip" href='/docs/reference/library/2m/#ly' title="List from raw noun"><code>++ly</code></a>
 <a class="tooltip" href='/docs/reference/library/2m/#my' title="Map from raw noun"><code>++my</code></a>
-<a class="tooltip" href='/docs/reference/library/2m/#sy'><code>++sy</code></a>
+<a class="tooltip" href='/docs/reference/library/2m/#sy' title="Produce set from null-terminated noun"><code>++sy</code></a>
 
 ### 2n: functional hacks
 
@@ -1047,11 +1047,11 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/2n/#hard' title="Force remold"><code>++hard</code></a>
 <a class="tooltip" href='/docs/reference/library/2n/#head' title="Get head of cell"><code>++head</code></a>
 <a class="tooltip" href='/docs/reference/library/2n/#mean' title="Crash and printf"><code>++mean</code></a>
-<a class="tooltip" href='/docs/reference/library/2n/#same'><code>++same</code></a>
-<a class="tooltip" href='/docs/reference/library/2n/#slog'><code>++slog</code></a>
-<a class="tooltip" href='/docs/reference/library/2n/#soft'><code>++soft</code></a>
-<a class="tooltip" href='/docs/reference/library/2n/#tail'><code>++tail</code></a>
-<a class="tooltip" href='/docs/reference/library/2n/#test'><code>++test</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#same' title="Identity (produces same value)"><code>++same</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#slog' title="Deify printf"><code>++slog</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#soft' title="Maybe remold"><code>++soft</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#tail' title="Get tail of cell"><code>++tail</code></a>
+<a class="tooltip" href='/docs/reference/library/2n/#test' title="Test for equality"><code>++test</code></a>
 
 ### 2o: normalizing containers
 
@@ -1059,7 +1059,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/2o/#jug' title="Mold generator (jug)"><code>++jug</code></a>
 <a class="tooltip" href='/docs/reference/library/2o/#map' title="Mold generator (map)"><code>++map</code></a>
 <a class="tooltip" href='/docs/reference/library/2o/#qeu' title="Mold generator (queue)"><code>++qeu</code></a>
-<a class="tooltip" href='/docs/reference/library/2o/#set'><code>++set</code></a>
+<a class="tooltip" href='/docs/reference/library/2o/#set' title="Mold generator (set)"><code>++set</code></a>
 
 ### 2p: serialization
 
@@ -1074,13 +1074,13 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/2q/#cord' title="UTF-8 text"><code>++cord</code></a>
 <a class="tooltip" href='/docs/reference/library/2q/#date' title="Point in time"><code>++date</code></a>
 <a class="tooltip" href='/docs/reference/library/2q/#knot' title="Atom type of ASCII characters"><code>++knot</code></a>
-<a class="tooltip" href='/docs/reference/library/2q/#tang'><code>++tang</code></a>
-<a class="tooltip" href='/docs/reference/library/2q/#tank'><code>++tank</code></a>
-<a class="tooltip" href='/docs/reference/library/2q/#tape'><code>++tape</code></a>
-<a class="tooltip" href='/docs/reference/library/2q/#tarp'><code>++tarp</code></a>
-<a class="tooltip" href='/docs/reference/library/2q/#term'><code>++term</code></a>
-<a class="tooltip" href='/docs/reference/library/2q/#wain'><code>++wain</code></a>
-<a class="tooltip" href='/docs/reference/library/2q/#wall'><code>++wall</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#tang' title="Generic print structure"><code>++tang</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#tank' title="Pretty-printing structure"><code>++tank</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#tape' title="List of characters"><code>++tape</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#tarp' title="Parsed time"><code>++tarp</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#term' title="Hoon constant"><code>++term</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#wain' title="List of cords"><code>++wain</code></a>
+<a class="tooltip" href='/docs/reference/library/2q/#wall' title="List of list of characters"><code>++wall</code></a>
 
 ### 3a: modular and signed ints
 
@@ -1090,10 +1090,10 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/3a/#fra-fo' title="Divide (modular base)"><code>++fra:fo</code></a>
 <a class="tooltip" href='/docs/reference/library/3a/#inv-fo' title="Inverse (signed modulus)"><code>++inv:fo</code></a>
 <a class="tooltip" href='/docs/reference/library/3a/#pro-fo' title="Multiplies b and c modulo a"><code>++pro:fo</code></a>
-<a class="tooltip" href='/docs/reference/library/3a/#sit-fo'><code>++sit:fo</code></a>
-<a class="tooltip" href='/docs/reference/library/3a/#sum-fo'><code>++sum:fo</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#sit-fo' title="Produce remainder of b modulo a"><code>++sit:fo</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#sum-fo' title="Modular sum"><code>++sum:fo</code></a>
 
-<a class="tooltip" href='/docs/reference/library/3a/#si'><code>++si</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#si' title="Signed integer"><code>++si</code></a>
 <a class="tooltip" href='/docs/reference/library/3a/#abs-si' title="Absolute value (signed integer)"><code>++abs:si</code></a>
 <a class="tooltip" href='/docs/reference/library/3a/#cmp-si' title="Compare (signed integer)"><code>++cmp:si</code></a>
 <a class="tooltip" href='/docs/reference/library/3a/#dif-si' title="Subtraction (signed integer)"><code>++dif:si</code></a>
@@ -1103,9 +1103,9 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/3a/#old-si' title="Sign and absolute value"><code>++old:si</code></a>
 <a class="tooltip" href='/docs/reference/library/3a/#pro-si' title="Multiply to signed integer"><code>++pro:si</code></a>
 <a class="tooltip" href='/docs/reference/library/3a/#rem-si' title="Remainder (signed integer)"><code>++rem:si</code></a>
-<a class="tooltip" href='/docs/reference/library/3a/#sum-si'><code>++sum:si</code></a>
-<a class="tooltip" href='/docs/reference/library/3a/#sun-si'><code>++sun:si</code></a>
-<a class="tooltip" href='/docs/reference/library/3a/#syn-si'><code>++syn:si</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#sum-si' title="Addition (signed integer)"><code>++sum:si</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#sun-si' title="@u to @s"><code>++sun:si</code></a>
+<a class="tooltip" href='/docs/reference/library/3a/#syn-si' title="Sign test"><code>++syn:si</code></a>
 
 <a class="tooltip" href='/docs/reference/library/3a/#egcd' title="Extended Euclidean algorithm"><code>++egcd</code></a>
 
@@ -1132,14 +1132,14 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/3b/#me-ff' title="Minimum exponent of ff"><code>++me:ff</code></a>
 <a class="tooltip" href='/docs/reference/library/3b/#mul-ff' title="Multiply (IEEE float)"><code>++mul:ff</code></a>
 <a class="tooltip" href='/docs/reference/library/3b/#pa-ff' title="Initialize fl from ff core"><code>++pa:ff</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#san-ff'><code>++san:ff</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sb-ff'><code>++sb:ff</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sea-ff'><code>++sea:ff</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sig-ff'><code>++sig:ff</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sqt-ff'><code>++sqt:ff</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sub-ff'><code>++sub:ff</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sun-ff'><code>++sun:ff</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#toi-ff'><code>++toi:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#san-ff' title="Signed integer to @r"><code>++san:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sb-ff' title="Sign bit"><code>++sb:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sea-ff' title="Convert from IEEE float to fn"><code>++sea:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sig-ff' title="Produce sign of IEEE float"><code>++sig:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sqt-ff' title="Produce square root from IEEE float"><code>++sqt:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sub-ff' title="Subtract from IEEE float"><code>++sub:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sun-ff' title="Unsigned integer to IEEE float"><code>++sun:ff</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#toi-ff' title="Round IEEE float to nearest signed integer"><code>++toi:ff</code></a>
 
 <a class="tooltip" href='/docs/reference/library/3b/#fl'><code>++fl</code></a>
 <a class="tooltip" href='/docs/reference/library/3b/#abs-fl' title="Absolute value"><code>++abs:fl</code></a>
@@ -1169,20 +1169,20 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/3b/#prc-fl' title="Force precision of 2 or greater (floating point)"><code>++prc:fl</code></a>
 <a class="tooltip" href='/docs/reference/library/3b/#rau-fl' title="Various roundings (floating point)"><code>++rau:fl</code></a>
 <a class="tooltip" href='/docs/reference/library/3b/#rou-fl' title="Round to nearest float with 113-bit significand"><code>++rou:fl</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#san-fl'><code>++san:fl</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#shf-fl'><code>++shf:fl</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#spd-fl'><code>++spd:fl</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#spn-fl'><code>++spn:fl</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sqt-fl'><code>++sqt:fl</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sub-fl'><code>++sub:fl</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sun-fl'><code>++sun:fl</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#swr-fl'><code>++swr:fl</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#syn-fl'><code>++syn:fl</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#toi-fl'><code>++toi:fl</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#toj-fl'><code>++toj:fl</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#uni-fl'><code>++uni:fl</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#xpd-fl'><code>++xpd:fl</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#zer-fl'><code>++zer:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#san-fl' title="Signed integer to float"><code>++san:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#shf-fl' title="Shift power"><code>++shf:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#spd-fl' title="Produce smallest denormalized float"><code>++spd:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#spn-fl' title="Produce smallest normal float"><code>++spn:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sqt-fl' title="Produce square root from signed and unsigned integer cell"><code>++sqt:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sub-fl' title="Subtract from signed and unsigned integer cells"><code>++sub:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sun-fl' title="Unsigned integer to float"><code>++sun:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#swr-fl' title="Switch rounding mode of floating point"><code>++swr:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#syn-fl' title="Get sign"><code>++syn:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#toi-fl' title="Round float to nearest signed integer"><code>++toi:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#toj-fl' title="Round unsigned and signed integer to float"><code>++toj:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#uni-fl' title="Change representation to odd"><code>++uni:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#xpd-fl' title="Expand signed and unsigned integer cell"><code>++xpd:fl</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#zer-fl' title="Produce zero as float"><code>++zer:fl</code></a>
 
 <a class="tooltip" href='/docs/reference/library/3b/#rd'><code>++rd</code></a>
 <a class="tooltip" href='/docs/reference/library/3b/#add-rd' title="Add (double-precision float)"><code>++add:rd</code></a>
@@ -1199,13 +1199,13 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/3b/#lth-rd' title="Less than (double-precision float)"><code>++lth:rd</code></a>
 <a class="tooltip" href='/docs/reference/library/3b/#ma-rd' title="Initialize ff (rd core)"><code>++ma:rd</code></a>
 <a class="tooltip" href='/docs/reference/library/3b/#mul-rd' title="Multiply (double-precision float)"><code>++mul:rd</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#san-rd'><code>++san:rd</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sea-rd'><code>++sea:rd</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sig-rd'><code>++sig:rd</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sqt-rd'><code>++sqt:rd</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sub-rd'><code>++sub:rd</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sun-rd'><code>++sun:rd</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#toi-rd'><code>++toi:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#san-rd' title="Unsigned integer to @rd"><code>++san:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sea-rd' title="Convert from double-precision binary float to fn"><code>++sea:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sig-rd' title="Produce sign of @rd"><code>++sig:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sqt-rd' title="Produce square root of double-precision float"><code>++sqt:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sub-rd' title="Subtract from double-precision float"><code>++sub:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sun-rd' title="Unsigned integer to double-precision float"><code>++sun:rd</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#toi-rd' title="Round double-precision float to nearest signed integer"><code>++toi:rd</code></a>
 
 <a class="tooltip" href='/docs/reference/library/3b/#rh'><code>++rh</code></a>
 <a class="tooltip" href='/docs/reference/library/3b/#add-rh' title="Add (half-precision float)"><code>++add:rh</code></a>
@@ -1223,14 +1223,14 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/3b/#lth-rh' title="Less than (half-precision float)"><code>++lth:rh</code></a>
 <a class="tooltip" href='/docs/reference/library/3b/#ma-rh' title="Initialize ff (rh core)"><code>++ma:rh</code></a>
 <a class="tooltip" href='/docs/reference/library/3b/#mul-rh' title="Multiply (quad-precision float)"><code>++mul:rh</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#san-rh'><code>++san:rh</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sea-rh'><code>++sea:rh</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sig-rh'><code>++sig:rh</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sqt-rh'><code>++sqt:rh</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sub-rh'><code>++sub:rh</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sun-rh'><code>++sun:rh</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#toi-rh'><code>++toi:rh</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#tos-rh'><code>++tos:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#san-rh' title="Signed integer to @rh"><code>++san:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sea-rh' title="Convert from half-precision float to fn"><code>++sea:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sig-rh' title="Produce sign of half-precision float"><code>++sig:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sqt-rh' title="Produce square root of half-precision float"><code>++sqt:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sub-rh' title="Subtract from half-precision float"><code>++sub:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sun-rh' title="Unsigned integer to half-precision float"><code>++sun:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#toi-rh' title="Round half-precision float to nearest signed integer"><code>++toi:rh</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#tos-rh' title="Convert half-precision float to single-precision float"><code>++tos:rh</code></a>
 
 <a class="tooltip" href='/docs/reference/library/3b/#rs'><code>++rs</code></a>
 <a class="tooltip" href='/docs/reference/library/3b/#add-rs' title="Add (single-precision float)"><code>++add:rs</code></a>
@@ -1247,13 +1247,13 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/3b/#lth-rs' title="Less than (single-precision float)"><code>++lth:rs</code></a>
 <a class="tooltip" href='/docs/reference/library/3b/#ma-rs' title="Initialize ff (rs core)"><code>++ma:rs</code></a>
 <a class="tooltip" href='/docs/reference/library/3b/#mul-rs' title="Multiply (single-precision float)"><code>++mul:rs</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#san-rs'><code>++san:rs</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sea-rs'><code>++sea:rs</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sig-rs'><code>++sig:rs</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sqt-rs'><code>++sqt:rs</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sub-rs'><code>++sub:rs</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sun-rs'><code>++sun:rs</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#toi-rs'><code>++toi:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#san-rs' title="Signed integer to @rs"><code>++san:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sea-rs' title="Convert from single-precision float to fn"><code>++sea:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sig-rs' title="Produce sign of @rs"><code>++sig:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sqt-rs' title="Produce square root of single-precision float"><code>++sqt:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sub-rs' title="Subtract from single-precision float"><code>++sub:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sun-rs' title="Unsigned integer to single-precision float"><code>++sun:rs</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#toi-rs' title="Round single-precision float to nearest signed integer"><code>++toi:rs</code></a>
 
 <a class="tooltip" href='/docs/reference/library/3b/#rq'><code>++rq</code></a>
 <a class="tooltip" href='/docs/reference/library/3b/#add-rq' title="Add (quad-precision float)"><code>++add:rq</code></a>
@@ -1270,13 +1270,13 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/3b/#lth-rq' title="Less than (quad-precision float)"><code>++lth:rq</code></a>
 <a class="tooltip" href='/docs/reference/library/3b/#ma-rq' title="Initialize ff (rq core)"><code>++ma:rq</code></a>
 <a class="tooltip" href='/docs/reference/library/3b/#mul-rq' title="Multiply (quad-precision float)"><code>++mul:rq</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#san-rq'><code>++san:rq</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sea-rq'><code>++sea:rq</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sig-rq'><code>++sig:rq</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sqt-rq'><code>++sqt:rq</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sub-rq'><code>++sub:rq</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#sun-rq'><code>++sun:rq</code></a>
-<a class="tooltip" href='/docs/reference/library/3b/#toi-rq'><code>++toi:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#san-rq' title="Signed integer to @rq"><code>++san:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sea-rq' title="Convert from quad-precision float to fn"><code>++sea:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sig-rq' title="Produce sign of quad-precision float"><code>++sig:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sqt-rq' title="Produce square root of quad-precision float"><code>++sqt:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sub-rq' title="Subtract from quad-precision float"><code>++sub:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#sun-rq' title="Unsigned integer to quad-precision float"><code>++sun:rq</code></a>
+<a class="tooltip" href='/docs/reference/library/3b/#toi-rq' title="Round quad-precision float to nearest signed integer"><code>++toi:rq</code></a>
 
 <a class="tooltip" href='/docs/reference/library/3b/#rlyd'><code>++rlyd</code></a>
 <a class="tooltip" href='/docs/reference/library/3b/#rlyh'><code>++rlyh</code></a>
@@ -1289,7 +1289,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 3c: urbit time
 
-<a class="tooltip" href='/docs/reference/library/3c/#yo'><code>++yo</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yo' title="Time constants core"><code>++yo</code></a>
 <a class="tooltip" href='/docs/reference/library/3c/#cet-yo' title="Days in a century"><code>++cet:yo</code></a>
 <a class="tooltip" href='/docs/reference/library/3c/#day-yo' title="Seconds in day"><code>++day:yo</code></a>
 <a class="tooltip" href='/docs/reference/library/3c/#era-yo' title="Leap-year period"><code>++era:yo</code></a>
@@ -1299,15 +1299,15 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/3c/#moh-yo' title="Days in month"><code>++moh:yo</code></a>
 <a class="tooltip" href='/docs/reference/library/3c/#moy-yo' title="Days in months of leap-year"><code>++moy:yo</code></a>
 <a class="tooltip" href='/docs/reference/library/3c/#qad-yo' title="Seconds in 4 years"><code>++qad:yo</code></a>
-<a class="tooltip" href='/docs/reference/library/3c/#yer-yo'><code>++yer:yo</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yer-yo' title="Seconds in year"><code>++yer:yo</code></a>
 
-<a class="tooltip" href='/docs/reference/library/3c/#yall'><code>++yall</code></a>
-<a class="tooltip" href='/docs/reference/library/3c/#yawn'><code>++yawn</code></a>
-<a class="tooltip" href='/docs/reference/library/3c/#year'><code>++year</code></a>
-<a class="tooltip" href='/docs/reference/library/3c/#yell'><code>++yell</code></a>
-<a class="tooltip" href='/docs/reference/library/3c/#yelp'><code>++yelp</code></a>
-<a class="tooltip" href='/docs/reference/library/3c/#yore'><code>++yore</code></a>
-<a class="tooltip" href='/docs/reference/library/3c/#yule'><code>++yule</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yall' title="Time since beginning of time"><code>++yall</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yawn' title="Days since beginning of time"><code>++yawn</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#year' title="Date to @d"><code>++year</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yell' title="Tarp from atomic date"><code>++yell</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yelp' title="Determine if leap-week"><code>++yelp</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yore' title="Date from atomic date"><code>++yore</code></a>
+<a class="tooltip" href='/docs/reference/library/3c/#yule' title="Daily time to time atom"><code>++yule</code></a>
 
 ### 3d: SHA hash family
 
@@ -1317,16 +1317,16 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/3d/#raw-og' title="Random bits"><code>++raw:og</code></a>
 <a class="tooltip" href='/docs/reference/library/3d/#raws-og' title="Random bits continuation"><code>++raws:og</code></a>
 
-<a class="tooltip" href='/docs/reference/library/3d/#shad'><code>++shad</code></a>
-<a class="tooltip" href='/docs/reference/library/3d/#shaf'><code>++shaf</code></a>
-<a class="tooltip" href='/docs/reference/library/3d/#shal'><code>++shal</code></a>
-<a class="tooltip" href='/docs/reference/library/3d/#sham'><code>++sham</code></a>
-<a class="tooltip" href='/docs/reference/library/3d/#shan'><code>++shan</code></a>
-<a class="tooltip" href='/docs/reference/library/3d/#shas'><code>++shas</code></a>
-<a class="tooltip" href='/docs/reference/library/3d/#shaw'><code>++shaw</code></a>
-<a class="tooltip" href='/docs/reference/library/3d/#shax'><code>++shax</code></a>
-<a class="tooltip" href='/docs/reference/library/3d/#shay'><code>++shay</code></a>
-<a class="tooltip" href='/docs/reference/library/3d/#shaz'><code>++shaz</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shad' title="Double SHA-256"><code>++shad</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shaf' title="Half SHA-256"><code>++shaf</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shal' title="SHA-512 with length"><code>++shal</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#sham' title="128-bit noun hash"><code>++sham</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shan' title="SHA-1"><code>++shan</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shas' title="Salted hash"><code>++shas</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shaw' title="Hash to nbits"><code>++shaw</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shax' title="SHA-256"><code>++shax</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shay' title="SHA-256 with length"><code>++shay</code></a>
+<a class="tooltip" href='/docs/reference/library/3d/#shaz' title="SHA-512"><code>++shaz</code></a>
 
 ### 3e: AES encryption
 
@@ -1341,17 +1341,17 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/3f/#raku-ob' title="Key list"><code>++raku:ob</code></a>
 <a class="tooltip" href='/docs/reference/library/3f/#rund-ob' title="Reverse single Feistel-like"><code>++rund:ob</code></a>
 <a class="tooltip" href='/docs/reference/library/3f/#rynd-ob' title="Reverse Feistel-like cipher"><code>++rynd:ob</code></a>
-<a class="tooltip" href='/docs/reference/library/3f/#teil-ob'><code>++teil:ob</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#teil-ob' title="Reverse Feistel-like cipher"><code>++teil:ob</code></a>
 
-<a class="tooltip" href='/docs/reference/library/3f/#un'><code>++un</code></a>
-<a class="tooltip" href='/docs/reference/library/3f/#wred-un'><code>++wred:un</code></a>
-<a class="tooltip" href='/docs/reference/library/3f/#wren-un'><code>++wren:un</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#un' title="Reversible scrambling"><code>++un</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#wred-un' title="Restore structure"><code>++wred:un</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#wren-un' title="Conceal structure"><code>++wren:un</code></a>
 <a class="tooltip" href='/docs/reference/library/3f/#xafo-un'><code>++xafo:un</code></a>
 <a class="tooltip" href='/docs/reference/library/3f/#xaro-un'><code>++xaro:un</code></a>
-<a class="tooltip" href='/docs/reference/library/3f/#zaft-un'><code>++zaft:un</code></a>
-<a class="tooltip" href='/docs/reference/library/3f/#zart-un'><code>++zart:un</code></a>
-<a class="tooltip" href='/docs/reference/library/3f/#zyft-un'><code>++zyft:un</code></a>
-<a class="tooltip" href='/docs/reference/library/3f/#zyrt-un'><code>++zyrt:un</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#zaft-un' title="Look up in 255 sub box"><code>++zaft:un</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#zart-un' title="Reverse look up in 255 sub box"><code>++zart:un</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#zyft-un' title="Lookup byte in 256 sub box"><code>++zyft:un</code></a>
+<a class="tooltip" href='/docs/reference/library/3f/#zyrt-un' title="Reverse lookup byte in 256 sub box"><code>++zyrt:un</code></a>
 
 ### 3g: molds and mold builders
 
@@ -1364,18 +1364,18 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/3g/#path' title="Filesystem path"><code>++path</code></a>
 <a class="tooltip" href='/docs/reference/library/3g/#pint' title="Parsing range"><code>++pint</code></a>
 <a class="tooltip" href='/docs/reference/library/3g/#rule' title="Parsing rule (match this with _)"><code>++rule</code></a>
-<a class="tooltip" href='/docs/reference/library/3g/#spot'><code>++spot</code></a>
-<a class="tooltip" href='/docs/reference/library/3g/#tone'><code>++tone</code></a>
-<a class="tooltip" href='/docs/reference/library/3g/#toon'><code>++toon</code></a>
-<a class="tooltip" href='/docs/reference/library/3g/#wonk'><code>++wonk</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#spot' title="Stack trace line"><code>++spot</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#tone' title="Nock result (error report)"><code>++tone</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#toon' title="Nock result (stack trace)"><code>++toon</code></a>
+<a class="tooltip" href='/docs/reference/library/3g/#wonk' title="Product from edge"><code>++wonk</code></a>
 
 ### 4a: exotic bases
 
 <a class="tooltip" href='/docs/reference/library/4a/#po' title="Phonetic base"><code>++po</code></a>
 <a class="tooltip" href='/docs/reference/library/4a/#ind-po' title="Parse suffix"><code>++ind:po</code></a>
 <a class="tooltip" href='/docs/reference/library/4a/#ins-po' title="Parse prefix"><code>++ins:po</code></a>
-<a class="tooltip" href='/docs/reference/library/4a/#tod-po'><code>++tod:po</code></a>
-<a class="tooltip" href='/docs/reference/library/4a/#tos-po'><code>++tos:po</code></a>
+<a class="tooltip" href='/docs/reference/library/4a/#tod-po' title="Fetch suffix"><code>++tod:po</code></a>
+<a class="tooltip" href='/docs/reference/library/4a/#tos-po' title="Fetch prefix"><code>++tos:po</code></a>
 
 ### 4b: text processing
 
@@ -1398,19 +1398,19 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/4b/#cuss' title="To uppercase"><code>++cuss</code></a>
 <a class="tooltip" href='/docs/reference/library/4b/#mesc' title="Escape special characters"><code>++mesc</code></a>
 <a class="tooltip" href='/docs/reference/library/4b/#runt' title="Prepend n times"><code>++runt</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#sand'><code>++sand</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#sane'><code>++sane</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#teff'><code>++teff</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#trim'><code>++trim</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#trip'><code>++trip</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#tuba'><code>++tuba</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#tufa'><code>++tufa</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#tuft'><code>++tuft</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#turf'><code>++turf</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#wack'><code>++wack</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#wick'><code>++wick</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#woad'><code>++woad</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#wood'><code>++wood</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#sand' title="Soft-cast by odor"><code>++sand</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#sane' title="Check odor validity"><code>++sane</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#teff' title="UTF-8 length"><code>++teff</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#trim' title="Tape split"><code>++trim</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#trip' title="Cord to tape"><code>++trip</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#tuba' title="UTF-8 to UTF-32 tape"><code>++tuba</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#tufa' title="UTF-32 to UTF-8 tape"><code>++tufa</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#tuft' title="UTF-32 to UTF-8 text"><code>++tuft</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#turf' title="UTF-8 to UTF-32 cord"><code>++turf</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#wack' title="Coin format encode"><code>++wack</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#wick' title="Coin format decode"><code>++wick</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#woad' title="Unescape cord"><code>++woad</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#wood' title="Escape cord"><code>++wood</code></a>
 
 ### 4c: tank printer
 
@@ -1419,12 +1419,12 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/4c/#fit-re' title="Fit on one line test"><code>++fit:re</code></a>
 <a class="tooltip" href='/docs/reference/library/4c/#ram-re' title="Flatten tank to tape"><code>++ram:re</code></a>
 <a class="tooltip" href='/docs/reference/library/4c/#rig-re' title="Wrap tape in / (tank)"><code>++rig:re</code></a>
-<a class="tooltip" href='/docs/reference/library/4c/#wig-re'><code>++wig:re</code></a>
-<a class="tooltip" href='/docs/reference/library/4c/#win-re'><code>++win:re</code></a>
+<a class="tooltip" href='/docs/reference/library/4c/#wig-re' title="++win - render tape"><code>++wig:re</code></a>
+<a class="tooltip" href='/docs/reference/library/4c/#win-re' title="Render at indent"><code>++win:re</code></a>
 
-<a class="tooltip" href='/docs/reference/library/4c/#shep'><code>++shep</code></a>
-<a class="tooltip" href='/docs/reference/library/4c/#shop'><code>++shop</code></a>
-<a class="tooltip" href='/docs/reference/library/4c/#show'><code>++show</code></a>
+<a class="tooltip" href='/docs/reference/library/4c/#shep' title="(Undocumented)"><code>++shep</code></a>
+<a class="tooltip" href='/docs/reference/library/4c/#shop' title="(Undocumented)"><code>++shop</code></a>
+<a class="tooltip" href='/docs/reference/library/4c/#show' title="(Undocumented)"><code>++show</code></a>
 
 ### 4d: parsing (tracing)
 
@@ -1441,8 +1441,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/4e/#pfix' title="Discard first rule"><code>++pfix</code></a>
 <a class="tooltip" href='/docs/reference/library/4e/#plug' title="Parse to tuple"><code>++plug</code></a>
 <a class="tooltip" href='/docs/reference/library/4e/#pose' title="Parse options"><code>++pose</code></a>
-<a class="tooltip" href='/docs/reference/library/4e/#sfix'><code>++sfix</code></a>
-<a class="tooltip" href='/docs/reference/library/4e/#simu'><code>++simu</code></a>
+<a class="tooltip" href='/docs/reference/library/4e/#sfix' title="Discard second rule"><code>++sfix</code></a>
+<a class="tooltip" href='/docs/reference/library/4e/#simu' title="First and second"><code>++simu</code></a>
 
 ### 4f: parsing (rule builders)
 
@@ -1463,22 +1463,22 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/4f/#most' title="Parse list of at least one match"><code>++most</code></a>
 <a class="tooltip" href='/docs/reference/library/4f/#next' title="Consume character"><code>++next</code></a>
 <a class="tooltip" href='/docs/reference/library/4f/#plus' title="List of at least one match"><code>++plus</code></a>
-<a class="tooltip" href='/docs/reference/library/4f/#sear'><code>++sear</code></a>
-<a class="tooltip" href='/docs/reference/library/4f/#shim'><code>++shim</code></a>
-<a class="tooltip" href='/docs/reference/library/4f/#slug'><code>++slug</code></a>
-<a class="tooltip" href='/docs/reference/library/4f/#stag'><code>++stag</code></a>
-<a class="tooltip" href='/docs/reference/library/4f/#star'><code>++star</code></a>
-<a class="tooltip" href='/docs/reference/library/4f/#stet'><code>++stet</code></a>
-<a class="tooltip" href='/docs/reference/library/4f/#stew'><code>++stew</code></a>
-<a class="tooltip" href='/docs/reference/library/4f/#stir'><code>++stir</code></a>
-<a class="tooltip" href='/docs/reference/library/4f/#stun'><code>++stun</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#sear' title="Conditional ++cook"><code>++sear</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#shim' title="Match character within range"><code>++shim</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#slug' title="Use gate to parse delimited list"><code>++slug</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#stag' title="Add label"><code>++stag</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#star' title="Produce list of matches"><code>++star</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#stet' title="Add faces to range-parser pairs in list"><code>++stet</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#stew' title="Switch by first"><code>++stew</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#stir' title="Parse repeatedly"><code>++stir</code></a>
+<a class="tooltip" href='/docs/reference/library/4f/#stun' title="Parse several times"><code>++stun</code></a>
 
 ### 4g: parsing (outside caller)
 
 <a class="tooltip" href='/docs/reference/library/4g/#rash' title="Parse or crash"><code>++rash</code></a>
 <a class="tooltip" href='/docs/reference/library/4g/#rush' title="Parse or null"><code>++rush</code></a>
 <a class="tooltip" href='/docs/reference/library/4g/#rust' title="Parse tape or null"><code>++rust</code></a>
-<a class="tooltip" href='/docs/reference/library/4g/#scan'><code>++scan</code></a>
+<a class="tooltip" href='/docs/reference/library/4g/#scan' title="Parse tape or crash"><code>++scan</code></a>
 
 ### 4h: parsing (ascii glyphs)
 
@@ -1505,16 +1505,16 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/4h/#pat' title="Parse @ (pat)"><code>++pat</code></a>
 <a class="tooltip" href='/docs/reference/library/4h/#pel' title="Parse ( (pel)"><code>++pel</code></a>
 <a class="tooltip" href='/docs/reference/library/4h/#per' title="Parse ) (per)"><code>++per</code></a>
-<a class="tooltip" href='/docs/reference/library/4h/#sel'><code>++sel</code></a>
-<a class="tooltip" href='/docs/reference/library/4h/#sem'><code>++sem</code></a>
-<a class="tooltip" href='/docs/reference/library/4h/#ser'><code>++ser</code></a>
-<a class="tooltip" href='/docs/reference/library/4h/#sig'><code>++sig</code></a>
-<a class="tooltip" href='/docs/reference/library/4h/#soq'><code>++soq</code></a>
-<a class="tooltip" href='/docs/reference/library/4h/#tar'><code>++tar</code></a>
-<a class="tooltip" href='/docs/reference/library/4h/#tec'><code>++tec</code></a>
-<a class="tooltip" href='/docs/reference/library/4h/#tis'><code>++tis</code></a>
-<a class="tooltip" href='/docs/reference/library/4h/#wut'><code>++wut</code></a>
-<a class="tooltip" href='/docs/reference/library/4h/#zap'><code>++zap</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#sel' title="Parse [ (sel)"><code>++sel</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#sem' title="Parse ; (sem)"><code>++sem</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#ser' title="Parse ] (ser)"><code>++ser</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#sig' title="Parse ~ (sig)"><code>++sig</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#soq' title="Parse ' (soq)"><code>++soq</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#tar' title="Parse * (tar)"><code>++tar</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#tec' title="Parse ` (tec)"><code>++tec</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#tis' title="Parse = (tis)"><code>++tis</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#wut' title="Parse ? (wut)"><code>++wut</code></a>
+<a class="tooltip" href='/docs/reference/library/4h/#zap' title="Parse ! (zap)"><code>++zap</code></a>
 
 ### 4i: parsing (useful idioms)
 
@@ -1549,11 +1549,11 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/4i/#prn' title="Parse any printable character"><code>++prn</code></a>
 <a class="tooltip" href='/docs/reference/library/4i/#qit' title="Parse character to cord atom"><code>++qit</code></a>
 <a class="tooltip" href='/docs/reference/library/4i/#qut' title="Parse cord"><code>++qut</code></a>
-<a class="tooltip" href='/docs/reference/library/4i/#soz'><code>++soz</code></a>
-<a class="tooltip" href='/docs/reference/library/4i/#sym'><code>++sym</code></a>
-<a class="tooltip" href='/docs/reference/library/4i/#ven'><code>++ven</code></a>
-<a class="tooltip" href='/docs/reference/library/4i/#vit'><code>++vit</code></a>
-<a class="tooltip" href='/docs/reference/library/4i/#vul'><code>++vul</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#soz' title="Parse triple single-quote"><code>++soz</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#sym' title="Term"><code>++sym</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#ven' title="Axis syntax parser"><code>++ven</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#vit' title="Parse base 64 digit"><code>++vit</code></a>
+<a class="tooltip" href='/docs/reference/library/4i/#vul' title="Comments to null"><code>++vul</code></a>
 
 ### 4j: parsing (bases and base digits)
 
@@ -1570,27 +1570,27 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/4j/#qex-ab' title="Parse <=4 hexadecimal digits"><code>++qex:ab</code></a>
 <a class="tooltip" href='/docs/reference/library/4j/#qib-ab' title="Parse 4 binary digits"><code>++qib:ab</code></a>
 <a class="tooltip" href='/docs/reference/library/4j/#qix-ab' title="Parse 4 hexadecimal digits"><code>++qix:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#seb-ab'><code>++seb:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#sed-ab'><code>++sed:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#sev-ab'><code>++sev:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#sew-ab'><code>++sew:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#sex-ab'><code>++sex:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#sib-ab'><code>++sib:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#sid-ab'><code>++sid:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#siv-ab'><code>++siv:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#siw-ab'><code>++siw:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#six-ab'><code>++six:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#sov-ab'><code>++sov:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#sow-ab'><code>++sow:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#sox-ab'><code>++sox:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#ted-ab'><code>++ted:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#tid-ab'><code>++tid:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#til-ab'><code>++til:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#tip-ab'><code>++tip:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#tiq-ab'><code>++tiq:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#urs-ab'><code>++urs:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#urt-ab'><code>++urt:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#voy-ab'><code>++voy:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#seb-ab' title="Parse 1"><code>++seb:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sed-ab' title="Parse non-zero decimal digit"><code>++sed:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sev-ab' title="Parse non-zero base 32 digit"><code>++sev:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sew-ab' title="Parse non-zero base 64 digit"><code>++sew:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sex-ab' title="Parse nonzero hexadecimal digit"><code>++sex:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sib-ab' title="Parse binary digit"><code>++sib:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sid-ab' title="Parse decimal digit"><code>++sid:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#siv-ab' title="Parse a base 32 digit"><code>++siv:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#siw-ab' title="Parse a base 64 digit"><code>++siw:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#six-ab' title="Parse a hexadecimal digit"><code>++six:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sov-ab' title="Parse base 32 letter"><code>++sov:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sow-ab' title="Parse base 64 letter/symbol"><code>++sow:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#sox-ab' title="Parse hexadecimal letter"><code>++sox:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#ted-ab' title="Parse decimal number with <= 3 digits"><code>++ted:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#tid-ab' title="Parse 3 decimal digits"><code>++tid:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#til-ab' title="Parse 3 lowercase letters"><code>++til:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#tip-ab' title="Leading phonetic byte"><code>++tip:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#tiq-ab' title="Trailing phonetic syllable"><code>++tiq:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#urs-ab' title="Parse span characters"><code>++urs:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#urt-ab' title="Parse non-_ span"><code>++urt:ab</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#voy-ab' title="Parse bas, soq, or bix"><code>++voy:ab</code></a>
 
 <a class="tooltip" href='/docs/reference/library/4j/#ag' title="Top-level atom parser engine"><code>++ag</code></a>
 <a class="tooltip" href='/docs/reference/library/4j/#ape-ag' title="Parse 0 or rule"><code>++ape:ag</code></a>
@@ -1602,20 +1602,20 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/4j/#fed-ag' title="Parse @p"><code>++fed:ag</code></a>
 <a class="tooltip" href='/docs/reference/library/4j/#hex-ag' title="Parse hexadecimal number"><code>++hex:ag</code></a>
 <a class="tooltip" href='/docs/reference/library/4j/#lip-ag' title="Parse IPv4 address"><code>++lip:ag</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#viz-ag'><code>++viz:ag</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#vum-ag'><code>++vum:ag</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#wiz-ag'><code>++wiz:ag</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#viz-ag' title="Parse base 32 digit with dot separators"><code>++viz:ag</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#vum-ag' title="Parse base 32 string"><code>++vum:ag</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#wiz-ag' title="Parse base 64 number"><code>++wiz:ag</code></a>
 
 <a class="tooltip" href='/docs/reference/library/4j/#mu' title="Core used to scramble 16-bit atoms"><code>++mu</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#zag-mu'><code>++zag:mu</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#zig-mu'><code>++zig:mu</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#zug-mu'><code>++zug:mu</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#zag-mu' title="Add bottom into top"><code>++zag:mu</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#zig-mu' title="Subtract bottom from top"><code>++zig:mu</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#zug-mu' title="Concatenate into atom"><code>++zug:mu</code></a>
 
 <a class="tooltip" href='/docs/reference/library/4j/#ne' title="Digit rendering engine"><code>++ne</code></a>
 <a class="tooltip" href='/docs/reference/library/4j/#d-ne' title="Render decimal"><code>++d:ne</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#v-ne'><code>++v:ne</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#w-ne'><code>++w:ne</code></a>
-<a class="tooltip" href='/docs/reference/library/4j/#x-ne'><code>++x:ne</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#v-ne' title="Render base 32"><code>++v:ne</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#w-ne' title="Render base 64 digit"><code>++w:ne</code></a>
+<a class="tooltip" href='/docs/reference/library/4j/#x-ne' title="Render hexadecimal digit as atom of ASCII byte value"><code>++x:ne</code></a>
 
 ### 4k: parsing (atom printing)
 
@@ -1626,7 +1626,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 4l: parsing (atom parsing)
 
-<a class="tooltip" href='/docs/reference/library/4l/#so'><code>++so</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#so' title="Coin parser engine"><code>++so</code></a>
 <a class="tooltip" href='/docs/reference/library/4l/#bisk-so' title="Parse odor-atom pair"><code>++bisk:so</code></a>
 <a class="tooltip" href='/docs/reference/library/4l/#crub-so' title="Parse @da, @dr, @p, @t"><code>++crub:so</code></a>
 <a class="tooltip" href='/docs/reference/library/4l/#nuck-so' title="Top-level coin parser"><code>++nuck:so</code></a>
@@ -1634,22 +1634,22 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/4l/#perd-so' title="Parses dime/tiple without standard prefixes"><code>++perd:so</code></a>
 <a class="tooltip" href='/docs/reference/library/4l/#royl-so' title="Parse dime float"><code>++royl:so</code></a>
 <a class="tooltip" href='/docs/reference/library/4l/#royl-cell-so' title="(Undocumented)"><code>++royl-cell:so</code></a>
-<a class="tooltip" href='/docs/reference/library/4l/#tash-so'><code>++tash:so</code></a>
-<a class="tooltip" href='/docs/reference/library/4l/#twid-so'><code>++twid:so</code></a>
-<a class="tooltip" href='/docs/reference/library/4l/#zust-so'><code>++zust:so</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#tash-so' title="Parse signed dime"><code>++tash:so</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#twid-so' title="Parse coins without ~ prefix"><code>++twid:so</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#zust-so' title="Parse prefixed dimes from IP, loobean, or floating point"><code>++zust:so</code></a>
 
 ### 4m: parsing (formatting functions)
 
-<a class="tooltip" href='/docs/reference/library/4m/#scot'><code>++scot</code></a>
-<a class="tooltip" href='/docs/reference/library/4m/#scow'><code>++scow</code></a>
-<a class="tooltip" href='/docs/reference/library/4m/#slat'><code>++slat</code></a>
-<a class="tooltip" href='/docs/reference/library/4m/#slav'><code>++slav</code></a>
-<a class="tooltip" href='/docs/reference/library/4m/#slaw'><code>++slaw</code></a>
-<a class="tooltip" href='/docs/reference/library/4m/#slay'><code>++slay</code></a>
-<a class="tooltip" href='/docs/reference/library/4m/#smyt'><code>++smyt</code></a>
-<a class="tooltip" href='/docs/reference/library/4m/#spat'><code>++spat</code></a>
-<a class="tooltip" href='/docs/reference/library/4m/#spud'><code>++spud</code></a>
-<a class="tooltip" href='/docs/reference/library/4m/#stab'><code>++stab</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#scot' title="Render dime as cord"><code>++scot</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#scow' title="Render dime as tape"><code>++scow</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#slat' title="Curried slaw"><code>++slat</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#slav' title="Demand: parse cord with input odor"><code>++slav</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#slaw' title="Parse cord to input odor"><code>++slaw</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#slay' title="Parse cord to coin"><code>++slay</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#smyt' title="Render path as tank"><code>++smyt</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#spat' title="Render path as cord"><code>++spat</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#spud' title="Render path as tape"><code>++spud</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#stab' title="Parse cord to path"><code>++stab</code></a>
 
 ### 4n: parsing (virtualization)
 
@@ -1680,18 +1680,18 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/4o/#noun' title="(Undocumented)"><code>++noun</code></a>
 <a class="tooltip" href='/docs/reference/library/4o/#null' title="(Undocumented)"><code>++null</code></a>
 <a class="tooltip" href='/docs/reference/library/4o/#port' title="(Undocumented)"><code>++port</code></a>
-<a class="tooltip" href='/docs/reference/library/4o/#span'><code>++span</code></a>
-<a class="tooltip" href='/docs/reference/library/4o/#tiki'><code>++tiki</code></a>
-<a class="tooltip" href='/docs/reference/library/4o/#toga'><code>++toga</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#span' title="ASCII atom"><code>++span</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#tiki' title="(Undocumented)"><code>++tiki</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#toga' title="Tree of faces"><code>++toga</code></a>
 <a class="tooltip" href='/docs/reference/library/4o/#tone'><code>++tone</code></a>
-<a class="tooltip" href='/docs/reference/library/4o/#tuna'><code>++tuna</code></a>
-<a class="tooltip" href='/docs/reference/library/4o/#tusk'><code>++tusk</code></a>
-<a class="tooltip" href='/docs/reference/library/4o/#tyke'><code>++tyke</code></a>
-<a class="tooltip" href='/docs/reference/library/4o/#typo'><code>++typo</code></a>
-<a class="tooltip" href='/docs/reference/library/4o/#tyre'><code>++tyre</code></a>
-<a class="tooltip" href='/docs/reference/library/4o/#vase'><code>++vase</code></a>
-<a class="tooltip" href='/docs/reference/library/4o/#vise'><code>++vise</code></a>
-<a class="tooltip" href='/docs/reference/library/4o/#wing'><code>++wing</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#tuna' title="XML template tree"><code>++tuna</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#tusk' title="List of expressions"><code>++tusk</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#tyke' title="List of 'maybe' hoons"><code>++tyke</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#typo' title="Pointer for ++type"><code>++typo</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#tyre' title="List, term hoon"><code>++tyre</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#vase' title="Typed data"><code>++vase</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#vise' title="Convert during reboot"><code>++vise</code></a>
+<a class="tooltip" href='/docs/reference/library/4o/#wing' title="Address in subject"><code>++wing</code></a>
 
 ### 5a: compiler utilities
 

--- a/reference/library/_index.md
+++ b/reference/library/_index.md
@@ -13,1718 +13,1718 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### a
 
-<a href='https://urbit.org/docs/reference/library/4j.md#ab' data-tippy-content="Primitive parser engine"><code>++ab</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#abs-fl' data-tippy-content="Absolute value"><code>++abs:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#abs-si' data-tippy-content="Absolute value (signed integer)"><code>++abs:si</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#abel' data-tippy-content="Compiler alias"><code>++abel</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#ace' data-tippy-content="Parse space"><code>++ace</code></a>
-<a href='https://urbit.org/docs/reference/library/1a.md#add' data-tippy-content="Add"><code>++add</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#add-ff' data-tippy-content="Add (floating point)"><code>++add:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#add-fl' data-tippy-content="Add (with exact/rounded flag)"><code>++add:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/2j.md#add-ja' data-tippy-content="Prepend to list"><code>+-add:ja</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#add-rd' data-tippy-content="Add (double-precision float)"><code>++add:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#add-rh' data-tippy-content="Add (half-precision float)"><code>++add:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#add-rs' data-tippy-content="Add (single-precision float)"><code>++add:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#add-rq' data-tippy-content="Add (quad-precision float)"><code>++add:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#ag' data-tippy-content="Top-level atom parser engine"><code>++ag</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#alf' data-tippy-content="Parse alphabetic characters"><code>++alf</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#all-by' data-tippy-content="Logical AND (map and wet gate)"><code>+-all:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#all-in' data-tippy-content="Logical AND (set and wet gate)"><code>+-all:in</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#aln' data-tippy-content="Parse alphanumeric characters"><code>++aln</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#alp' data-tippy-content="Parse alphanumeric characters and -"><code>++alp</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#any-by' data-tippy-content="Logical OR (map and wet gate)"><code>+-any:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#any-in' data-tippy-content="Logical OR (set and gate)"><code>+-any:in</code></a>
-<a href='https://urbit.org/docs/reference/library/2f.md#aor' data-tippy-content="Alphabetical order"><code>++aor</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#ape-ag' data-tippy-content="Parse 0 or rule"><code>++ape:ag</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#apt-by' data-tippy-content="Check correctness (map)"><code>+-apt:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#apt-in' data-tippy-content="Check correctness (set)"><code>+-apt:in</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#at' data-tippy-content="(Undocumented)"><code>++at</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#aura' data-tippy-content="'Type' of atom"><code>++aura</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#axis' data-tippy-content="Nock axis"><code>++axis</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#ab' data-tippy-content="Primitive parser engine"><code>++ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#abs-fl' data-tippy-content="Absolute value"><code>++abs:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#abs-si' data-tippy-content="Absolute value (signed integer)"><code>++abs:si</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#abel' data-tippy-content="Compiler alias"><code>++abel</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#ace' data-tippy-content="Parse space"><code>++ace</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#add' data-tippy-content="Add"><code>++add</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#add-ff' data-tippy-content="Add (floating point)"><code>++add:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#add-fl' data-tippy-content="Add (with exact/rounded flag)"><code>++add:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#add-ja' data-tippy-content="Prepend to list"><code>+-add:ja</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#add-rd' data-tippy-content="Add (double-precision float)"><code>++add:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#add-rh' data-tippy-content="Add (half-precision float)"><code>++add:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#add-rs' data-tippy-content="Add (single-precision float)"><code>++add:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#add-rq' data-tippy-content="Add (quad-precision float)"><code>++add:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#ag' data-tippy-content="Top-level atom parser engine"><code>++ag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#alf' data-tippy-content="Parse alphabetic characters"><code>++alf</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#all-by' data-tippy-content="Logical AND (map and wet gate)"><code>+-all:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#all-in' data-tippy-content="Logical AND (set and wet gate)"><code>+-all:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#aln' data-tippy-content="Parse alphanumeric characters"><code>++aln</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#alp' data-tippy-content="Parse alphanumeric characters and -"><code>++alp</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#any-by' data-tippy-content="Logical OR (map and wet gate)"><code>+-any:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#any-in' data-tippy-content="Logical OR (set and gate)"><code>+-any:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2f.md#aor' data-tippy-content="Alphabetical order"><code>++aor</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#ape-ag' data-tippy-content="Parse 0 or rule"><code>++ape:ag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#apt-by' data-tippy-content="Check correctness (map)"><code>+-apt:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#apt-in' data-tippy-content="Check correctness (set)"><code>+-apt:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#at' data-tippy-content="(Undocumented)"><code>++at</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#aura' data-tippy-content="'Type' of atom"><code>++aura</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#axis' data-tippy-content="Nock axis"><code>++axis</code></a>
 
 ### b
 
-<a href='https://urbit.org/docs/reference/library/2k.md#bal-to'><code>+-bal:to</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#bar'><code>++bar</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#bas'><code>++bas</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#base'><code>++base</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#bass'><code>++bass</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#bay-ag'><code>++bay:ag</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#bean'><code>++bean</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#beer'><code>++beer</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#beet'><code>++beet</code></a>
-<a href='https://urbit.org/docs/reference/library/4e.md#bend'><code>++bend</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#bet'><code>++bet</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#bex'><code>++bex</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#bif-ff'><code>++bif:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#bif-by'><code>+-bif:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#bif-in'><code>+-bif:in</code></a>
-<a href='https://urbit.org/docs/reference/library/2a.md#biff'><code>++biff</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#bin'><code>++bin</code></a>
-<a href='https://urbit.org/docs/reference/library/2a.md#bind'><code>++bind</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#bip-ag'><code>++bip:ag</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#bit-ff'><code>++bit:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#bit-rd'><code>++bit:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#bit-rh'><code>++bit:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#bit-rs'><code>++bit:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#bit-rq'><code>++bit:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#bix-ab'><code>++bix:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4l.md#bisk-so'><code>++bisk:so</code></a>
-<a href='https://urbit.org/docs/reference/library/1c.md#bloq'><code>++bloq</code></a>
-<a href='https://urbit.org/docs/reference/library/2a.md#bond'><code>++bond</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#boss'><code>++boss</code></a>
-<a href='https://urbit.org/docs/reference/library/2a.md#both'><code>++both</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#buc'><code>++buc</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#but'><code>++but</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#bal-to'><code>+-bal:to</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#bar'><code>++bar</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#bas'><code>++bas</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#base'><code>++base</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#bass'><code>++bass</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#bay-ag'><code>++bay:ag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#bean'><code>++bean</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#beer'><code>++beer</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#beet'><code>++beet</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#bend'><code>++bend</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#bet'><code>++bet</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#bex'><code>++bex</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bif-ff'><code>++bif:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#bif-by'><code>+-bif:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#bif-in'><code>+-bif:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#biff'><code>++biff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#bin'><code>++bin</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#bind'><code>++bind</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#bip-ag'><code>++bip:ag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-ff'><code>++bit:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rd'><code>++bit:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rh'><code>++bit:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rs'><code>++bit:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rq'><code>++bit:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#bix-ab'><code>++bix:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#bisk-so'><code>++bisk:so</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#bloq'><code>++bloq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#bond'><code>++bond</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#boss'><code>++boss</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#both'><code>++both</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#buc'><code>++buc</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#but'><code>++but</code></a>
 
 ### c
 
-<a href='https://urbit.org/docs/reference/library/4h.md#cab'><code>++cab</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#can'><code>++can</code></a>
-<a href='https://urbit.org/docs/reference/library/1b.md#cap'><code>++cap</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#cass'><code>++cass</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#cat'><code>++cat</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#cen'><code>++cen</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#cet-yo'><code>++cet:yo</code></a>
-<a href='https://urbit.org/docs/reference/library/2q.md#char'><code>++char</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#chum'><code>++chum</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#cit'><code>++cit</code></a>
-<a href='https://urbit.org/docs/reference/library/2a.md#clap'><code>++clap</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#cmp-si'><code>++cmp:si</code></a>
-<a href='https://urbit.org/docs/reference/library/4k.md#co'><code>++co</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#coil'><code>++coil</code></a>
-<a href='https://urbit.org/docs/reference/library/3g.md#coin'><code>++coin</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#col'><code>++col</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#cold'><code>++cold</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#com'><code>++com</code></a>
-<a href='https://urbit.org/docs/reference/library/4e.md#comp'><code>++comp</code></a>
-<a href='https://urbit.org/docs/reference/library/2d.md#con'><code>++con</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#cook'><code>++cook</code></a>
-<a href='https://urbit.org/docs/reference/library/2q.md#cord'><code>++cord</code></a>
-<a href='https://urbit.org/docs/reference/library/2n.md#cork'><code>++cork</code></a>
-<a href='https://urbit.org/docs/reference/library/2n.md#corl'><code>++corl</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#crip'><code>++crip</code></a>
-<a href='https://urbit.org/docs/reference/library/4l.md#crub-so'><code>++crub:so</code></a>
-<a href='https://urbit.org/docs/reference/library/2p.md#cue'><code>++cue</code></a>
-<a href='https://urbit.org/docs/reference/library/2n.md#curr'><code>++curr</code></a>
-<a href='https://urbit.org/docs/reference/library/2n.md#cury'><code>++cury</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#cuss'><code>++cuss</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#cut'><code>++cut</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#cab'><code>++cab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#can'><code>++can</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1b.md#cap'><code>++cap</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#cass'><code>++cass</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#cat'><code>++cat</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#cen'><code>++cen</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#cet-yo'><code>++cet:yo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#char'><code>++char</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#chum'><code>++chum</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#cit'><code>++cit</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#clap'><code>++clap</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#cmp-si'><code>++cmp:si</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4k.md#co'><code>++co</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#coil'><code>++coil</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#coin'><code>++coin</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#col'><code>++col</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#cold'><code>++cold</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#com'><code>++com</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#comp'><code>++comp</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2d.md#con'><code>++con</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#cook'><code>++cook</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#cord'><code>++cord</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#cork'><code>++cork</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#corl'><code>++corl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#crip'><code>++crip</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#crub-so'><code>++crub:so</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2p.md#cue'><code>++cue</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#curr'><code>++curr</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#cury'><code>++cury</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#cuss'><code>++cuss</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#cut'><code>++cut</code></a>
 
 ### d
 
-<a href='https://urbit.org/docs/reference/library/4j.md#d-ne'><code>++d:ne</code></a>
-<a href='https://urbit.org/docs/reference/library/2q.md#date'><code>++date</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#day-yo'><code>++day:yo</code></a>
-<a href='https://urbit.org/docs/reference/library/1a.md#dec'><code>++dec</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#def-by'><code>+-def:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#del-by'><code>+-del:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#del-in'><code>+-del:in</code></a>
-<a href='https://urbit.org/docs/reference/library/2j.md#del-ju'><code>+-del:ju</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#dem'><code>++dem</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#dem-ag'><code>++dem:ag</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#den-fl'><code>++den:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#dep-by'><code>+-dep:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2k.md#dep-to'><code>+-dep:to</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#dif-fe'><code>++dif:fe</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#dif-fo'><code>++dif:fo</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#dif-in'><code>+-dif:in</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#dif-si'><code>++dif:si</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#dig-by'><code>+-dig:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#dig-in'><code>+-dig:in</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#dim-ag'><code>++dim:ag</code></a>
-<a href='https://urbit.org/docs/reference/library/3g.md#dime'><code>++dime</code></a>
-<a href='https://urbit.org/docs/reference/library/4c.md#din-re'><code>++din:re</code></a>
-<a href='https://urbit.org/docs/reference/library/2d.md#dis'><code>++dis</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#dit'><code>++dit</code></a>
-<a href='https://urbit.org/docs/reference/library/1a.md#div'><code>++div</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#div-ff'><code>++div:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#div-fl'><code>++div:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#div-rd'><code>++div:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#div-rh'><code>++div:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#div-rs'><code>++div:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#div-rq'><code>++div:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#dog'><code>++dog</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#doh'><code>++doh</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#doq'><code>++doq</code></a>
-<a href='https://urbit.org/docs/reference/library/2f.md#dor'><code>++dor</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#dot'><code>++dot</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#drg-ff'><code>++drg:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#drg-fl'><code>++drg:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#drg-rd'><code>++drg:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#drg-rh'><code>++drg:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#drg-rs'><code>++drg:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#drg-rq'><code>++drg:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/2a.md#drop'><code>++drop</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#dul-si'><code>++dul:si</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#dum-ag'><code>++dum:ag</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#dun'><code>++dun</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#duz'><code>++duz</code></a>
-<a href='https://urbit.org/docs/reference/library/1a.md#dvr'><code>++dvr</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#d-ne'><code>++d:ne</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#date'><code>++date</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#day-yo'><code>++day:yo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#dec'><code>++dec</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#def-by'><code>+-def:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#del-by'><code>+-del:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#del-in'><code>+-del:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#del-ju'><code>+-del:ju</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#dem'><code>++dem</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#dem-ag'><code>++dem:ag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#den-fl'><code>++den:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#dep-by'><code>+-dep:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#dep-to'><code>+-dep:to</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#dif-fe'><code>++dif:fe</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#dif-fo'><code>++dif:fo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#dif-in'><code>+-dif:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#dif-si'><code>++dif:si</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#dig-by'><code>+-dig:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#dig-in'><code>+-dig:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#dim-ag'><code>++dim:ag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#dime'><code>++dime</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#din-re'><code>++din:re</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2d.md#dis'><code>++dis</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#dit'><code>++dit</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#div'><code>++div</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#div-ff'><code>++div:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#div-fl'><code>++div:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#div-rd'><code>++div:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#div-rh'><code>++div:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#div-rs'><code>++div:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#div-rq'><code>++div:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#dog'><code>++dog</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#doh'><code>++doh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#doq'><code>++doq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2f.md#dor'><code>++dor</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#dot'><code>++dot</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#drg-ff'><code>++drg:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#drg-fl'><code>++drg:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#drg-rd'><code>++drg:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#drg-rh'><code>++drg:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#drg-rs'><code>++drg:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#drg-rq'><code>++drg:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#drop'><code>++drop</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#dul-si'><code>++dul:si</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#dum-ag'><code>++dum:ag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#dun'><code>++dun</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#duz'><code>++duz</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#dvr'><code>++dvr</code></a>
 
 ### e
 
-<a href='https://urbit.org/docs/reference/library/3b.md#ead-fl'><code>++ead:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/1c.md#each'><code>++each</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#easy'><code>++easy</code></a>
-<a href='https://urbit.org/docs/reference/library/3g.md#edge'><code>++edge</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#egcd'><code>++egcd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#emn-fl'><code>++emn:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#emu-fl'><code>++emu:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#emx-fl'><code>++emx:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#end'><code>++end</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#equ-ff'><code>++equ:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#equ-fl'><code>++equ:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#equ-rd'><code>++equ:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#equ-rh'><code>++equ:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#equ-rs'><code>++equ:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#equ-rq'><code>++equ:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#era-yo'><code>++era:yo</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#exp-ff'><code>++exp:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#exp-fo'><code>++exp:fo</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#exp-rd'><code>++exp:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#exp-rh'><code>++exp:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#exp-rs'><code>++exp:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#exp-rq'><code>++exp:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ead-fl'><code>++ead:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#each'><code>++each</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#easy'><code>++easy</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#edge'><code>++edge</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#egcd'><code>++egcd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#emn-fl'><code>++emn:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#emu-fl'><code>++emu:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#emx-fl'><code>++emx:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#end'><code>++end</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#equ-ff'><code>++equ:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#equ-fl'><code>++equ:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#equ-rd'><code>++equ:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#equ-rh'><code>++equ:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#equ-rs'><code>++equ:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#equ-rq'><code>++equ:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#era-yo'><code>++era:yo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#exp-ff'><code>++exp:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#exp-fo'><code>++exp:fo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#exp-rd'><code>++exp:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#exp-rh'><code>++exp:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#exp-rs'><code>++exp:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#exp-rq'><code>++exp:rq</code></a>
 
 ### f
 
-<a href='https://urbit.org/docs/reference/library/4e.md#fail'><code>++fail</code></a>
-<a href='https://urbit.org/docs/reference/library/2a.md#fall'><code>++fall</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#fand'><code>++fand</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#fas'><code>++fas</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#fe'><code>++fe</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#fed-ag'><code>++fed:ag</code></a>
-<a href='https://urbit.org/docs/reference/library/3f.md#feen-ob'><code>++feen:ob</code></a>
-<a href='https://urbit.org/docs/reference/library/3f.md#fend-ob'><code>++fend:ob</code></a>
-<a href='https://urbit.org/docs/reference/library/3f.md#fice-ob'><code>++fice:ob</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#fil'><code>++fil</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#find'><code>++find</code></a>
-<a href='https://urbit.org/docs/reference/library/4c.md#fit-re'><code>++fit:re</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#fli-fl'><code>++fli:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#flop'><code>++flop</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#fma-ff'><code>++fma:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#fma-fl'><code>++fma:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#fma-rd'><code>++fma:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#fma-rh'><code>++fma:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#fma-rs'><code>++fma:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#fma-rq'><code>++fma:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/2e.md#fnv'><code>++fnv</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#fo'><code>++fo</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#foot'><code>++foot</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#fos-rh'><code>++fos:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#fra-fo'><code>++fra:fo</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#fra-si'><code>++fra:si</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#full'><code>++full</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#funk'><code>++funk</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#fail'><code>++fail</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#fall'><code>++fall</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#fand'><code>++fand</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#fas'><code>++fas</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#fe'><code>++fe</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#fed-ag'><code>++fed:ag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#feen-ob'><code>++feen:ob</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#fend-ob'><code>++fend:ob</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#fice-ob'><code>++fice:ob</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#fil'><code>++fil</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#find'><code>++find</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#fit-re'><code>++fit:re</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fli-fl'><code>++fli:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#flop'><code>++flop</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fma-ff'><code>++fma:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fma-fl'><code>++fma:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fma-rd'><code>++fma:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fma-rh'><code>++fma:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fma-rs'><code>++fma:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fma-rq'><code>++fma:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2e.md#fnv'><code>++fnv</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#fo'><code>++fo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#foot'><code>++foot</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fos-rh'><code>++fos:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#fra-fo'><code>++fra:fo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#fra-si'><code>++fra:si</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#full'><code>++full</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#funk'><code>++funk</code></a>
 
 ### g
 
-<a href='https://urbit.org/docs/reference/library/4i.md#gah'><code>++gah</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#gal'><code>++gal</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#gap'><code>++gap</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#gaq'><code>++gaq</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#gar'><code>++gar</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#gas-by'><code>+-gas:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#gas-in'><code>+-gas:in</code></a>
-<a href='https://urbit.org/docs/reference/library/2k.md#gas-to'><code>+-gas:to</code></a>
-<a href='https://urbit.org/docs/reference/library/1c.md#gate'><code>++gate</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#gaw'><code>++gaw</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#gay'><code>++gay</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#get-by'><code>+-get:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2j.md#get-ja'><code>+-get:ja</code></a>
-<a href='https://urbit.org/docs/reference/library/2j.md#get-ju'><code>+-get:ju</code></a>
-<a href='https://urbit.org/docs/reference/library/2k.md#get-to'><code>+-get:to</code></a>
-<a href='https://urbit.org/docs/reference/library/4e.md#glue'><code>++glue</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#gon'><code>++gon</code></a>
-<a href='https://urbit.org/docs/reference/library/2f.md#gor'><code>++gor</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#got-by'><code>+-got:by</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#grd-ff'><code>++grd:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#grd-fl'><code>++grd:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#grd-rd'><code>++grd:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#grd-rh'><code>++grd:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#grd-rs'><code>++grd:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#grd-rq'><code>++grd:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/1a.md#gte'><code>++gte</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#gte-ff'><code>++gte:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#gte-fl'><code>++gte:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#gte-rd'><code>++gte:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#gte-rh'><code>++gte:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#gte-rs'><code>++gte:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#gte-rq'><code>++gte:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/1a.md#gth'><code>++gth</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#gth-ff'><code>++gth:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#gth-fl'><code>++gth:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#gth-rd'><code>++gth:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#gth-rh'><code>++gth:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#gth-rs'><code>++gth:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#gth-rq'><code>++gth:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#gul'><code>++gul</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#gulf'><code>++gulf</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#gah'><code>++gah</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#gal'><code>++gal</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#gap'><code>++gap</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#gaq'><code>++gaq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#gar'><code>++gar</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#gas-by'><code>+-gas:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#gas-in'><code>+-gas:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#gas-to'><code>+-gas:to</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#gate'><code>++gate</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#gaw'><code>++gaw</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#gay'><code>++gay</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#get-by'><code>+-get:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#get-ja'><code>+-get:ja</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#get-ju'><code>+-get:ju</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#get-to'><code>+-get:to</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#glue'><code>++glue</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#gon'><code>++gon</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2f.md#gor'><code>++gor</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#got-by'><code>+-got:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#grd-ff'><code>++grd:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#grd-fl'><code>++grd:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#grd-rd'><code>++grd:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#grd-rh'><code>++grd:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#grd-rs'><code>++grd:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#grd-rq'><code>++grd:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#gte'><code>++gte</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gte-ff'><code>++gte:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gte-fl'><code>++gte:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gte-rd'><code>++gte:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gte-rh'><code>++gte:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gte-rs'><code>++gte:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gte-rq'><code>++gte:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#gth'><code>++gth</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gth-ff'><code>++gth:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gth-fl'><code>++gth:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gth-rd'><code>++gth:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gth-rh'><code>++gth:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gth-rs'><code>++gth:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gth-rq'><code>++gth:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#gul'><code>++gul</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#gulf'><code>++gulf</code></a>
 
 ### h
 
-<a href='https://urbit.org/docs/reference/library/3g.md#hair'><code>++hair</code></a>
-<a href='https://urbit.org/docs/reference/library/2n.md#hard'><code>++hard</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#has-by'><code>+-has:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#has-in'><code>+-has:in</code></a>
-<a href='https://urbit.org/docs/reference/library/2j.md#has-ju'><code>+-has:ju</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#hax'><code>++hax</code></a>
-<a href='https://urbit.org/docs/reference/library/2n.md#head'><code>++head</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#here'><code>++here</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#hep'><code>++hep</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#hex'><code>++hex</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#hex-ag'><code>++hex:ag</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#hif-ab'><code>++hif:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#hig'><code>++hig</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#hit'><code>++hit</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#homo'><code>++homo</code></a>
-<a href='https://urbit.org/docs/reference/library/2f.md#hor'><code>++hor</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#hor-yo'><code>++hor:yo</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#huf-ab'><code>++huf:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#hyf-ab'><code>++hyf:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#hair'><code>++hair</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#hard'><code>++hard</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#has-by'><code>+-has:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#has-in'><code>+-has:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#has-ju'><code>+-has:ju</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#hax'><code>++hax</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#head'><code>++head</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#here'><code>++here</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#hep'><code>++hep</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#hex'><code>++hex</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#hex-ag'><code>++hex:ag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#hif-ab'><code>++hif:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#hig'><code>++hig</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#hit'><code>++hit</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#homo'><code>++homo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2f.md#hor'><code>++hor</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#hor-yo'><code>++hor:yo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#huf-ab'><code>++huf:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#hyf-ab'><code>++hyf:ab</code></a>
 
 ### i
 
-<a href='https://urbit.org/docs/reference/library/3b.md#ibl-fl'><code>++ibl:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#ifix'><code>++ifix</code></a>
-<a href='https://urbit.org/docs/reference/library/4a.md#ind-po'><code>++ind:po</code></a>
-<a href='https://urbit.org/docs/reference/library/4a.md#ins-po'><code>++ins:po</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#int-by'><code>+-int:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#int-in'><code>+-int:in</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#inv-fe'><code>++inv:fe</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#inv-fl'><code>++inv:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#inv-fo'><code>++inv:fo</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#iny'><code>++iny</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ibl-fl'><code>++ibl:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#ifix'><code>++ifix</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4a.md#ind-po'><code>++ind:po</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4a.md#ins-po'><code>++ins:po</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#int-by'><code>+-int:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#int-in'><code>+-int:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#inv-fe'><code>++inv:fe</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#inv-fl'><code>++inv:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#inv-fo'><code>++inv:fo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#iny'><code>++iny</code></a>
 
 ### j
 
-<a href='https://urbit.org/docs/reference/library/2j.md#ja'><code>++ja</code></a>
-<a href='https://urbit.org/docs/reference/library/2p.md#jam'><code>++jam</code></a>
-<a href='https://urbit.org/docs/reference/library/2o.md#jar'><code>++jar</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#jes-yo'><code>++jes:yo</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#jest'><code>++jest</code></a>
-<a href='https://urbit.org/docs/reference/library/2j.md#ju'><code>++ju</code></a>
-<a href='https://urbit.org/docs/reference/library/2o.md#jug'><code>++jug</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#just'><code>++just</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#ja'><code>++ja</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2p.md#jam'><code>++jam</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2o.md#jar'><code>++jar</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#jes-yo'><code>++jes:yo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#jest'><code>++jest</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#ju'><code>++ju</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2o.md#jug'><code>++jug</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#just'><code>++just</code></a>
 
 ### k
 
-<a href='https://urbit.org/docs/reference/library/4h.md#kel'><code>++kel</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#ker'><code>++ker</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#ket'><code>++ket</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#knee'><code>++knee</code></a>
-<a href='https://urbit.org/docs/reference/library/2q.md#knot'><code>++knot</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#kel'><code>++kel</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#ker'><code>++ker</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#ket'><code>++ket</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#knee'><code>++knee</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#knot'><code>++knot</code></a>
 
 ### l
 
-<a href='https://urbit.org/docs/reference/library/4d.md#last'><code>++last</code></a>
-<a href='https://urbit.org/docs/reference/library/2m.md#le-nl'><code>++le:nl</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#lent'><code>++lent</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#levy'><code>++levy</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#lfe-fl'><code>++lfe:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#lfn-fl'><code>++lfn:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#lien'><code>++lien</code></a>
-<a href='https://urbit.org/docs/reference/library/2a.md#lift'><code>++lift</code></a>
-<a href='https://urbit.org/docs/reference/library/3g.md#like'><code>++like</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#limb'><code>++limb</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#limo'><code>++limo</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#line'><code>++line</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#lip-ag'><code>++lip:ag</code></a>
-<a href='https://urbit.org/docs/reference/library/1c.md#list'><code>++list</code></a>
-<a href='https://urbit.org/docs/reference/library/1c.md#lone'><code>++lone</code></a>
-<a href='https://urbit.org/docs/reference/library/2f.md#lor'><code>++lor</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#low'><code>++low</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#lsh'><code>++lsh</code></a>
-<a href='https://urbit.org/docs/reference/library/1a.md#lte'><code>++lte</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#lte-ff'><code>++lte:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#lte-fl'><code>++lte:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#lte-rd'><code>++lte:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#lte-rh'><code>++lte:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#lte-rs'><code>++lte:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#lte-rq'><code>++lte:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/1a.md#lth'><code>++lth</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#lth-ff'><code>++lth:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#lth-fl'><code>++lth:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#lth-rd'><code>++lth:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#lth-rh'><code>++lth:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#lth-rs'><code>++lth:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#lth-rq'><code>++lth:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#lug-fl'><code>++lug:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#lus'><code>++lus</code></a>
-<a href='https://urbit.org/docs/reference/library/4d.md#lust'><code>++lust</code></a>
-<a href='https://urbit.org/docs/reference/library/4e.md#less'><code>++less</code></a>
-<a href='https://urbit.org/docs/reference/library/2m.md#ly'><code>++ly</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4d.md#last'><code>++last</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#le-nl'><code>++le:nl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#lent'><code>++lent</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#levy'><code>++levy</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lfe-fl'><code>++lfe:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lfn-fl'><code>++lfn:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#lien'><code>++lien</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#lift'><code>++lift</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#like'><code>++like</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#limb'><code>++limb</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#limo'><code>++limo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#line'><code>++line</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#lip-ag'><code>++lip:ag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#list'><code>++list</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#lone'><code>++lone</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2f.md#lor'><code>++lor</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#low'><code>++low</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#lsh'><code>++lsh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#lte'><code>++lte</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lte-ff'><code>++lte:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lte-fl'><code>++lte:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lte-rd'><code>++lte:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lte-rh'><code>++lte:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lte-rs'><code>++lte:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lte-rq'><code>++lte:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#lth'><code>++lth</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lth-ff'><code>++lth:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lth-fl'><code>++lth:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lth-rd'><code>++lth:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lth-rh'><code>++lth:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lth-rs'><code>++lth:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lth-rq'><code>++lth:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lug-fl'><code>++lug:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#lus'><code>++lus</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4d.md#lust'><code>++lust</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#less'><code>++less</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#ly'><code>++ly</code></a>
 
 ### m
 
-<a href='https://urbit.org/docs/reference/library/3b.md#ma-rd'><code>++ma:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#ma-rh'><code>++ma:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#ma-rs'><code>++ma:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#ma-rq'><code>++ma:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/4n.md#mack'><code>++mack</code></a>
-<a href='https://urbit.org/docs/reference/library/2l.md#malt'><code>++malt</code></a>
-<a href='https://urbit.org/docs/reference/library/2o.md#map'><code>++map</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#mar-by'><code>+-mar:by</code></a>
-<a href='https://urbit.org/docs/reference/library/1b.md#mas'><code>++mas</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#mask'><code>++mask</code></a>
-<a href='https://urbit.org/docs/reference/library/2p.md#mat'><code>++mat</code></a>
-<a href='https://urbit.org/docs/reference/library/2a.md#mate'><code>++mate</code></a>
-<a href='https://urbit.org/docs/reference/library/1a.md#max'><code>++max</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#me-ff'><code>++me:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/2n.md#mean'><code>++mean</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#mes'><code>++mes</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#mesc'><code>++mesc</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#met'><code>++met</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#metl'><code>++metl</code></a>
-<a href='https://urbit.org/docs/reference/library/1a.md#min'><code>++min</code></a>
-<a href='https://urbit.org/docs/reference/library/4n.md#mink'><code>++mink</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#mit-yo'><code>++mit:yo</code></a>
-<a href='https://urbit.org/docs/reference/library/2d.md#mix'><code>++mix</code></a>
-<a href='https://urbit.org/docs/reference/library/4n.md#mock'><code>++mock</code></a>
-<a href='https://urbit.org/docs/reference/library/1a.md#mod'><code>++mod</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#moh-yo'><code>++moh:yo</code></a>
-<a href='https://urbit.org/docs/reference/library/2l.md#molt'><code>++molt</code></a>
-<a href='https://urbit.org/docs/reference/library/4n.md#mong'><code>++mong</code></a>
-<a href='https://urbit.org/docs/reference/library/4n.md#mook'><code>++mook</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#more'><code>++more</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#most'><code>++most</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#moy-yo'><code>++moy:yo</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#mu'><code>++mu</code></a>
-<a href='https://urbit.org/docs/reference/library/2e.md#mug'><code>++mug</code></a>
-<a href='https://urbit.org/docs/reference/library/2e.md#muk'><code>++muk</code></a>
-<a href='https://urbit.org/docs/reference/library/1a.md#mul'><code>++mul</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#mul-ff'><code>++mul:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#mul-fl'><code>++mul:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#mul-rd'><code>++mul:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#mul-rh'><code>++mul:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#mul-rs'><code>++mul:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#mul-rq'><code>++mul:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/4n.md#mule'><code>++mule</code></a>
-<a href='https://urbit.org/docs/reference/library/4n.md#mute'><code>++mute</code></a>
-<a href='https://urbit.org/docs/reference/library/2e.md#mum'><code>++mum</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#murn'><code>++murn</code></a>
-<a href='https://urbit.org/docs/reference/library/2m.md#my'><code>++my</code></a>
-<a href='https://urbit.org/docs/reference/library/2m.md#my-nl'><code>++my:nl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ma-rd'><code>++ma:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ma-rh'><code>++ma:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ma-rs'><code>++ma:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ma-rq'><code>++ma:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4n.md#mack'><code>++mack</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2l.md#malt'><code>++malt</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2o.md#map'><code>++map</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#mar-by'><code>+-mar:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1b.md#mas'><code>++mas</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#mask'><code>++mask</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2p.md#mat'><code>++mat</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#mate'><code>++mate</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#max'><code>++max</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#me-ff'><code>++me:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#mean'><code>++mean</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#mes'><code>++mes</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#mesc'><code>++mesc</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#met'><code>++met</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#metl'><code>++metl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#min'><code>++min</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4n.md#mink'><code>++mink</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#mit-yo'><code>++mit:yo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2d.md#mix'><code>++mix</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4n.md#mock'><code>++mock</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#mod'><code>++mod</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#moh-yo'><code>++moh:yo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2l.md#molt'><code>++molt</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4n.md#mong'><code>++mong</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4n.md#mook'><code>++mook</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#more'><code>++more</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#most'><code>++most</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#moy-yo'><code>++moy:yo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#mu'><code>++mu</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2e.md#mug'><code>++mug</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2e.md#muk'><code>++muk</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#mul'><code>++mul</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#mul-ff'><code>++mul:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#mul-fl'><code>++mul:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#mul-rd'><code>++mul:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#mul-rh'><code>++mul:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#mul-rs'><code>++mul:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#mul-rq'><code>++mul:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4n.md#mule'><code>++mule</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4n.md#mute'><code>++mute</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2e.md#mum'><code>++mum</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#murn'><code>++murn</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#my'><code>++my</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#my-nl'><code>++my:nl</code></a>
 
 ### n
 
-<a href='https://urbit.org/docs/reference/library/3g.md#nail'><code>++nail</code></a>
-<a href='https://urbit.org/docs/reference/library/2k.md#nap-to'><code>+-nap:to</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#ne'><code>++ne</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#ned-fl'><code>++ned:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/2a.md#need'><code>++need</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#net-fe'><code>++net:fe</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#new-si'><code>++new:si</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#next'><code>++next</code></a>
-<a href='https://urbit.org/docs/reference/library/2k.md#nip-to'><code>+-nip:to</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#nix'><code>++nix</code></a>
-<a href='https://urbit.org/docs/reference/library/2m.md#nl'><code>++nl</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#nock'><code>++nock</code></a>
-<a href='https://urbit.org/docs/reference/library/2d.md#not'><code>++not</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#noun'><code>++noun</code></a>
-<a href='https://urbit.org/docs/reference/library/4l.md#nuck-so'><code>++nuck:so</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#nud'><code>++nud</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#null'><code>++null</code></a>
-<a href='https://urbit.org/docs/reference/library/4l.md#nusk-so'><code>++nusk:so</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#nail'><code>++nail</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#nap-to'><code>+-nap:to</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#ne'><code>++ne</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ned-fl'><code>++ned:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#need'><code>++need</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#net-fe'><code>++net:fe</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#new-si'><code>++new:si</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#next'><code>++next</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#nip-to'><code>+-nip:to</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#nix'><code>++nix</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#nl'><code>++nl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#nock'><code>++nock</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2d.md#not'><code>++not</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#noun'><code>++noun</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#nuck-so'><code>++nuck:so</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#nud'><code>++nud</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#null'><code>++null</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#nusk-so'><code>++nusk:so</code></a>
 
 ### o
 
-<a href='https://urbit.org/docs/reference/library/3f.md#ob'><code>++ob</code></a>
-<a href='https://urbit.org/docs/reference/library/3d.md#og'><code>++og</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#old-si'><code>++old:si</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#oust'><code>++oust</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#out-fe'><code>++out:fe</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#ob'><code>++ob</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#og'><code>++og</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#old-si'><code>++old:si</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#oust'><code>++oust</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#out-fe'><code>++out:fe</code></a>
 
 ### p
 
-<a href='https://urbit.org/docs/reference/library/3b.md#pa-ff'><code>++pa:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/1c.md#pair'><code>++pair</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#pam'><code>++pam</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#pat'><code>++pat</code></a>
-<a href='https://urbit.org/docs/reference/library/3g.md#path'><code>++path</code></a>
-<a href='https://urbit.org/docs/reference/library/1b.md#peg'><code>++peg</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#pel'><code>++pel</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#per'><code>++per</code></a>
-<a href='https://urbit.org/docs/reference/library/4l.md#perd-so'><code>++perd:so</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#pev-ab'><code>++pev:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#pew-ab'><code>++pew:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4e.md#pfix'><code>++pfix</code></a>
-<a href='https://urbit.org/docs/reference/library/3g.md#pint'><code>++pint</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#piv-ab'><code>++piv:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#piw-ab'><code>++piw:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4e.md#plug'><code>++plug</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#plus'><code>++plus</code></a>
-<a href='https://urbit.org/docs/reference/library/4a.md#po'><code>++po</code></a>
-<a href='https://urbit.org/docs/reference/library/1c.md#pole'><code>++pole</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#port'><code>++port</code></a>
-<a href='https://urbit.org/docs/reference/library/4e.md#pose'><code>++pose</code></a>
-<a href='https://urbit.org/docs/reference/library/2g.md#pow'><code>++pow</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#prc-fl'><code>++prc:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#prn'><code>++prn</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#pro-fo'><code>++pro:fo</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#pro-si'><code>++pro:si</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#put-by'><code>+-put:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#put-in'><code>+-put:in</code></a>
-<a href='https://urbit.org/docs/reference/library/2j.md#put-ju'><code>+-put:ju</code></a>
-<a href='https://urbit.org/docs/reference/library/2k.md#put-to'><code>+-put:to</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#pa-ff'><code>++pa:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#pair'><code>++pair</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#pam'><code>++pam</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#pat'><code>++pat</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#path'><code>++path</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1b.md#peg'><code>++peg</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#pel'><code>++pel</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#per'><code>++per</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#perd-so'><code>++perd:so</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#pev-ab'><code>++pev:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#pew-ab'><code>++pew:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#pfix'><code>++pfix</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#pint'><code>++pint</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#piv-ab'><code>++piv:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#piw-ab'><code>++piw:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#plug'><code>++plug</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#plus'><code>++plus</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4a.md#po'><code>++po</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#pole'><code>++pole</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#port'><code>++port</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#pose'><code>++pose</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2g.md#pow'><code>++pow</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#prc-fl'><code>++prc:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#prn'><code>++prn</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#pro-fo'><code>++pro:fo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#pro-si'><code>++pro:si</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#put-by'><code>+-put:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#put-in'><code>+-put:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#put-ju'><code>+-put:ju</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#put-to'><code>+-put:to</code></a>
 
 ### q
 
-<a href='https://urbit.org/docs/reference/library/3c.md#qad-yo'><code>++qad:yo</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#qeb-ab'><code>++qeb:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/2o.md#qeu'><code>++qeu</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#qex-ab'><code>++qex:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#qib-ab'><code>++qib:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#qit'><code>++qit</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#qix-ab'><code>++qix:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/1c.md#quip'><code>++quip</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#qut'><code>++qut</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#qad-yo'><code>++qad:yo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#qeb-ab'><code>++qeb:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2o.md#qeu'><code>++qeu</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#qex-ab'><code>++qex:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#qib-ab'><code>++qib:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#qit'><code>++qit</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#qix-ab'><code>++qix:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#quip'><code>++quip</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#qut'><code>++qut</code></a>
 
 ### r
 
-<a href='https://urbit.org/docs/reference/library/4b.md#r-at'><code>++r:at</code></a>
-<a href='https://urbit.org/docs/reference/library/3d.md#rad-og'><code>++rad:og</code></a>
-<a href='https://urbit.org/docs/reference/library/3d.md#rads-og'><code>++rads:og</code></a>
-<a href='https://urbit.org/docs/reference/library/3f.md#raku-ob'><code>++raku:ob</code></a>
-<a href='https://urbit.org/docs/reference/library/4c.md#ram-re'><code>++ram:re</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#rap'><code>++rap</code></a>
-<a href='https://urbit.org/docs/reference/library/4g.md#rash'><code>++rash</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#rau-fl'><code>++rau:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3d.md#raw-og'><code>++raw:og</code></a>
-<a href='https://urbit.org/docs/reference/library/3d.md#raws-og'><code>++raws:og</code></a>
-<a href='https://urbit.org/docs/reference/library/4c.md#re'><code>++re</code></a>
-<a href='https://urbit.org/docs/reference/library/4k.md#rear-co'><code>++rear:co</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#reap'><code>++reap</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#reel'><code>++reel</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#rem-si'><code>++rem:si</code></a>
-<a href='https://urbit.org/docs/reference/library/4k.md#rend-co'><code>++rend:co</code></a>
-<a href='https://urbit.org/docs/reference/library/4k.md#rent-co'><code>++rent:co</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#rep'><code>++rep</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#rep-by'><code>+-rep:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#rep-in'><code>+-rep:in</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#rf-at'><code>++rf:at</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#rib-by'><code>+-rib:by</code></a>
-<a href='https://urbit.org/docs/reference/library/4c.md#rig-re'><code>++rig:re</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#rip'><code>++rip</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#rn-at'><code>++rn:at</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#rol-fe'><code>++rol:fe</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#roll'><code>++roll</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#r-at'><code>++r:at</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#rad-og'><code>++rad:og</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#rads-og'><code>++rads:og</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#raku-ob'><code>++raku:ob</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#ram-re'><code>++ram:re</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#rap'><code>++rap</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4g.md#rash'><code>++rash</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rau-fl'><code>++rau:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#raw-og'><code>++raw:og</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#raws-og'><code>++raws:og</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#re'><code>++re</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4k.md#rear-co'><code>++rear:co</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#reap'><code>++reap</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#reel'><code>++reel</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#rem-si'><code>++rem:si</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4k.md#rend-co'><code>++rend:co</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4k.md#rent-co'><code>++rent:co</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#rep'><code>++rep</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#rep-by'><code>+-rep:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#rep-in'><code>+-rep:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rf-at'><code>++rf:at</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#rib-by'><code>+-rib:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#rig-re'><code>++rig:re</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#rip'><code>++rip</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rn-at'><code>++rn:at</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#rol-fe'><code>++rol:fe</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#roll'><code>++roll</code></a>
 <code>++rood</code>
-<a href='https://urbit.org/docs/reference/library/2c.md#ror-fe'><code>++ror:fe</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#rou-fl'><code>++rou:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/4l.md#royl-so'><code>++royl:so</code></a>
-<a href='https://urbit.org/docs/reference/library/4l.md#royl-cell-so'><code>++royl-cell:so</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#rsh'><code>++rsh</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#rt-at'><code>++rt:at</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#rta-at'><code>++rta:at</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#rtam-at'><code>++rtam:at</code></a>
-<a href='https://urbit.org/docs/reference/library/2p.md#rub'><code>++rub</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#rub-at'><code>++rub:at</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#rud-at'><code>++rud:at</code></a>
-<a href='https://urbit.org/docs/reference/library/3g.md#rule'><code>++rule</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#rum-at'><code>++rum:at</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#run-by'><code>+-run:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#run-in'><code>+-run:in</code></a>
-<a href='https://urbit.org/docs/reference/library/3f.md#rund-ob'><code>++rund:ob</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#runt'><code>++runt</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#rup-at'><code>++rup:at</code></a>
-<a href='https://urbit.org/docs/reference/library/4g.md#rush'><code>++rush</code></a>
-<a href='https://urbit.org/docs/reference/library/4g.md#rust'><code>++rust</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#rut-by'><code>+-rut:by</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#ruv-at'><code>++ruv:at</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#rux-at'><code>++rux:at</code></a>
-<a href='https://urbit.org/docs/reference/library/3f.md#rynd-ob'><code>++rynd:ob</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#ror-fe'><code>++ror:fe</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rou-fl'><code>++rou:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#royl-so'><code>++royl:so</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#royl-cell-so'><code>++royl-cell:so</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#rsh'><code>++rsh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rt-at'><code>++rt:at</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rta-at'><code>++rta:at</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rtam-at'><code>++rtam:at</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2p.md#rub'><code>++rub</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rub-at'><code>++rub:at</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rud-at'><code>++rud:at</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#rule'><code>++rule</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rum-at'><code>++rum:at</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#run-by'><code>+-run:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#run-in'><code>+-run:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#rund-ob'><code>++rund:ob</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#runt'><code>++runt</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rup-at'><code>++rup:at</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4g.md#rush'><code>++rush</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4g.md#rust'><code>++rust</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#rut-by'><code>+-rut:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#ruv-at'><code>++ruv:at</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rux-at'><code>++rux:at</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#rynd-ob'><code>++rynd:ob</code></a>
 
 ### s
 
-<a href='https://urbit.org/docs/reference/library/2n.md#same'><code>++same</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#san-ff'><code>++san:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#san-fl'><code>++san:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#san-rd'><code>++san:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#san-rh'><code>++san:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#san-rs'><code>++san:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#san-rq'><code>++san:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#sand'><code>++sand</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#sane'><code>++sane</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sb-ff'><code>++sb:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#scag'><code>++scag</code></a>
-<a href='https://urbit.org/docs/reference/library/4g.md#scan'><code>++scan</code></a>
-<a href='https://urbit.org/docs/reference/library/4m.md#scot'><code>++scot</code></a>
-<a href='https://urbit.org/docs/reference/library/4m.md#scow'><code>++scow</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sea-ff'><code>++sea:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sea-rd'><code>++sea:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sea-rh'><code>++sea:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sea-rs'><code>++sea:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sea-rq'><code>++sea:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#sear'><code>++sear</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#seb-ab'><code>++seb:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#sed-ab'><code>++sed:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#sel'><code>++sel</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#sem'><code>++sem</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#ser'><code>++ser</code></a>
-<a href='https://urbit.org/docs/reference/library/2o.md#set'><code>++set</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#sev-ab'><code>++sev:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#sew-ab'><code>++sew:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#sex-ab'><code>++sex:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4e.md#sfix'><code>++sfix</code></a>
-<a href='https://urbit.org/docs/reference/library/3d.md#shad'><code>++shad</code></a>
-<a href='https://urbit.org/docs/reference/library/3d.md#shaf'><code>++shaf</code></a>
-<a href='https://urbit.org/docs/reference/library/3d.md#shal'><code>++shal</code></a>
-<a href='https://urbit.org/docs/reference/library/3d.md#sham'><code>++sham</code></a>
-<a href='https://urbit.org/docs/reference/library/3d.md#shan'><code>++shan</code></a>
-<a href='https://urbit.org/docs/reference/library/3d.md#shas'><code>++shas</code></a>
-<a href='https://urbit.org/docs/reference/library/3d.md#shaw'><code>++shaw</code></a>
-<a href='https://urbit.org/docs/reference/library/3d.md#shax'><code>++shax</code></a>
-<a href='https://urbit.org/docs/reference/library/3d.md#shay'><code>++shay</code></a>
-<a href='https://urbit.org/docs/reference/library/3d.md#shaz'><code>++shaz</code></a>
-<a href='https://urbit.org/docs/reference/library/4c.md#shep'><code>++shep</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#shf-fl'><code>++shf:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#shim'><code>++shim</code></a>
-<a href='https://urbit.org/docs/reference/library/4c.md#shop'><code>++shop</code></a>
-<a href='https://urbit.org/docs/reference/library/4c.md#show'><code>++show</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#si'><code>++si</code></a>
-<a href='https://urbit.org/docs/reference/library/2m.md#si-nl'><code>++si:nl</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#sib-ab'><code>++sib:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#sid-ab'><code>++sid:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#sig'><code>++sig</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sig-ff'><code>++sig:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sig-rd'><code>++sig:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sig-rh'><code>++sig:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sig-rs'><code>++sig:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sig-rq'><code>++sig:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/2l.md#silt'><code>++silt</code></a>
-<a href='https://urbit.org/docs/reference/library/4e.md#simu'><code>++simu</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#sit-fe'><code>++sit:fe</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#sit-fo'><code>++sit:fo</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#siv-ab'><code>++siv:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#siw-ab'><code>++siw:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#six-ab'><code>++six:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#skid'><code>++skid</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#skim'><code>++skim</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#skip'><code>++skip</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#slag'><code>++slag</code></a>
-<a href='https://urbit.org/docs/reference/library/4m.md#slat'><code>++slat</code></a>
-<a href='https://urbit.org/docs/reference/library/4m.md#slav'><code>++slav</code></a>
-<a href='https://urbit.org/docs/reference/library/4m.md#slaw'><code>++slaw</code></a>
-<a href='https://urbit.org/docs/reference/library/4m.md#slay'><code>++slay</code></a>
-<a href='https://urbit.org/docs/reference/library/2n.md#slog'><code>++slog</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#slug'><code>++slug</code></a>
-<a href='https://urbit.org/docs/reference/library/4m.md#smyt'><code>++smyt</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#snag'><code>++snag</code></a>
-<a href='https://urbit.org/docs/reference/library/2m.md#snag-nl'><code>++snag:nl</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#snoc'><code>++snoc</code></a>
-<a href='https://urbit.org/docs/reference/library/4l.md#so'><code>++so</code></a>
-<a href='https://urbit.org/docs/reference/library/2n.md#soft'><code>++soft</code></a>
-<a href='https://urbit.org/docs/reference/library/2a.md#some'><code>++some</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#soq'><code>++soq</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#sort'><code>++sort</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#sov-ab'><code>++sov:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#sow-ab'><code>++sow:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#sox-ab'><code>++sox:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#soz'><code>++soz</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#span'><code>++span</code></a>
-<a href='https://urbit.org/docs/reference/library/4m.md#spat'><code>++spat</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#spd-fl'><code>++spd:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#spin'><code>++spin</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#spn-fl'><code>++spn:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3g.md#spot'><code>++spot</code></a>
-<a href='https://urbit.org/docs/reference/library/4m.md#spud'><code>++spud</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#spun'><code>++spun</code></a>
-<a href='https://urbit.org/docs/reference/library/2g.md#sqt'><code>++sqt</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sqt-ff'><code>++sqt:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sqt-fl'><code>++sqt:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sqt-rd'><code>++sqt:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sqt-rh'><code>++sqt:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sqt-rs'><code>++sqt:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sqt-rq'><code>++sqt:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/4m.md#stab'><code>++stab</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#stag'><code>++stag</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#star'><code>++star</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#stet'><code>++stet</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#stew'><code>++stew</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#stir'><code>++stir</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#stun'><code>++stun</code></a>
-<a href='https://urbit.org/docs/reference/library/1a.md#sub'><code>++sub</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sub-ff'><code>++sub:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sub-fl'><code>++sub:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sub-rd'><code>++sub:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sub-rh'><code>++sub:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sub-rs'><code>++sub:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sub-rq'><code>++sub:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#sum-fe'><code>++sum:fe</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#sum-fo'><code>++sum:fo</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#sum-si'><code>++sum:si</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sun-ff'><code>++sun:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sun-fl'><code>++sun:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sun-rd'><code>++sun:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sun-rh'><code>++sun:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sun-rs'><code>++sun:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sun-rq'><code>++sun:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#sun-si'><code>++sun:si</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#swag'><code>++swag</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#swp'><code>++swp</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#swr-fl'><code>++swr:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/2m.md#sy'><code>++sy</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#sym'><code>++sym</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#syn-fl'><code>++syn:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#syn-si'><code>++syn:si</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#same'><code>++same</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#san-ff'><code>++san:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#san-fl'><code>++san:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#san-rd'><code>++san:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#san-rh'><code>++san:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#san-rs'><code>++san:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#san-rq'><code>++san:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#sand'><code>++sand</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#sane'><code>++sane</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sb-ff'><code>++sb:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#scag'><code>++scag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4g.md#scan'><code>++scan</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#scot'><code>++scot</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#scow'><code>++scow</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sea-ff'><code>++sea:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sea-rd'><code>++sea:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sea-rh'><code>++sea:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sea-rs'><code>++sea:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sea-rq'><code>++sea:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#sear'><code>++sear</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#seb-ab'><code>++seb:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sed-ab'><code>++sed:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#sel'><code>++sel</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#sem'><code>++sem</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#ser'><code>++ser</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2o.md#set'><code>++set</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sev-ab'><code>++sev:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sew-ab'><code>++sew:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sex-ab'><code>++sex:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#sfix'><code>++sfix</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shad'><code>++shad</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shaf'><code>++shaf</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shal'><code>++shal</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#sham'><code>++sham</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shan'><code>++shan</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shas'><code>++shas</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shaw'><code>++shaw</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shax'><code>++shax</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shay'><code>++shay</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shaz'><code>++shaz</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#shep'><code>++shep</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#shf-fl'><code>++shf:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#shim'><code>++shim</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#shop'><code>++shop</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#show'><code>++show</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#si'><code>++si</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#si-nl'><code>++si:nl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sib-ab'><code>++sib:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sid-ab'><code>++sid:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#sig'><code>++sig</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sig-ff'><code>++sig:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sig-rd'><code>++sig:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sig-rh'><code>++sig:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sig-rs'><code>++sig:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sig-rq'><code>++sig:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2l.md#silt'><code>++silt</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#simu'><code>++simu</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#sit-fe'><code>++sit:fe</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#sit-fo'><code>++sit:fo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#siv-ab'><code>++siv:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#siw-ab'><code>++siw:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#six-ab'><code>++six:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#skid'><code>++skid</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#skim'><code>++skim</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#skip'><code>++skip</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#slag'><code>++slag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#slat'><code>++slat</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#slav'><code>++slav</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#slaw'><code>++slaw</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#slay'><code>++slay</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#slog'><code>++slog</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#slug'><code>++slug</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#smyt'><code>++smyt</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#snag'><code>++snag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#snag-nl'><code>++snag:nl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#snoc'><code>++snoc</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#so'><code>++so</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#soft'><code>++soft</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#some'><code>++some</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#soq'><code>++soq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#sort'><code>++sort</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sov-ab'><code>++sov:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sow-ab'><code>++sow:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sox-ab'><code>++sox:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#soz'><code>++soz</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#span'><code>++span</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#spat'><code>++spat</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#spd-fl'><code>++spd:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#spin'><code>++spin</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#spn-fl'><code>++spn:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#spot'><code>++spot</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#spud'><code>++spud</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#spun'><code>++spun</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2g.md#sqt'><code>++sqt</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sqt-ff'><code>++sqt:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sqt-fl'><code>++sqt:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sqt-rd'><code>++sqt:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sqt-rh'><code>++sqt:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sqt-rs'><code>++sqt:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sqt-rq'><code>++sqt:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#stab'><code>++stab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#stag'><code>++stag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#star'><code>++star</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#stet'><code>++stet</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#stew'><code>++stew</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#stir'><code>++stir</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#stun'><code>++stun</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#sub'><code>++sub</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sub-ff'><code>++sub:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sub-fl'><code>++sub:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sub-rd'><code>++sub:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sub-rh'><code>++sub:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sub-rs'><code>++sub:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sub-rq'><code>++sub:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#sum-fe'><code>++sum:fe</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#sum-fo'><code>++sum:fo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#sum-si'><code>++sum:si</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sun-ff'><code>++sun:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sun-fl'><code>++sun:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sun-rd'><code>++sun:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sun-rh'><code>++sun:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sun-rs'><code>++sun:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sun-rq'><code>++sun:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#sun-si'><code>++sun:si</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#swag'><code>++swag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#swp'><code>++swp</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#swr-fl'><code>++swr:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#sy'><code>++sy</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#sym'><code>++sym</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#syn-fl'><code>++syn:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#syn-si'><code>++syn:si</code></a>
 
 ### t
 
-<a href='https://urbit.org/docs/reference/library/2n.md#tail'><code>++tail</code></a>
-<a href='https://urbit.org/docs/reference/library/2k.md#tap-to'><code>+-tap:to</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#tar'><code>++tar</code></a>
-<a href='https://urbit.org/docs/reference/library/2q.md#tang'><code>++tang</code></a>
-<a href='https://urbit.org/docs/reference/library/2q.md#tank'><code>++tank</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#tap-by'><code>+-tap:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#tap-in'><code>+-tap:in</code></a>
-<a href='https://urbit.org/docs/reference/library/2q.md#tape'><code>++tape</code></a>
-<a href='https://urbit.org/docs/reference/library/2q.md#tarp'><code>++tarp</code></a>
-<a href='https://urbit.org/docs/reference/library/4l.md#tash-so'><code>++tash:so</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#tec'><code>++tec</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#ted-ab'><code>++ted:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#teff'><code>++teff</code></a>
-<a href='https://urbit.org/docs/reference/library/3f.md#teil-ob'><code>++teil:ob</code></a>
-<a href='https://urbit.org/docs/reference/library/2q.md#term'><code>++term</code></a>
-<a href='https://urbit.org/docs/reference/library/2n.md#test'><code>++test</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#tid-ab'><code>++tid:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#tiki'><code>++tiki</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#til-ab'><code>++til:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#tip-ab'><code>++tip:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#tiq-ab'><code>++tiq:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#tis'><code>++tis</code></a>
-<a href='https://urbit.org/docs/reference/library/2k.md#to'><code>++to</code></a>
-<a href='https://urbit.org/docs/reference/library/4a.md#tod-po'><code>++tod:po</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#toga'><code>++toga</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#toi-ff'><code>++toi:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#toi-fl'><code>++toi:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#toi-rd'><code>++toi:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#toi-rh'><code>++toi:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#toi-rs'><code>++toi:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#toi-rq'><code>++toi:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#toj-fl'><code>++toj:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3g.md#tone'><code>++tone</code></a>
-<a href='https://urbit.org/docs/reference/library/3g.md#toon'><code>++toon</code></a>
-<a href='https://urbit.org/docs/reference/library/2k.md#top-to'><code>+-top:to</code></a>
-<a href='https://urbit.org/docs/reference/library/4a.md#tos-po'><code>++tos:po</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#tos-rh'><code>++tos:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/1c.md#trap'><code>++trap</code></a>
-<a href='https://urbit.org/docs/reference/library/1c.md#tree'><code>++tree</code></a>
-<a href='https://urbit.org/docs/reference/library/1c.md#trel'><code>++trel</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#trim'><code>++trim</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#trip'><code>++trip</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#tuba'><code>++tuba</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#tufa'><code>++tufa</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#tuna'><code>++tuna</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#tuft'><code>++tuft</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#turf'><code>++turf</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#turn'><code>++turn</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#tusk'><code>++tusk</code></a>
-<a href='https://urbit.org/docs/reference/library/4l.md#twid-so'><code>++twid:so</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#tyke'><code>++tyke</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#typo'><code>++typo</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#tyre'><code>++tyre</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#tail'><code>++tail</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#tap-to'><code>+-tap:to</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#tar'><code>++tar</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#tang'><code>++tang</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#tank'><code>++tank</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#tap-by'><code>+-tap:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#tap-in'><code>+-tap:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#tape'><code>++tape</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#tarp'><code>++tarp</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#tash-so'><code>++tash:so</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#tec'><code>++tec</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#ted-ab'><code>++ted:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#teff'><code>++teff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#teil-ob'><code>++teil:ob</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#term'><code>++term</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#test'><code>++test</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#tid-ab'><code>++tid:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#tiki'><code>++tiki</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#til-ab'><code>++til:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#tip-ab'><code>++tip:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#tiq-ab'><code>++tiq:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#tis'><code>++tis</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#to'><code>++to</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4a.md#tod-po'><code>++tod:po</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#toga'><code>++toga</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#toi-ff'><code>++toi:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#toi-fl'><code>++toi:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#toi-rd'><code>++toi:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#toi-rh'><code>++toi:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#toi-rs'><code>++toi:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#toi-rq'><code>++toi:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#toj-fl'><code>++toj:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#tone'><code>++tone</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#toon'><code>++toon</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#top-to'><code>+-top:to</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4a.md#tos-po'><code>++tos:po</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#tos-rh'><code>++tos:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#trap'><code>++trap</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#tree'><code>++tree</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#trel'><code>++trel</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#trim'><code>++trim</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#trip'><code>++trip</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#tuba'><code>++tuba</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#tufa'><code>++tufa</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#tuna'><code>++tuna</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#tuft'><code>++tuft</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#turf'><code>++turf</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#turn'><code>++turn</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#tusk'><code>++tusk</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#twid-so'><code>++twid:so</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#tyke'><code>++tyke</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#typo'><code>++typo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#tyre'><code>++tyre</code></a>
 
 ### u
 
-<a href='https://urbit.org/docs/reference/library/3f.md#un'><code>++un</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#uni-by'><code>+-uni:by</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#uni-fl'><code>++uni:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#uni-in'><code>+-uni:in</code></a>
-<a href='https://urbit.org/docs/reference/library/1c.md#unit'><code>++unit</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#urn-by'><code>+-urn:by</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#urs-ab'><code>++urs:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#urt-ab'><code>++urt:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#un'><code>++un</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#uni-by'><code>+-uni:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#uni-fl'><code>++uni:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#uni-in'><code>+-uni:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#unit'><code>++unit</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#urn-by'><code>+-urn:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#urs-ab'><code>++urs:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#urt-ab'><code>++urt:ab</code></a>
 
 ### v
 
-<a href='https://urbit.org/docs/reference/library/4j.md#v-ne'><code>++v:ne</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#v-ne'><code>++v:ne</code></a>
 <code>++vang</code>
-<a href='https://urbit.org/docs/reference/library/4o.md#vase'><code>++vase</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#vase'><code>++vase</code></a>
 <code>++vast</code>
-<a href='https://urbit.org/docs/reference/library/4i.md#ven'><code>++ven</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#vise'><code>++vise</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#vit'><code>++vit</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#viz-ag'><code>++viz:ag</code></a>
-<a href='https://urbit.org/docs/reference/library/2f.md#vor'><code>++vor</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#voy-ab'><code>++voy:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#vul'><code>++vul</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#vum-ag'><code>++vum:ag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#ven'><code>++ven</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#vise'><code>++vise</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#vit'><code>++vit</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#viz-ag'><code>++viz:ag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2f.md#vor'><code>++vor</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#voy-ab'><code>++voy:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#vul'><code>++vul</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#vum-ag'><code>++vum:ag</code></a>
 
 ### w
 
-<a href='https://urbit.org/docs/reference/library/4j.md#w-ne'><code>++w:ne</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#wack'><code>++wack</code></a>
-<a href='https://urbit.org/docs/reference/library/2q.md#wain'><code>++wain</code></a>
-<a href='https://urbit.org/docs/reference/library/2q.md#wall'><code>++wall</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#weld'><code>++weld</code></a>
-<a href='https://urbit.org/docs/reference/library/2m.md#weld-nl'><code>++weld:nl</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#welp'><code>++welp</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#wick'><code>++wick</code></a>
-<a href='https://urbit.org/docs/reference/library/4c.md#wig-re'><code>++wig:re</code></a>
-<a href='https://urbit.org/docs/reference/library/4c.md#win-re'><code>++win:re</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#wing'><code>++wing</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#wiz-ag'><code>++wiz:ag</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#woad'><code>++woad</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#wood'><code>++wood</code></a>
-<a href='https://urbit.org/docs/reference/library/3g.md#wonk'><code>++wonk</code></a>
-<a href='https://urbit.org/docs/reference/library/3f.md#wred-un'><code>++wred:un</code></a>
-<a href='https://urbit.org/docs/reference/library/3f.md#wren-un'><code>++wren:un</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#wut'><code>++wut</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#wyt-by'><code>+-wyt:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#wyt-in'><code>+-wyt:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#w-ne'><code>++w:ne</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#wack'><code>++wack</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#wain'><code>++wain</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#wall'><code>++wall</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#weld'><code>++weld</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#weld-nl'><code>++weld:nl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#welp'><code>++welp</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#wick'><code>++wick</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#wig-re'><code>++wig:re</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#win-re'><code>++win:re</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#wing'><code>++wing</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#wiz-ag'><code>++wiz:ag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#woad'><code>++woad</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#wood'><code>++wood</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#wonk'><code>++wonk</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#wred-un'><code>++wred:un</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#wren-un'><code>++wren:un</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#wut'><code>++wut</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#wyt-by'><code>+-wyt:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#wyt-in'><code>+-wyt:in</code></a>
 
 ### x
 
-<a href='https://urbit.org/docs/reference/library/4j.md#x-ne'><code>++x:ne</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#xeb'><code>++xeb</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#xpd-fl'><code>++xpd:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#x-ne'><code>++x:ne</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#xeb'><code>++xeb</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#xpd-fl'><code>++xpd:fl</code></a>
 
 ### y
 
-<a href='https://urbit.org/docs/reference/library/3c.md#yall'><code>++yall</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#yawn'><code>++yawn</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#year'><code>++year</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#yell'><code>++yell</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#yelp'><code>++yelp</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#yer-yo'><code>++yer:yo</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#yo'><code>++yo</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#yore'><code>++yore</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#yule'><code>++yule</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yall'><code>++yall</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yawn'><code>++yawn</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#year'><code>++year</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yell'><code>++yell</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yelp'><code>++yelp</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yer-yo'><code>++yer:yo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yo'><code>++yo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yore'><code>++yore</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yule'><code>++yule</code></a>
 
 ### z
 
-<a href='https://urbit.org/docs/reference/library/3f.md#zaft-un'><code>++zaft:un</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#zag-mu'><code>++zag:mu</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#zap'><code>++zap</code></a>
-<a href='https://urbit.org/docs/reference/library/3f.md#zart-un'><code>++zart:un</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#zer-fl'><code>++zer:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#zig-mu'><code>++zig:mu</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#zing'><code>++zing</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#zug-mu'><code>++zug:mu</code></a>
-<a href='https://urbit.org/docs/reference/library/4l.md#zust-so'><code>++zust:so</code></a>
-<a href='https://urbit.org/docs/reference/library/3f.md#zyft-un'><code>++zyft:un</code></a>
-<a href='https://urbit.org/docs/reference/library/3f.md#zyrt-un'><code>++zyrt:un</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#zaft-un'><code>++zaft:un</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#zag-mu'><code>++zag:mu</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#zap'><code>++zap</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#zart-un'><code>++zart:un</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#zer-fl'><code>++zer:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#zig-mu'><code>++zig:mu</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#zing'><code>++zing</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#zug-mu'><code>++zug:mu</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#zust-so'><code>++zust:so</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#zyft-un'><code>++zyft:un</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#zyrt-un'><code>++zyrt:un</code></a>
 
 ## By Section
 
 ### 1a: basic arithmetic
 
-<a href='https://urbit.org/docs/reference/library/1a.md#add' data-tippy-content="Add"><code>++add</code></a>
-<a href='https://urbit.org/docs/reference/library/1a.md#dec'><code>++dec</code></a>
-<a href='https://urbit.org/docs/reference/library/1a.md#div'><code>++div</code></a>
-<a href='https://urbit.org/docs/reference/library/1a.md#dvr'><code>++dvr</code></a>
-<a href='https://urbit.org/docs/reference/library/1a.md#gte'><code>++gte</code></a>
-<a href='https://urbit.org/docs/reference/library/1a.md#gth'><code>++gth</code></a>
-<a href='https://urbit.org/docs/reference/library/1a.md#lte'><code>++lte</code></a>
-<a href='https://urbit.org/docs/reference/library/1a.md#lth'><code>++lth</code></a>
-<a href='https://urbit.org/docs/reference/library/1a.md#max'><code>++max</code></a>
-<a href='https://urbit.org/docs/reference/library/1a.md#min'><code>++min</code></a>
-<a href='https://urbit.org/docs/reference/library/1a.md#mod'><code>++mod</code></a>
-<a href='https://urbit.org/docs/reference/library/1a.md#mul'><code>++mul</code></a>
-<a href='https://urbit.org/docs/reference/library/1a.md#sub'><code>++sub</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#add' data-tippy-content="Add"><code>++add</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#dec'><code>++dec</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#div'><code>++div</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#dvr'><code>++dvr</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#gte'><code>++gte</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#gth'><code>++gth</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#lte'><code>++lte</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#lth'><code>++lth</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#max'><code>++max</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#min'><code>++min</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#mod'><code>++mod</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#mul'><code>++mul</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#sub'><code>++sub</code></a>
 
 ### 1b: tree addressing
 
-<a href='https://urbit.org/docs/reference/library/1b.md#cap'><code>++cap</code></a>
-<a href='https://urbit.org/docs/reference/library/1b.md#mas'><code>++mas</code></a>
-<a href='https://urbit.org/docs/reference/library/1b.md#peg'><code>++peg</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1b.md#cap'><code>++cap</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1b.md#mas'><code>++mas</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1b.md#peg'><code>++peg</code></a>
 
 ### 1c: molds and mold builders
 
-<a href='https://urbit.org/docs/reference/library/1c.md#bloq'><code>++bloq</code></a>
-<a href='https://urbit.org/docs/reference/library/1c.md#each'><code>++each</code></a>
-<a href='https://urbit.org/docs/reference/library/1c.md#gate'><code>++gate</code></a>
-<a href='https://urbit.org/docs/reference/library/1c.md#list'><code>++list</code></a>
-<a href='https://urbit.org/docs/reference/library/1c.md#lone'><code>++lone</code></a>
-<a href='https://urbit.org/docs/reference/library/1c.md#pair'><code>++pair</code></a>
-<a href='https://urbit.org/docs/reference/library/1c.md#pole'><code>++pole</code></a>
-<a href='https://urbit.org/docs/reference/library/1c.md#quip'><code>++quip</code></a>
-<a href='https://urbit.org/docs/reference/library/1c.md#trap'><code>++trap</code></a>
-<a href='https://urbit.org/docs/reference/library/1c.md#tree'><code>++tree</code></a>
-<a href='https://urbit.org/docs/reference/library/1c.md#trel'><code>++trel</code></a>
-<a href='https://urbit.org/docs/reference/library/1c.md#unit'><code>++unit</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#bloq'><code>++bloq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#each'><code>++each</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#gate'><code>++gate</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#list'><code>++list</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#lone'><code>++lone</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#pair'><code>++pair</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#pole'><code>++pole</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#quip'><code>++quip</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#trap'><code>++trap</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#tree'><code>++tree</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#trel'><code>++trel</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#unit'><code>++unit</code></a>
 
 ### 2a: unit logic
 
-<a href='https://urbit.org/docs/reference/library/2a.md#biff'><code>++biff</code></a>
-<a href='https://urbit.org/docs/reference/library/2a.md#bind'><code>++bind</code></a>
-<a href='https://urbit.org/docs/reference/library/2a.md#bond'><code>++bond</code></a>
-<a href='https://urbit.org/docs/reference/library/2a.md#both'><code>++both</code></a>
-<a href='https://urbit.org/docs/reference/library/2a.md#clap'><code>++clap</code></a>
-<a href='https://urbit.org/docs/reference/library/2a.md#drop'><code>++drop</code></a>
-<a href='https://urbit.org/docs/reference/library/2a.md#fall'><code>++fall</code></a>
-<a href='https://urbit.org/docs/reference/library/2a.md#lift'><code>++lift</code></a>
-<a href='https://urbit.org/docs/reference/library/2a.md#mate'><code>++mate</code></a>
-<a href='https://urbit.org/docs/reference/library/2a.md#need'><code>++need</code></a>
-<a href='https://urbit.org/docs/reference/library/2a.md#some'><code>++some</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#biff'><code>++biff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#bind'><code>++bind</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#bond'><code>++bond</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#both'><code>++both</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#clap'><code>++clap</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#drop'><code>++drop</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#fall'><code>++fall</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#lift'><code>++lift</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#mate'><code>++mate</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#need'><code>++need</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#some'><code>++some</code></a>
 
 ### 2b: list logic
 
-<a href='https://urbit.org/docs/reference/library/2b.md#fand'><code>++fand</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#find'><code>++find</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#flop'><code>++flop</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#gulf'><code>++gulf</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#homo'><code>++homo</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#lent'><code>++lent</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#levy'><code>++levy</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#lien'><code>++lien</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#limo'><code>++limo</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#murn'><code>++murn</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#oust'><code>++oust</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#reap'><code>++reap</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#reel'><code>++reel</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#roll'><code>++roll</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#scag'><code>++scag</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#skid'><code>++skid</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#skim'><code>++skim</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#skip'><code>++skip</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#slag'><code>++slag</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#snag'><code>++snag</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#snoc'><code>++snoc</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#sort'><code>++sort</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#spin'><code>++spin</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#spun'><code>++spun</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#swag'><code>++swag</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#turn'><code>++turn</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#weld'><code>++weld</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#welp'><code>++welp</code></a>
-<a href='https://urbit.org/docs/reference/library/2b.md#zing'><code>++zing</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#fand'><code>++fand</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#find'><code>++find</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#flop'><code>++flop</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#gulf'><code>++gulf</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#homo'><code>++homo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#lent'><code>++lent</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#levy'><code>++levy</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#lien'><code>++lien</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#limo'><code>++limo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#murn'><code>++murn</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#oust'><code>++oust</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#reap'><code>++reap</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#reel'><code>++reel</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#roll'><code>++roll</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#scag'><code>++scag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#skid'><code>++skid</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#skim'><code>++skim</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#skip'><code>++skip</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#slag'><code>++slag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#snag'><code>++snag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#snoc'><code>++snoc</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#sort'><code>++sort</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#spin'><code>++spin</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#spun'><code>++spun</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#swag'><code>++swag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#turn'><code>++turn</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#weld'><code>++weld</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#welp'><code>++welp</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2b.md#zing'><code>++zing</code></a>
 
 ### 2c: bit arithmetic
 
-<a href='https://urbit.org/docs/reference/library/2c.md#fe'><code>++fe</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#dif-fe'><code>++dif:fe</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#inv-fe'><code>++inv:fe</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#net-fe'><code>++net:fe</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#out-fe'><code>++out:fe</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#rol-fe'><code>++rol:fe</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#ror-fe'><code>++ror:fe</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#sit-fe'><code>++sit:fe</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#sum-fe'><code>++sum:fe</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#fe'><code>++fe</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#dif-fe'><code>++dif:fe</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#inv-fe'><code>++inv:fe</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#net-fe'><code>++net:fe</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#out-fe'><code>++out:fe</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#rol-fe'><code>++rol:fe</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#ror-fe'><code>++ror:fe</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#sit-fe'><code>++sit:fe</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#sum-fe'><code>++sum:fe</code></a>
 
-<a href='https://urbit.org/docs/reference/library/2c.md#bex'><code>++bex</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#can'><code>++can</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#cat'><code>++cat</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#cut'><code>++cut</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#end'><code>++end</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#fil'><code>++fil</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#lsh'><code>++lsh</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#met'><code>++met</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#rap'><code>++rap</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#rep'><code>++rep</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#rip'><code>++rip</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#rsh'><code>++rsh</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#swp'><code>++swp</code></a>
-<a href='https://urbit.org/docs/reference/library/2c.md#xeb'><code>++xeb</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#bex'><code>++bex</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#can'><code>++can</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#cat'><code>++cat</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#cut'><code>++cut</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#end'><code>++end</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#fil'><code>++fil</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#lsh'><code>++lsh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#met'><code>++met</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#rap'><code>++rap</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#rep'><code>++rep</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#rip'><code>++rip</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#rsh'><code>++rsh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#swp'><code>++swp</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#xeb'><code>++xeb</code></a>
 
 ### 2d: bit logic
 
-<a href='https://urbit.org/docs/reference/library/2d.md#con'><code>++con</code></a>
-<a href='https://urbit.org/docs/reference/library/2d.md#dis'><code>++dis</code></a>
-<a href='https://urbit.org/docs/reference/library/2d.md#mix'><code>++mix</code></a>
-<a href='https://urbit.org/docs/reference/library/2d.md#not'><code>++not</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2d.md#con'><code>++con</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2d.md#dis'><code>++dis</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2d.md#mix'><code>++mix</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2d.md#not'><code>++not</code></a>
 
 ### 2e: insecure hashing
 
-<a href='https://urbit.org/docs/reference/library/2e.md#fnv'><code>++fnv</code></a>
-<a href='https://urbit.org/docs/reference/library/2e.md#mug'><code>++mug</code></a>
-<a href='https://urbit.org/docs/reference/library/2e.md#muk'><code>++muk</code></a>
-<a href='https://urbit.org/docs/reference/library/2e.md#mum'><code>++mum</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2e.md#fnv'><code>++fnv</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2e.md#mug'><code>++mug</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2e.md#muk'><code>++muk</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2e.md#mum'><code>++mum</code></a>
 
 ### 2f: noun ordering
 
-<a href='https://urbit.org/docs/reference/library/2f.md#aor' data-tippy-content="Alphabetical order"><code>++aor</code></a>
-<a href='https://urbit.org/docs/reference/library/2f.md#dor'><code>++dor</code></a>
-<a href='https://urbit.org/docs/reference/library/2f.md#gor'><code>++gor</code></a>
-<a href='https://urbit.org/docs/reference/library/2f.md#hor'><code>++hor</code></a>
-<a href='https://urbit.org/docs/reference/library/2f.md#lor'><code>++lor</code></a>
-<a href='https://urbit.org/docs/reference/library/2f.md#vor'><code>++vor</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2f.md#aor' data-tippy-content="Alphabetical order"><code>++aor</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2f.md#dor'><code>++dor</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2f.md#gor'><code>++gor</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2f.md#hor'><code>++hor</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2f.md#lor'><code>++lor</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2f.md#vor'><code>++vor</code></a>
 
 ### 2g: unsigned powers
 
-<a href='https://urbit.org/docs/reference/library/2g.md#pow'><code>++pow</code></a>
-<a href='https://urbit.org/docs/reference/library/2g.md#sqt'><code>++sqt</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2g.md#pow'><code>++pow</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2g.md#sqt'><code>++sqt</code></a>
 
 ### 2h: set logic
 
-<a href='https://urbit.org/docs/reference/library/2h.md#in'><code>++in</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#all-in' data-tippy-content="Logical AND (set and wet gate)"><code>+-all:in</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#any-in' data-tippy-content="Logical OR (set and gate)"><code>+-any:in</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#apt-in' data-tippy-content="Check correctness (set)"><code>+-apt:in</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#bif-in'><code>+-bif:in</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#del-in'><code>+-del:in</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#dif-in'><code>+-dif:in</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#dig-in'><code>+-dig:in</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#gas-in'><code>+-gas:in</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#has-in'><code>+-has:in</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#int-in'><code>+-int:in</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#put-in'><code>+-put:in</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#rep-in'><code>+-rep:in</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#run-in'><code>+-run:in</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#tap-in'><code>+-tap:in</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#uni-in'><code>+-uni:in</code></a>
-<a href='https://urbit.org/docs/reference/library/2h.md#wyt-in'><code>+-wyt:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#in'><code>++in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#all-in' data-tippy-content="Logical AND (set and wet gate)"><code>+-all:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#any-in' data-tippy-content="Logical OR (set and gate)"><code>+-any:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#apt-in' data-tippy-content="Check correctness (set)"><code>+-apt:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#bif-in'><code>+-bif:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#del-in'><code>+-del:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#dif-in'><code>+-dif:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#dig-in'><code>+-dig:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#gas-in'><code>+-gas:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#has-in'><code>+-has:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#int-in'><code>+-int:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#put-in'><code>+-put:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#rep-in'><code>+-rep:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#run-in'><code>+-run:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#tap-in'><code>+-tap:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#uni-in'><code>+-uni:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#wyt-in'><code>+-wyt:in</code></a>
 
 ### 2i: map logic
 
-<a href='https://urbit.org/docs/reference/library/2i.md#by'><code>++by</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#all-by' data-tippy-content="Logical AND (map and wet gate)"><code>+-all:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#any-by' data-tippy-content="Logical OR (map and wet gate)"><code>+-any:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#apt-by' data-tippy-content="Check correctness (map)"><code>+-apt:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#bif-by'><code>+-bif:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#def-by'><code>+-def:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#del-by'><code>+-del:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#dep-by'><code>+-dep:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#dig-by'><code>+-dig:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#gas-by'><code>+-gas:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#get-by'><code>+-get:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#got-by'><code>+-got:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#has-by'><code>+-has:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#int-by'><code>+-int:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#mar-by'><code>+-mar:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#put-by'><code>+-put:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#rep-by'><code>+-rep:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#rib-by'><code>+-rib:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#run-by'><code>+-run:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#rut-by'><code>+-rut:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#tap-by'><code>+-tap:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#uni-by'><code>+-uni:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#urn-by'><code>+-urn:by</code></a>
-<a href='https://urbit.org/docs/reference/library/2i.md#wyt-by'><code>+-wyt:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#by'><code>++by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#all-by' data-tippy-content="Logical AND (map and wet gate)"><code>+-all:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#any-by' data-tippy-content="Logical OR (map and wet gate)"><code>+-any:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#apt-by' data-tippy-content="Check correctness (map)"><code>+-apt:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#bif-by'><code>+-bif:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#def-by'><code>+-def:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#del-by'><code>+-del:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#dep-by'><code>+-dep:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#dig-by'><code>+-dig:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#gas-by'><code>+-gas:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#get-by'><code>+-get:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#got-by'><code>+-got:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#has-by'><code>+-has:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#int-by'><code>+-int:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#mar-by'><code>+-mar:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#put-by'><code>+-put:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#rep-by'><code>+-rep:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#rib-by'><code>+-rib:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#run-by'><code>+-run:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#rut-by'><code>+-rut:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#tap-by'><code>+-tap:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#uni-by'><code>+-uni:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#urn-by'><code>+-urn:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#wyt-by'><code>+-wyt:by</code></a>
 
 ### 2j: jar and jug logic
 
-<a href='https://urbit.org/docs/reference/library/2j.md#ja'><code>++ja</code></a>
-<a href='https://urbit.org/docs/reference/library/2j.md#add-ja' data-tippy-content="Prepend to list"><code>+-add:ja</code></a>
-<a href='https://urbit.org/docs/reference/library/2j.md#get-ja'><code>+-get:ja</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#ja'><code>++ja</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#add-ja' data-tippy-content="Prepend to list"><code>+-add:ja</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#get-ja'><code>+-get:ja</code></a>
 
-<a href='https://urbit.org/docs/reference/library/2j.md#ju'><code>++ju</code></a>
-<a href='https://urbit.org/docs/reference/library/2j.md#del-ju'><code>+-del:ju</code></a>
-<a href='https://urbit.org/docs/reference/library/2j.md#get-ju'><code>+-get:ju</code></a>
-<a href='https://urbit.org/docs/reference/library/2j.md#has-ju'><code>+-has:ju</code></a>
-<a href='https://urbit.org/docs/reference/library/2j.md#put-ju'><code>+-put:ju</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#ju'><code>++ju</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#del-ju'><code>+-del:ju</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#get-ju'><code>+-get:ju</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#has-ju'><code>+-has:ju</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#put-ju'><code>+-put:ju</code></a>
 
 ### 2k: queue logic
 
-<a href='https://urbit.org/docs/reference/library/2k.md#to'><code>++to</code></a>
-<a href='https://urbit.org/docs/reference/library/2k.md#bal-to'><code>+-bal:to</code></a>
-<a href='https://urbit.org/docs/reference/library/2k.md#dep-to'><code>+-dep:to</code></a>
-<a href='https://urbit.org/docs/reference/library/2k.md#gas-to'><code>+-gas:to</code></a>
-<a href='https://urbit.org/docs/reference/library/2k.md#get-to'><code>+-get:to</code></a>
-<a href='https://urbit.org/docs/reference/library/2k.md#nap-to'><code>+-nap:to</code></a>
-<a href='https://urbit.org/docs/reference/library/2k.md#nip-to'><code>+-nip:to</code></a>
-<a href='https://urbit.org/docs/reference/library/2k.md#put-to'><code>+-put:to</code></a>
-<a href='https://urbit.org/docs/reference/library/2k.md#tap-to'><code>+-tap:to</code></a>
-<a href='https://urbit.org/docs/reference/library/2k.md#top-to'><code>+-top:to</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#to'><code>++to</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#bal-to'><code>+-bal:to</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#dep-to'><code>+-dep:to</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#gas-to'><code>+-gas:to</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#get-to'><code>+-get:to</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#nap-to'><code>+-nap:to</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#nip-to'><code>+-nip:to</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#put-to'><code>+-put:to</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#tap-to'><code>+-tap:to</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#top-to'><code>+-top:to</code></a>
 
 ### 2l: container from container
 
-<a href='https://urbit.org/docs/reference/library/2l.md#malt'><code>++malt</code></a>
-<a href='https://urbit.org/docs/reference/library/2l.md#molt'><code>++molt</code></a>
-<a href='https://urbit.org/docs/reference/library/2l.md#silt'><code>++silt</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2l.md#malt'><code>++malt</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2l.md#molt'><code>++molt</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2l.md#silt'><code>++silt</code></a>
 
 ### 2m: container from noun
 
-<a href='https://urbit.org/docs/reference/library/2m.md#nl'><code>++nl</code></a>
-<a href='https://urbit.org/docs/reference/library/2m.md#le-nl'><code>++le:nl</code></a>
-<a href='https://urbit.org/docs/reference/library/2m.md#my-nl'><code>++my:nl</code></a>
-<a href='https://urbit.org/docs/reference/library/2m.md#si-nl'><code>++si:nl</code></a>
-<a href='https://urbit.org/docs/reference/library/2m.md#snag-nl'><code>++snag:nl</code></a>
-<a href='https://urbit.org/docs/reference/library/2m.md#weld-nl'><code>++weld:nl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#nl'><code>++nl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#le-nl'><code>++le:nl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#my-nl'><code>++my:nl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#si-nl'><code>++si:nl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#snag-nl'><code>++snag:nl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#weld-nl'><code>++weld:nl</code></a>
 
-<a href='https://urbit.org/docs/reference/library/2m.md#ly'><code>++ly</code></a>
-<a href='https://urbit.org/docs/reference/library/2m.md#my'><code>++my</code></a>
-<a href='https://urbit.org/docs/reference/library/2m.md#sy'><code>++sy</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#ly'><code>++ly</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#my'><code>++my</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2m.md#sy'><code>++sy</code></a>
 
 ### 2n: functional hacks
 
-<a href='https://urbit.org/docs/reference/library/2n.md#cork'><code>++cork</code></a>
-<a href='https://urbit.org/docs/reference/library/2n.md#corl'><code>++corl</code></a>
-<a href='https://urbit.org/docs/reference/library/2n.md#curr'><code>++curr</code></a>
-<a href='https://urbit.org/docs/reference/library/2n.md#cury'><code>++cury</code></a>
-<a href='https://urbit.org/docs/reference/library/2n.md#hard'><code>++hard</code></a>
-<a href='https://urbit.org/docs/reference/library/2n.md#head'><code>++head</code></a>
-<a href='https://urbit.org/docs/reference/library/2n.md#mean'><code>++mean</code></a>
-<a href='https://urbit.org/docs/reference/library/2n.md#same'><code>++same</code></a>
-<a href='https://urbit.org/docs/reference/library/2n.md#slog'><code>++slog</code></a>
-<a href='https://urbit.org/docs/reference/library/2n.md#soft'><code>++soft</code></a>
-<a href='https://urbit.org/docs/reference/library/2n.md#tail'><code>++tail</code></a>
-<a href='https://urbit.org/docs/reference/library/2n.md#test'><code>++test</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#cork'><code>++cork</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#corl'><code>++corl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#curr'><code>++curr</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#cury'><code>++cury</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#hard'><code>++hard</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#head'><code>++head</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#mean'><code>++mean</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#same'><code>++same</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#slog'><code>++slog</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#soft'><code>++soft</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#tail'><code>++tail</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#test'><code>++test</code></a>
 
 ### 2o: normalizing containers
 
-<a href='https://urbit.org/docs/reference/library/2o.md#jar'><code>++jar</code></a>
-<a href='https://urbit.org/docs/reference/library/2o.md#jug'><code>++jug</code></a>
-<a href='https://urbit.org/docs/reference/library/2o.md#map'><code>++map</code></a>
-<a href='https://urbit.org/docs/reference/library/2o.md#qeu'><code>++qeu</code></a>
-<a href='https://urbit.org/docs/reference/library/2o.md#set'><code>++set</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2o.md#jar'><code>++jar</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2o.md#jug'><code>++jug</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2o.md#map'><code>++map</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2o.md#qeu'><code>++qeu</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2o.md#set'><code>++set</code></a>
 
 ### 2p: serialization
 
-<a href='https://urbit.org/docs/reference/library/2p.md#cue'><code>++cue</code></a>
-<a href='https://urbit.org/docs/reference/library/2p.md#jam'><code>++jam</code></a>
-<a href='https://urbit.org/docs/reference/library/2p.md#mat'><code>++mat</code></a>
-<a href='https://urbit.org/docs/reference/library/2p.md#rub'><code>++rub</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2p.md#cue'><code>++cue</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2p.md#jam'><code>++jam</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2p.md#mat'><code>++mat</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2p.md#rub'><code>++rub</code></a>
 
 ### 2q: molds and mold builders
 
-<a href='https://urbit.org/docs/reference/library/2q.md#char'><code>++char</code></a>
-<a href='https://urbit.org/docs/reference/library/2q.md#cord'><code>++cord</code></a>
-<a href='https://urbit.org/docs/reference/library/2q.md#date'><code>++date</code></a>
-<a href='https://urbit.org/docs/reference/library/2q.md#knot'><code>++knot</code></a>
-<a href='https://urbit.org/docs/reference/library/2q.md#tang'><code>++tang</code></a>
-<a href='https://urbit.org/docs/reference/library/2q.md#tank'><code>++tank</code></a>
-<a href='https://urbit.org/docs/reference/library/2q.md#tape'><code>++tape</code></a>
-<a href='https://urbit.org/docs/reference/library/2q.md#tarp'><code>++tarp</code></a>
-<a href='https://urbit.org/docs/reference/library/2q.md#term'><code>++term</code></a>
-<a href='https://urbit.org/docs/reference/library/2q.md#wain'><code>++wain</code></a>
-<a href='https://urbit.org/docs/reference/library/2q.md#wall'><code>++wall</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#char'><code>++char</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#cord'><code>++cord</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#date'><code>++date</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#knot'><code>++knot</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#tang'><code>++tang</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#tank'><code>++tank</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#tape'><code>++tape</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#tarp'><code>++tarp</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#term'><code>++term</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#wain'><code>++wain</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#wall'><code>++wall</code></a>
 
 ### 3a: modular and signed ints
 
-<a href='https://urbit.org/docs/reference/library/3a.md#fo'><code>++fo</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#dif-fo'><code>++dif:fo</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#exp-fo'><code>++exp:fo</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#fra-fo'><code>++fra:fo</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#inv-fo'><code>++inv:fo</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#pro-fo'><code>++pro:fo</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#sit-fo'><code>++sit:fo</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#sum-fo'><code>++sum:fo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#fo'><code>++fo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#dif-fo'><code>++dif:fo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#exp-fo'><code>++exp:fo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#fra-fo'><code>++fra:fo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#inv-fo'><code>++inv:fo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#pro-fo'><code>++pro:fo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#sit-fo'><code>++sit:fo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#sum-fo'><code>++sum:fo</code></a>
 
-<a href='https://urbit.org/docs/reference/library/3a.md#si'><code>++si</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#abs-si' data-tippy-content="Absolute value (signed integer)"><code>++abs:si</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#cmp-si'><code>++cmp:si</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#dif-si'><code>++dif:si</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#dul-si'><code>++dul:si</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#fra-si'><code>++fra:si</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#new-si'><code>++new:si</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#old-si'><code>++old:si</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#pro-si'><code>++pro:si</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#rem-si'><code>++rem:si</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#sum-si'><code>++sum:si</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#sun-si'><code>++sun:si</code></a>
-<a href='https://urbit.org/docs/reference/library/3a.md#syn-si'><code>++syn:si</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#si'><code>++si</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#abs-si' data-tippy-content="Absolute value (signed integer)"><code>++abs:si</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#cmp-si'><code>++cmp:si</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#dif-si'><code>++dif:si</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#dul-si'><code>++dul:si</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#fra-si'><code>++fra:si</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#new-si'><code>++new:si</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#old-si'><code>++old:si</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#pro-si'><code>++pro:si</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#rem-si'><code>++rem:si</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#sum-si'><code>++sum:si</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#sun-si'><code>++sun:si</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#syn-si'><code>++syn:si</code></a>
 
-<a href='https://urbit.org/docs/reference/library/3a.md#egcd'><code>++egcd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#egcd'><code>++egcd</code></a>
 
 ### 3b: floating point
 
-<a href='https://urbit.org/docs/reference/library/3b.md#dn'><code>++dn</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#fn'><code>++fn</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#rn'><code>++rn</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#dn'><code>++dn</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fn'><code>++fn</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rn'><code>++rn</code></a>
 
-<a href='https://urbit.org/docs/reference/library/3b.md#ff'><code>++ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#add-ff' data-tippy-content="Add (floating point)"><code>++add:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#bif-ff'><code>++bif:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#bit-ff'><code>++bit:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#div-ff'><code>++div:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#drg-ff'><code>++drg:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#equ-ff'><code>++equ:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#exp-ff'><code>++exp:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#fma-ff'><code>++fma:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#grd-ff'><code>++grd:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#gte-ff'><code>++gte:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#gth-ff'><code>++gth:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#lte-ff'><code>++lte:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#lth-ff'><code>++lth:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#me-ff'><code>++me:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#mul-ff'><code>++mul:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#pa-ff'><code>++pa:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#san-ff'><code>++san:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sb-ff'><code>++sb:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sea-ff'><code>++sea:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sig-ff'><code>++sig:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sqt-ff'><code>++sqt:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sub-ff'><code>++sub:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sun-ff'><code>++sun:ff</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#toi-ff'><code>++toi:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ff'><code>++ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#add-ff' data-tippy-content="Add (floating point)"><code>++add:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bif-ff'><code>++bif:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-ff'><code>++bit:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#div-ff'><code>++div:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#drg-ff'><code>++drg:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#equ-ff'><code>++equ:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#exp-ff'><code>++exp:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fma-ff'><code>++fma:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#grd-ff'><code>++grd:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gte-ff'><code>++gte:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gth-ff'><code>++gth:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lte-ff'><code>++lte:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lth-ff'><code>++lth:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#me-ff'><code>++me:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#mul-ff'><code>++mul:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#pa-ff'><code>++pa:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#san-ff'><code>++san:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sb-ff'><code>++sb:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sea-ff'><code>++sea:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sig-ff'><code>++sig:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sqt-ff'><code>++sqt:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sub-ff'><code>++sub:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sun-ff'><code>++sun:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#toi-ff'><code>++toi:ff</code></a>
 
-<a href='https://urbit.org/docs/reference/library/3b.md#fl'><code>++fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#abs-fl' data-tippy-content="Absolute value"><code>++abs:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#add-fl' data-tippy-content="Add (with exact/rounded flag)"><code>++add:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#den-fl'><code>++den:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#div-fl'><code>++div:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#drg-fl'><code>++drg:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#ead-fl'><code>++ead:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#emn-fl'><code>++emn:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#emu-fl'><code>++emu:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#emx-fl'><code>++emx:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#equ-fl'><code>++equ:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#fli-fl'><code>++fli:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#fma-fl'><code>++fma:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#grd-fl'><code>++grd:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#gte-fl'><code>++gte:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#gth-fl'><code>++gth:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#ibl-fl'><code>++ibl:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#inv-fl'><code>++inv:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#lfe-fl'><code>++lfe:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#lfn-fl'><code>++lfn:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#lte-fl'><code>++lte:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#lth-fl'><code>++lth:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#lug-fl'><code>++lug:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#mul-fl'><code>++mul:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#ned-fl'><code>++ned:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#prc-fl'><code>++prc:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#rau-fl'><code>++rau:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#rou-fl'><code>++rou:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#san-fl'><code>++san:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#shf-fl'><code>++shf:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#spd-fl'><code>++spd:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#spn-fl'><code>++spn:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sqt-fl'><code>++sqt:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sub-fl'><code>++sub:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sun-fl'><code>++sun:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#swr-fl'><code>++swr:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#syn-fl'><code>++syn:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#toi-fl'><code>++toi:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#toj-fl'><code>++toj:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#uni-fl'><code>++uni:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#xpd-fl'><code>++xpd:fl</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#zer-fl'><code>++zer:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fl'><code>++fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#abs-fl' data-tippy-content="Absolute value"><code>++abs:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#add-fl' data-tippy-content="Add (with exact/rounded flag)"><code>++add:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#den-fl'><code>++den:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#div-fl'><code>++div:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#drg-fl'><code>++drg:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ead-fl'><code>++ead:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#emn-fl'><code>++emn:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#emu-fl'><code>++emu:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#emx-fl'><code>++emx:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#equ-fl'><code>++equ:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fli-fl'><code>++fli:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fma-fl'><code>++fma:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#grd-fl'><code>++grd:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gte-fl'><code>++gte:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gth-fl'><code>++gth:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ibl-fl'><code>++ibl:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#inv-fl'><code>++inv:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lfe-fl'><code>++lfe:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lfn-fl'><code>++lfn:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lte-fl'><code>++lte:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lth-fl'><code>++lth:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lug-fl'><code>++lug:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#mul-fl'><code>++mul:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ned-fl'><code>++ned:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#prc-fl'><code>++prc:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rau-fl'><code>++rau:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rou-fl'><code>++rou:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#san-fl'><code>++san:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#shf-fl'><code>++shf:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#spd-fl'><code>++spd:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#spn-fl'><code>++spn:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sqt-fl'><code>++sqt:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sub-fl'><code>++sub:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sun-fl'><code>++sun:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#swr-fl'><code>++swr:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#syn-fl'><code>++syn:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#toi-fl'><code>++toi:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#toj-fl'><code>++toj:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#uni-fl'><code>++uni:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#xpd-fl'><code>++xpd:fl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#zer-fl'><code>++zer:fl</code></a>
 
-<a href='https://urbit.org/docs/reference/library/3b.md#rd'><code>++rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#add-rd' data-tippy-content="Add (double-precision float)"><code>++add:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#bit-rd'><code>++bit:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#div-rd'><code>++div:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#drg-rd'><code>++drg:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#equ-rd'><code>++equ:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#exp-rd'><code>++exp:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#fma-rd'><code>++fma:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#grd-rd'><code>++grd:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#gte-rd'><code>++gte:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#gth-rd'><code>++gth:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#lte-rd'><code>++lte:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#lth-rd'><code>++lth:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#ma-rd'><code>++ma:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#mul-rd'><code>++mul:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#san-rd'><code>++san:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sea-rd'><code>++sea:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sig-rd'><code>++sig:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sqt-rd'><code>++sqt:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sub-rd'><code>++sub:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sun-rd'><code>++sun:rd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#toi-rd'><code>++toi:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rd'><code>++rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#add-rd' data-tippy-content="Add (double-precision float)"><code>++add:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rd'><code>++bit:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#div-rd'><code>++div:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#drg-rd'><code>++drg:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#equ-rd'><code>++equ:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#exp-rd'><code>++exp:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fma-rd'><code>++fma:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#grd-rd'><code>++grd:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gte-rd'><code>++gte:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gth-rd'><code>++gth:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lte-rd'><code>++lte:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lth-rd'><code>++lth:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ma-rd'><code>++ma:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#mul-rd'><code>++mul:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#san-rd'><code>++san:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sea-rd'><code>++sea:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sig-rd'><code>++sig:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sqt-rd'><code>++sqt:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sub-rd'><code>++sub:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sun-rd'><code>++sun:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#toi-rd'><code>++toi:rd</code></a>
 
-<a href='https://urbit.org/docs/reference/library/3b.md#rh'><code>++rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#add-rh' data-tippy-content="Add (half-precision float)"><code>++add:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#bit-rh'><code>++bit:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#div-rh'><code>++div:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#drg-rh'><code>++drg:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#equ-rh'><code>++equ:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#exp-rh'><code>++exp:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#fma-rh'><code>++fma:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#fos-rh'><code>++fos:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#grd-rh'><code>++grd:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#gte-rh'><code>++gte:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#gth-rh'><code>++gth:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#lte-rh'><code>++lte:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#lth-rh'><code>++lth:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#ma-rh'><code>++ma:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#mul-rh'><code>++mul:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#san-rh'><code>++san:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sea-rh'><code>++sea:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sig-rh'><code>++sig:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sqt-rh'><code>++sqt:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sub-rh'><code>++sub:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sun-rh'><code>++sun:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#toi-rh'><code>++toi:rh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#tos-rh'><code>++tos:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rh'><code>++rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#add-rh' data-tippy-content="Add (half-precision float)"><code>++add:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rh'><code>++bit:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#div-rh'><code>++div:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#drg-rh'><code>++drg:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#equ-rh'><code>++equ:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#exp-rh'><code>++exp:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fma-rh'><code>++fma:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fos-rh'><code>++fos:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#grd-rh'><code>++grd:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gte-rh'><code>++gte:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gth-rh'><code>++gth:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lte-rh'><code>++lte:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lth-rh'><code>++lth:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ma-rh'><code>++ma:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#mul-rh'><code>++mul:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#san-rh'><code>++san:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sea-rh'><code>++sea:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sig-rh'><code>++sig:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sqt-rh'><code>++sqt:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sub-rh'><code>++sub:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sun-rh'><code>++sun:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#toi-rh'><code>++toi:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#tos-rh'><code>++tos:rh</code></a>
 
-<a href='https://urbit.org/docs/reference/library/3b.md#rs'><code>++rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#add-rs' data-tippy-content="Add (single-precision float)"><code>++add:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#bit-rs'><code>++bit:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#div-rs'><code>++div:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#drg-rs'><code>++drg:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#equ-rs'><code>++equ:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#exp-rs'><code>++exp:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#fma-rs'><code>++fma:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#grd-rs'><code>++grd:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#gte-rs'><code>++gte:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#gth-rs'><code>++gth:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#lte-rs'><code>++lte:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#lth-rs'><code>++lth:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#ma-rs'><code>++ma:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#mul-rs'><code>++mul:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#san-rs'><code>++san:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sea-rs'><code>++sea:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sig-rs'><code>++sig:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sqt-rs'><code>++sqt:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sub-rs'><code>++sub:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sun-rs'><code>++sun:rs</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#toi-rs'><code>++toi:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rs'><code>++rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#add-rs' data-tippy-content="Add (single-precision float)"><code>++add:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rs'><code>++bit:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#div-rs'><code>++div:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#drg-rs'><code>++drg:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#equ-rs'><code>++equ:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#exp-rs'><code>++exp:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fma-rs'><code>++fma:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#grd-rs'><code>++grd:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gte-rs'><code>++gte:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gth-rs'><code>++gth:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lte-rs'><code>++lte:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lth-rs'><code>++lth:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ma-rs'><code>++ma:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#mul-rs'><code>++mul:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#san-rs'><code>++san:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sea-rs'><code>++sea:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sig-rs'><code>++sig:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sqt-rs'><code>++sqt:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sub-rs'><code>++sub:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sun-rs'><code>++sun:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#toi-rs'><code>++toi:rs</code></a>
 
-<a href='https://urbit.org/docs/reference/library/3b.md#rq'><code>++rq</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#add-rq' data-tippy-content="Add (quad-precision float)"><code>++add:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#bit-rq'><code>++bit:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#div-rq'><code>++div:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#drg-rq'><code>++drg:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#equ-rq'><code>++equ:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#exp-rq'><code>++exp:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#fma-rq'><code>++fma:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#grd-rq'><code>++grd:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#gte-rq'><code>++gte:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#gth-rq'><code>++gth:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#lte-rq'><code>++lte:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#lth-rq'><code>++lth:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#ma-rq'><code>++ma:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#mul-rq'><code>++mul:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#san-rq'><code>++san:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sea-rq'><code>++sea:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sig-rq'><code>++sig:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sqt-rq'><code>++sqt:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sub-rq'><code>++sub:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#sun-rq'><code>++sun:rq</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#toi-rq'><code>++toi:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rq'><code>++rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#add-rq' data-tippy-content="Add (quad-precision float)"><code>++add:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rq'><code>++bit:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#div-rq'><code>++div:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#drg-rq'><code>++drg:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#equ-rq'><code>++equ:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#exp-rq'><code>++exp:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#fma-rq'><code>++fma:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#grd-rq'><code>++grd:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gte-rq'><code>++gte:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#gth-rq'><code>++gth:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lte-rq'><code>++lte:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#lth-rq'><code>++lth:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ma-rq'><code>++ma:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#mul-rq'><code>++mul:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#san-rq'><code>++san:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sea-rq'><code>++sea:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sig-rq'><code>++sig:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sqt-rq'><code>++sqt:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sub-rq'><code>++sub:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#sun-rq'><code>++sun:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#toi-rq'><code>++toi:rq</code></a>
 
-<a href='https://urbit.org/docs/reference/library/3b.md#rlyd'><code>++rlyd</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#rlyh'><code>++rlyh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#rlyq'><code>++rlyq</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#rlys'><code>++rlys</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#ryld'><code>++ryld</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#rylh'><code>++rylh</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#rylq'><code>++rylq</code></a>
-<a href='https://urbit.org/docs/reference/library/3b.md#ryls'><code>++ryls</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rlyd'><code>++rlyd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rlyh'><code>++rlyh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rlyq'><code>++rlyq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rlys'><code>++rlys</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ryld'><code>++ryld</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rylh'><code>++rylh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rylq'><code>++rylq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ryls'><code>++ryls</code></a>
 
 ### 3c: urbit time
 
-<a href='https://urbit.org/docs/reference/library/3c.md#yo'><code>++yo</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#cet-yo'><code>++cet:yo</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#day-yo'><code>++day:yo</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#era-yo'><code>++era:yo</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#hor-yo'><code>++hor:yo</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#jes-yo'><code>++jes:yo</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#mit-yo'><code>++mit:yo</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#moh-yo'><code>++moh:yo</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#moy-yo'><code>++moy:yo</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#qad-yo'><code>++qad:yo</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#yer-yo'><code>++yer:yo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yo'><code>++yo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#cet-yo'><code>++cet:yo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#day-yo'><code>++day:yo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#era-yo'><code>++era:yo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#hor-yo'><code>++hor:yo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#jes-yo'><code>++jes:yo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#mit-yo'><code>++mit:yo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#moh-yo'><code>++moh:yo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#moy-yo'><code>++moy:yo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#qad-yo'><code>++qad:yo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yer-yo'><code>++yer:yo</code></a>
 
-<a href='https://urbit.org/docs/reference/library/3c.md#yall'><code>++yall</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#yawn'><code>++yawn</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#year'><code>++year</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#yell'><code>++yell</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#yelp'><code>++yelp</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#yore'><code>++yore</code></a>
-<a href='https://urbit.org/docs/reference/library/3c.md#yule'><code>++yule</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yall'><code>++yall</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yawn'><code>++yawn</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#year'><code>++year</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yell'><code>++yell</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yelp'><code>++yelp</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yore'><code>++yore</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yule'><code>++yule</code></a>
 
 ### 3d: SHA hash family
 
-<a href='https://urbit.org/docs/reference/library/3d.md#og'><code>++og</code></a>
-<a href='https://urbit.org/docs/reference/library/3d.md#rad-og'><code>++rad:og</code></a>
-<a href='https://urbit.org/docs/reference/library/3d.md#rads-og'><code>++rads:og</code></a>
-<a href='https://urbit.org/docs/reference/library/3d.md#raw-og'><code>++raw:og</code></a>
-<a href='https://urbit.org/docs/reference/library/3d.md#raws-og'><code>++raws:og</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#og'><code>++og</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#rad-og'><code>++rad:og</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#rads-og'><code>++rads:og</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#raw-og'><code>++raw:og</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#raws-og'><code>++raws:og</code></a>
 
-<a href='https://urbit.org/docs/reference/library/3d.md#shad'><code>++shad</code></a>
-<a href='https://urbit.org/docs/reference/library/3d.md#shaf'><code>++shaf</code></a>
-<a href='https://urbit.org/docs/reference/library/3d.md#shal'><code>++shal</code></a>
-<a href='https://urbit.org/docs/reference/library/3d.md#sham'><code>++sham</code></a>
-<a href='https://urbit.org/docs/reference/library/3d.md#shan'><code>++shan</code></a>
-<a href='https://urbit.org/docs/reference/library/3d.md#shas'><code>++shas</code></a>
-<a href='https://urbit.org/docs/reference/library/3d.md#shaw'><code>++shaw</code></a>
-<a href='https://urbit.org/docs/reference/library/3d.md#shax'><code>++shax</code></a>
-<a href='https://urbit.org/docs/reference/library/3d.md#shay'><code>++shay</code></a>
-<a href='https://urbit.org/docs/reference/library/3d.md#shaz'><code>++shaz</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shad'><code>++shad</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shaf'><code>++shaf</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shal'><code>++shal</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#sham'><code>++sham</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shan'><code>++shan</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shas'><code>++shas</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shaw'><code>++shaw</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shax'><code>++shax</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shay'><code>++shay</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3d.md#shaz'><code>++shaz</code></a>
 
 ### 3e: AES encryption
 
-<a href='https://urbit.org/docs/reference/library/3e.md'>_(removed)_</a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3e.md'>_(removed)_</a>
 
 ### 3f: scrambling
 
-<a href='https://urbit.org/docs/reference/library/3f.md#ob'><code>++ob</code></a>
-<a href='https://urbit.org/docs/reference/library/3f.md#feen-ob'><code>++feen:ob</code></a>
-<a href='https://urbit.org/docs/reference/library/3f.md#fend-ob'><code>++fend:ob</code></a>
-<a href='https://urbit.org/docs/reference/library/3f.md#fice-ob'><code>++fice:ob</code></a>
-<a href='https://urbit.org/docs/reference/library/3f.md#raku-ob'><code>++raku:ob</code></a>
-<a href='https://urbit.org/docs/reference/library/3f.md#rund-ob'><code>++rund:ob</code></a>
-<a href='https://urbit.org/docs/reference/library/3f.md#rynd-ob'><code>++rynd:ob</code></a>
-<a href='https://urbit.org/docs/reference/library/3f.md#teil-ob'><code>++teil:ob</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#ob'><code>++ob</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#feen-ob'><code>++feen:ob</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#fend-ob'><code>++fend:ob</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#fice-ob'><code>++fice:ob</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#raku-ob'><code>++raku:ob</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#rund-ob'><code>++rund:ob</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#rynd-ob'><code>++rynd:ob</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#teil-ob'><code>++teil:ob</code></a>
 
-<a href='https://urbit.org/docs/reference/library/3f.md#un'><code>++un</code></a>
-<a href='https://urbit.org/docs/reference/library/3f.md#wred-un'><code>++wred:un</code></a>
-<a href='https://urbit.org/docs/reference/library/3f.md#wren-un'><code>++wren:un</code></a>
-<a href='https://urbit.org/docs/reference/library/3f.md#xafo-un'><code>++xafo:un</code></a>
-<a href='https://urbit.org/docs/reference/library/3f.md#xaro-un'><code>++xaro:un</code></a>
-<a href='https://urbit.org/docs/reference/library/3f.md#zaft-un'><code>++zaft:un</code></a>
-<a href='https://urbit.org/docs/reference/library/3f.md#zart-un'><code>++zart:un</code></a>
-<a href='https://urbit.org/docs/reference/library/3f.md#zyft-un'><code>++zyft:un</code></a>
-<a href='https://urbit.org/docs/reference/library/3f.md#zyrt-un'><code>++zyrt:un</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#un'><code>++un</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#wred-un'><code>++wred:un</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#wren-un'><code>++wren:un</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#xafo-un'><code>++xafo:un</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#xaro-un'><code>++xaro:un</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#zaft-un'><code>++zaft:un</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#zart-un'><code>++zart:un</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#zyft-un'><code>++zyft:un</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3f.md#zyrt-un'><code>++zyrt:un</code></a>
 
 ### 3g: molds and mold builders
 
-<a href='https://urbit.org/docs/reference/library/3g.md#coin'><code>++coin</code></a>
-<a href='https://urbit.org/docs/reference/library/3g.md#dime'><code>++dime</code></a>
-<a href='https://urbit.org/docs/reference/library/3g.md#edge'><code>++edge</code></a>
-<a href='https://urbit.org/docs/reference/library/3g.md#hair'><code>++hair</code></a>
-<a href='https://urbit.org/docs/reference/library/3g.md#like'><code>++like</code></a>
-<a href='https://urbit.org/docs/reference/library/3g.md#nail'><code>++nail</code></a>
-<a href='https://urbit.org/docs/reference/library/3g.md#path'><code>++path</code></a>
-<a href='https://urbit.org/docs/reference/library/3g.md#pint'><code>++pint</code></a>
-<a href='https://urbit.org/docs/reference/library/3g.md#rule'><code>++rule</code></a>
-<a href='https://urbit.org/docs/reference/library/3g.md#spot'><code>++spot</code></a>
-<a href='https://urbit.org/docs/reference/library/3g.md#tone'><code>++tone</code></a>
-<a href='https://urbit.org/docs/reference/library/3g.md#toon'><code>++toon</code></a>
-<a href='https://urbit.org/docs/reference/library/3g.md#wonk'><code>++wonk</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#coin'><code>++coin</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#dime'><code>++dime</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#edge'><code>++edge</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#hair'><code>++hair</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#like'><code>++like</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#nail'><code>++nail</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#path'><code>++path</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#pint'><code>++pint</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#rule'><code>++rule</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#spot'><code>++spot</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#tone'><code>++tone</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#toon'><code>++toon</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#wonk'><code>++wonk</code></a>
 
 ### 4a: exotic bases
 
-<a href='https://urbit.org/docs/reference/library/4a.md#po'><code>++po</code></a>
-<a href='https://urbit.org/docs/reference/library/4a.md#ind-po'><code>++ind:po</code></a>
-<a href='https://urbit.org/docs/reference/library/4a.md#ins-po'><code>++ins:po</code></a>
-<a href='https://urbit.org/docs/reference/library/4a.md#tod-po'><code>++tod:po</code></a>
-<a href='https://urbit.org/docs/reference/library/4a.md#tos-po'><code>++tos:po</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4a.md#po'><code>++po</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4a.md#ind-po'><code>++ind:po</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4a.md#ins-po'><code>++ins:po</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4a.md#tod-po'><code>++tod:po</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4a.md#tos-po'><code>++tos:po</code></a>
 
 ### 4b: text processing
 
-<a href='https://urbit.org/docs/reference/library/4b.md#at' data-tippy-content="(Undocumented)"><code>++at</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#r-at'><code>++r:at</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#rf-at'><code>++rf:at</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#rn-at'><code>++rn:at</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#rt-at'><code>++rt:at</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#rta-at'><code>++rta:at</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#rtam-at'><code>++rtam:at</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#rub-at'><code>++rub:at</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#rud-at'><code>++rud:at</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#rum-at'><code>++rum:at</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#rup-at'><code>++rup:at</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#ruv-at'><code>++ruv:at</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#rux-at'><code>++rux:at</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#at' data-tippy-content="(Undocumented)"><code>++at</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#r-at'><code>++r:at</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rf-at'><code>++rf:at</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rn-at'><code>++rn:at</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rt-at'><code>++rt:at</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rta-at'><code>++rta:at</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rtam-at'><code>++rtam:at</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rub-at'><code>++rub:at</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rud-at'><code>++rud:at</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rum-at'><code>++rum:at</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rup-at'><code>++rup:at</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#ruv-at'><code>++ruv:at</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rux-at'><code>++rux:at</code></a>
 
-<a href='https://urbit.org/docs/reference/library/4b.md#cass'><code>++cass</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#crip'><code>++crip</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#cuss'><code>++cuss</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#mesc'><code>++mesc</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#runt'><code>++runt</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#sand'><code>++sand</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#sane'><code>++sane</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#teff'><code>++teff</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#trim'><code>++trim</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#trip'><code>++trip</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#tuba'><code>++tuba</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#tufa'><code>++tufa</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#tuft'><code>++tuft</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#turf'><code>++turf</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#wack'><code>++wack</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#wick'><code>++wick</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#woad'><code>++woad</code></a>
-<a href='https://urbit.org/docs/reference/library/4b.md#wood'><code>++wood</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#cass'><code>++cass</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#crip'><code>++crip</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#cuss'><code>++cuss</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#mesc'><code>++mesc</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#runt'><code>++runt</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#sand'><code>++sand</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#sane'><code>++sane</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#teff'><code>++teff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#trim'><code>++trim</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#trip'><code>++trip</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#tuba'><code>++tuba</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#tufa'><code>++tufa</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#tuft'><code>++tuft</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#turf'><code>++turf</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#wack'><code>++wack</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#wick'><code>++wick</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#woad'><code>++woad</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#wood'><code>++wood</code></a>
 
 ### 4c: tank printer
 
-<a href='https://urbit.org/docs/reference/library/4c.md#re'><code>++re</code></a>
-<a href='https://urbit.org/docs/reference/library/4c.md#din-re'><code>++din:re</code></a>
-<a href='https://urbit.org/docs/reference/library/4c.md#fit-re'><code>++fit:re</code></a>
-<a href='https://urbit.org/docs/reference/library/4c.md#ram-re'><code>++ram:re</code></a>
-<a href='https://urbit.org/docs/reference/library/4c.md#rig-re'><code>++rig:re</code></a>
-<a href='https://urbit.org/docs/reference/library/4c.md#wig-re'><code>++wig:re</code></a>
-<a href='https://urbit.org/docs/reference/library/4c.md#win-re'><code>++win:re</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#re'><code>++re</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#din-re'><code>++din:re</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#fit-re'><code>++fit:re</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#ram-re'><code>++ram:re</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#rig-re'><code>++rig:re</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#wig-re'><code>++wig:re</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#win-re'><code>++win:re</code></a>
 
-<a href='https://urbit.org/docs/reference/library/4c.md#shep'><code>++shep</code></a>
-<a href='https://urbit.org/docs/reference/library/4c.md#shop'><code>++shop</code></a>
-<a href='https://urbit.org/docs/reference/library/4c.md#show'><code>++show</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#shep'><code>++shep</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#shop'><code>++shop</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4c.md#show'><code>++show</code></a>
 
 ### 4d: parsing (tracing)
 
-<a href='https://urbit.org/docs/reference/library/4d.md#last'><code>++last</code></a>
-<a href='https://urbit.org/docs/reference/library/4d.md#lust'><code>++lust</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4d.md#last'><code>++last</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4d.md#lust'><code>++lust</code></a>
 
 ### 4e: parsing (combinators)
 
-<a href='https://urbit.org/docs/reference/library/4e.md#bend'><code>++bend</code></a>
-<a href='https://urbit.org/docs/reference/library/4e.md#comp'><code>++comp</code></a>
-<a href='https://urbit.org/docs/reference/library/4e.md#fail'><code>++fail</code></a>
-<a href='https://urbit.org/docs/reference/library/4e.md#glue'><code>++glue</code></a>
-<a href='https://urbit.org/docs/reference/library/4e.md#less'><code>++less</code></a>
-<a href='https://urbit.org/docs/reference/library/4e.md#pfix'><code>++pfix</code></a>
-<a href='https://urbit.org/docs/reference/library/4e.md#plug'><code>++plug</code></a>
-<a href='https://urbit.org/docs/reference/library/4e.md#pose'><code>++pose</code></a>
-<a href='https://urbit.org/docs/reference/library/4e.md#sfix'><code>++sfix</code></a>
-<a href='https://urbit.org/docs/reference/library/4e.md#simu'><code>++simu</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#bend'><code>++bend</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#comp'><code>++comp</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#fail'><code>++fail</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#glue'><code>++glue</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#less'><code>++less</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#pfix'><code>++pfix</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#plug'><code>++plug</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#pose'><code>++pose</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#sfix'><code>++sfix</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#simu'><code>++simu</code></a>
 
 ### 4f: parsing (rule builders)
 
-<a href='https://urbit.org/docs/reference/library/4f.md#bass'><code>++bass</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#boss'><code>++boss</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#cold'><code>++cold</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#cook'><code>++cook</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#easy'><code>++easy</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#full'><code>++full</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#funk'><code>++funk</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#here'><code>++here</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#ifix'><code>++ifix</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#jest'><code>++jest</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#just'><code>++just</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#knee'><code>++knee</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#mask'><code>++mask</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#more'><code>++more</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#most'><code>++most</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#next'><code>++next</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#plus'><code>++plus</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#sear'><code>++sear</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#shim'><code>++shim</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#slug'><code>++slug</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#stag'><code>++stag</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#star'><code>++star</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#stet'><code>++stet</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#stew'><code>++stew</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#stir'><code>++stir</code></a>
-<a href='https://urbit.org/docs/reference/library/4f.md#stun'><code>++stun</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#bass'><code>++bass</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#boss'><code>++boss</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#cold'><code>++cold</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#cook'><code>++cook</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#easy'><code>++easy</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#full'><code>++full</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#funk'><code>++funk</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#here'><code>++here</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#ifix'><code>++ifix</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#jest'><code>++jest</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#just'><code>++just</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#knee'><code>++knee</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#mask'><code>++mask</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#more'><code>++more</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#most'><code>++most</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#next'><code>++next</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#plus'><code>++plus</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#sear'><code>++sear</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#shim'><code>++shim</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#slug'><code>++slug</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#stag'><code>++stag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#star'><code>++star</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#stet'><code>++stet</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#stew'><code>++stew</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#stir'><code>++stir</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#stun'><code>++stun</code></a>
 
 ### 4g: parsing (outside caller)
 
-<a href='https://urbit.org/docs/reference/library/4g.md#rash'><code>++rash</code></a>
-<a href='https://urbit.org/docs/reference/library/4g.md#rush'><code>++rush</code></a>
-<a href='https://urbit.org/docs/reference/library/4g.md#rust'><code>++rust</code></a>
-<a href='https://urbit.org/docs/reference/library/4g.md#scan'><code>++scan</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4g.md#rash'><code>++rash</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4g.md#rush'><code>++rush</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4g.md#rust'><code>++rust</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4g.md#scan'><code>++scan</code></a>
 
 ### 4h: parsing (ascii glyphs)
 
-<a href='https://urbit.org/docs/reference/library/4h.md#ace' data-tippy-content="Parse space"><code>++ace</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#bar'><code>++bar</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#bas'><code>++bas</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#buc'><code>++buc</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#cab'><code>++cab</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#cen'><code>++cen</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#col'><code>++col</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#com'><code>++com</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#doq'><code>++doq</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#dot'><code>++dot</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#fas'><code>++fas</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#gal'><code>++gal</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#gar'><code>++gar</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#hax'><code>++hax</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#hep'><code>++hep</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#kel'><code>++kel</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#ker'><code>++ker</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#ket'><code>++ket</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#lus'><code>++lus</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#pam'><code>++pam</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#pat'><code>++pat</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#pel'><code>++pel</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#per'><code>++per</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#sel'><code>++sel</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#sem'><code>++sem</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#ser'><code>++ser</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#sig'><code>++sig</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#soq'><code>++soq</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#tar'><code>++tar</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#tec'><code>++tec</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#tis'><code>++tis</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#wut'><code>++wut</code></a>
-<a href='https://urbit.org/docs/reference/library/4h.md#zap'><code>++zap</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#ace' data-tippy-content="Parse space"><code>++ace</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#bar'><code>++bar</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#bas'><code>++bas</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#buc'><code>++buc</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#cab'><code>++cab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#cen'><code>++cen</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#col'><code>++col</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#com'><code>++com</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#doq'><code>++doq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#dot'><code>++dot</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#fas'><code>++fas</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#gal'><code>++gal</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#gar'><code>++gar</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#hax'><code>++hax</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#hep'><code>++hep</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#kel'><code>++kel</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#ker'><code>++ker</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#ket'><code>++ket</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#lus'><code>++lus</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#pam'><code>++pam</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#pat'><code>++pat</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#pel'><code>++pel</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#per'><code>++per</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#sel'><code>++sel</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#sem'><code>++sem</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#ser'><code>++ser</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#sig'><code>++sig</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#soq'><code>++soq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#tar'><code>++tar</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#tec'><code>++tec</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#tis'><code>++tis</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#wut'><code>++wut</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#zap'><code>++zap</code></a>
 
 ### 4i: parsing (useful idioms)
 
-<a href='https://urbit.org/docs/reference/library/4i.md#alf' data-tippy-content="Parse alphabetic characters"><code>++alf</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#aln' data-tippy-content="Parse alphanumeric characters"><code>++aln</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#alp' data-tippy-content="Parse alphanumeric characters and -"><code>++alp</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#bet'><code>++bet</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#bin'><code>++bin</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#but'><code>++but</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#cit'><code>++cit</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#dem'><code>++dem</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#dit'><code>++dit</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#dog'><code>++dog</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#doh'><code>++doh</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#dun'><code>++dun</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#duz'><code>++duz</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#gah'><code>++gah</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#gap'><code>++gap</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#gaq'><code>++gaq</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#gaw'><code>++gaw</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#gay'><code>++gay</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#gon'><code>++gon</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#gul'><code>++gul</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#hex'><code>++hex</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#hig'><code>++hig</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#hit'><code>++hit</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#iny'><code>++iny</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#low'><code>++low</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#mes'><code>++mes</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#nix'><code>++nix</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#nud'><code>++nud</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#prn'><code>++prn</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#qit'><code>++qit</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#qut'><code>++qut</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#soz'><code>++soz</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#sym'><code>++sym</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#ven'><code>++ven</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#vit'><code>++vit</code></a>
-<a href='https://urbit.org/docs/reference/library/4i.md#vul'><code>++vul</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#alf' data-tippy-content="Parse alphabetic characters"><code>++alf</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#aln' data-tippy-content="Parse alphanumeric characters"><code>++aln</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#alp' data-tippy-content="Parse alphanumeric characters and -"><code>++alp</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#bet'><code>++bet</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#bin'><code>++bin</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#but'><code>++but</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#cit'><code>++cit</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#dem'><code>++dem</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#dit'><code>++dit</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#dog'><code>++dog</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#doh'><code>++doh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#dun'><code>++dun</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#duz'><code>++duz</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#gah'><code>++gah</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#gap'><code>++gap</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#gaq'><code>++gaq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#gaw'><code>++gaw</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#gay'><code>++gay</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#gon'><code>++gon</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#gul'><code>++gul</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#hex'><code>++hex</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#hig'><code>++hig</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#hit'><code>++hit</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#iny'><code>++iny</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#low'><code>++low</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#mes'><code>++mes</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#nix'><code>++nix</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#nud'><code>++nud</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#prn'><code>++prn</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#qit'><code>++qit</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#qut'><code>++qut</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#soz'><code>++soz</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#sym'><code>++sym</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#ven'><code>++ven</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#vit'><code>++vit</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#vul'><code>++vul</code></a>
 
 ### 4j: parsing (bases and base digits)
 
-<a href='https://urbit.org/docs/reference/library/4j.md#ab' data-tippy-content="Primitive parser engine"><code>++ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#bix-ab'><code>++bix:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#hif-ab'><code>++hif:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#huf-ab'><code>++huf:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#hyf-ab'><code>++hyf:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#pev-ab'><code>++pev:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#pew-ab'><code>++pew:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#piv-ab'><code>++piv:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#piw-ab'><code>++piw:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#qeb-ab'><code>++qeb:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#qex-ab'><code>++qex:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#qib-ab'><code>++qib:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#qix-ab'><code>++qix:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#seb-ab'><code>++seb:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#sed-ab'><code>++sed:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#sev-ab'><code>++sev:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#sew-ab'><code>++sew:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#sex-ab'><code>++sex:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#sib-ab'><code>++sib:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#sid-ab'><code>++sid:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#siv-ab'><code>++siv:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#siw-ab'><code>++siw:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#six-ab'><code>++six:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#sov-ab'><code>++sov:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#sow-ab'><code>++sow:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#sox-ab'><code>++sox:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#ted-ab'><code>++ted:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#tid-ab'><code>++tid:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#til-ab'><code>++til:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#tip-ab'><code>++tip:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#tiq-ab'><code>++tiq:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#urs-ab'><code>++urs:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#urt-ab'><code>++urt:ab</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#voy-ab'><code>++voy:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#ab' data-tippy-content="Primitive parser engine"><code>++ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#bix-ab'><code>++bix:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#hif-ab'><code>++hif:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#huf-ab'><code>++huf:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#hyf-ab'><code>++hyf:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#pev-ab'><code>++pev:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#pew-ab'><code>++pew:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#piv-ab'><code>++piv:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#piw-ab'><code>++piw:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#qeb-ab'><code>++qeb:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#qex-ab'><code>++qex:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#qib-ab'><code>++qib:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#qix-ab'><code>++qix:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#seb-ab'><code>++seb:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sed-ab'><code>++sed:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sev-ab'><code>++sev:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sew-ab'><code>++sew:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sex-ab'><code>++sex:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sib-ab'><code>++sib:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sid-ab'><code>++sid:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#siv-ab'><code>++siv:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#siw-ab'><code>++siw:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#six-ab'><code>++six:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sov-ab'><code>++sov:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sow-ab'><code>++sow:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#sox-ab'><code>++sox:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#ted-ab'><code>++ted:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#tid-ab'><code>++tid:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#til-ab'><code>++til:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#tip-ab'><code>++tip:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#tiq-ab'><code>++tiq:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#urs-ab'><code>++urs:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#urt-ab'><code>++urt:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#voy-ab'><code>++voy:ab</code></a>
 
-<a href='https://urbit.org/docs/reference/library/4j.md#ag' data-tippy-content="Top-level atom parser engine"><code>++ag</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#ape-ag' data-tippy-content="Parse 0 or rule"><code>++ape:ag</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#bay-ag'><code>++bay:ag</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#bip-ag'><code>++bip:ag</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#dem-ag'><code>++dem:ag</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#dim-ag'><code>++dim:ag</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#dum-ag'><code>++dum:ag</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#fed-ag'><code>++fed:ag</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#hex-ag'><code>++hex:ag</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#lip-ag'><code>++lip:ag</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#viz-ag'><code>++viz:ag</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#vum-ag'><code>++vum:ag</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#wiz-ag'><code>++wiz:ag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#ag' data-tippy-content="Top-level atom parser engine"><code>++ag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#ape-ag' data-tippy-content="Parse 0 or rule"><code>++ape:ag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#bay-ag'><code>++bay:ag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#bip-ag'><code>++bip:ag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#dem-ag'><code>++dem:ag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#dim-ag'><code>++dim:ag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#dum-ag'><code>++dum:ag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#fed-ag'><code>++fed:ag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#hex-ag'><code>++hex:ag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#lip-ag'><code>++lip:ag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#viz-ag'><code>++viz:ag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#vum-ag'><code>++vum:ag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#wiz-ag'><code>++wiz:ag</code></a>
 
-<a href='https://urbit.org/docs/reference/library/4j.md#mu'><code>++mu</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#zag-mu'><code>++zag:mu</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#zig-mu'><code>++zig:mu</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#zug-mu'><code>++zug:mu</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#mu'><code>++mu</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#zag-mu'><code>++zag:mu</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#zig-mu'><code>++zig:mu</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#zug-mu'><code>++zug:mu</code></a>
 
-<a href='https://urbit.org/docs/reference/library/4j.md#ne'><code>++ne</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#d-ne'><code>++d:ne</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#v-ne'><code>++v:ne</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#w-ne'><code>++w:ne</code></a>
-<a href='https://urbit.org/docs/reference/library/4j.md#x-ne'><code>++x:ne</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#ne'><code>++ne</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#d-ne'><code>++d:ne</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#v-ne'><code>++v:ne</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#w-ne'><code>++w:ne</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#x-ne'><code>++x:ne</code></a>
 
 ### 4k: parsing (atom printing)
 
-<a href='https://urbit.org/docs/reference/library/4k.md#co'><code>++co</code></a>
-<a href='https://urbit.org/docs/reference/library/4k.md#rear-co'><code>++rear:co</code></a>
-<a href='https://urbit.org/docs/reference/library/4k.md#rend-co'><code>++rend:co</code></a>
-<a href='https://urbit.org/docs/reference/library/4k.md#rent-co'><code>++rent:co</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4k.md#co'><code>++co</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4k.md#rear-co'><code>++rear:co</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4k.md#rend-co'><code>++rend:co</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4k.md#rent-co'><code>++rent:co</code></a>
 
 ### 4l: parsing (atom parsing)
 
-<a href='https://urbit.org/docs/reference/library/4l.md#so'><code>++so</code></a>
-<a href='https://urbit.org/docs/reference/library/4l.md#bisk-so'><code>++bisk:so</code></a>
-<a href='https://urbit.org/docs/reference/library/4l.md#crub-so'><code>++crub:so</code></a>
-<a href='https://urbit.org/docs/reference/library/4l.md#nuck-so'><code>++nuck:so</code></a>
-<a href='https://urbit.org/docs/reference/library/4l.md#nusk-so'><code>++nusk:so</code></a>
-<a href='https://urbit.org/docs/reference/library/4l.md#perd-so'><code>++perd:so</code></a>
-<a href='https://urbit.org/docs/reference/library/4l.md#royl-so'><code>++royl:so</code></a>
-<a href='https://urbit.org/docs/reference/library/4l.md#royl-cell-so'><code>++royl-cell:so</code></a>
-<a href='https://urbit.org/docs/reference/library/4l.md#tash-so'><code>++tash:so</code></a>
-<a href='https://urbit.org/docs/reference/library/4l.md#twid-so'><code>++twid:so</code></a>
-<a href='https://urbit.org/docs/reference/library/4l.md#zust-so'><code>++zust:so</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#so'><code>++so</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#bisk-so'><code>++bisk:so</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#crub-so'><code>++crub:so</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#nuck-so'><code>++nuck:so</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#nusk-so'><code>++nusk:so</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#perd-so'><code>++perd:so</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#royl-so'><code>++royl:so</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#royl-cell-so'><code>++royl-cell:so</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#tash-so'><code>++tash:so</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#twid-so'><code>++twid:so</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#zust-so'><code>++zust:so</code></a>
 
 ### 4m: parsing (formatting functions)
 
-<a href='https://urbit.org/docs/reference/library/4m.md#scot'><code>++scot</code></a>
-<a href='https://urbit.org/docs/reference/library/4m.md#scow'><code>++scow</code></a>
-<a href='https://urbit.org/docs/reference/library/4m.md#slat'><code>++slat</code></a>
-<a href='https://urbit.org/docs/reference/library/4m.md#slav'><code>++slav</code></a>
-<a href='https://urbit.org/docs/reference/library/4m.md#slaw'><code>++slaw</code></a>
-<a href='https://urbit.org/docs/reference/library/4m.md#slay'><code>++slay</code></a>
-<a href='https://urbit.org/docs/reference/library/4m.md#smyt'><code>++smyt</code></a>
-<a href='https://urbit.org/docs/reference/library/4m.md#spat'><code>++spat</code></a>
-<a href='https://urbit.org/docs/reference/library/4m.md#spud'><code>++spud</code></a>
-<a href='https://urbit.org/docs/reference/library/4m.md#stab'><code>++stab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#scot'><code>++scot</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#scow'><code>++scow</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#slat'><code>++slat</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#slav'><code>++slav</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#slaw'><code>++slaw</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#slay'><code>++slay</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#smyt'><code>++smyt</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#spat'><code>++spat</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#spud'><code>++spud</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4m.md#stab'><code>++stab</code></a>
 
 ### 4n: parsing (virtualization)
 
-<a href='https://urbit.org/docs/reference/library/4n.md#mack'><code>++mack</code></a>
-<a href='https://urbit.org/docs/reference/library/4n.md#mink'><code>++mink</code></a>
-<a href='https://urbit.org/docs/reference/library/4n.md#mock'><code>++mock</code></a>
-<a href='https://urbit.org/docs/reference/library/4n.md#mong'><code>++mong</code></a>
-<a href='https://urbit.org/docs/reference/library/4n.md#mook'><code>++mook</code></a>
-<a href='https://urbit.org/docs/reference/library/4n.md#mule'><code>++mule</code></a>
-<a href='https://urbit.org/docs/reference/library/4n.md#mute'><code>++mute</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4n.md#mack'><code>++mack</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4n.md#mink'><code>++mink</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4n.md#mock'><code>++mock</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4n.md#mong'><code>++mong</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4n.md#mook'><code>++mook</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4n.md#mule'><code>++mule</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4n.md#mute'><code>++mute</code></a>
 
 ### 4o: parsing (molds)
 
-<a href='https://urbit.org/docs/reference/library/4o.md#abel' data-tippy-content="Compiler alias"><code>++abel</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#aura' data-tippy-content="'Type' of atom"><code>++aura</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#axis' data-tippy-content="Nock axis"><code>++axis</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#base'><code>++base</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#bean'><code>++bean</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#beer'><code>++beer</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#beet'><code>++beet</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#chum'><code>++chum</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#coil'><code>++coil</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#foot'><code>++foot</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#limb'><code>++limb</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#line'><code>++line</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#metl'><code>++metl</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#nock'><code>++nock</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#noun'><code>++noun</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#null'><code>++null</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#port'><code>++port</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#span'><code>++span</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#tiki'><code>++tiki</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#toga'><code>++toga</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#tone'><code>++tone</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#tuna'><code>++tuna</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#tusk'><code>++tusk</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#tyke'><code>++tyke</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#typo'><code>++typo</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#tyre'><code>++tyre</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#vase'><code>++vase</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#vise'><code>++vise</code></a>
-<a href='https://urbit.org/docs/reference/library/4o.md#wing'><code>++wing</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#abel' data-tippy-content="Compiler alias"><code>++abel</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#aura' data-tippy-content="'Type' of atom"><code>++aura</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#axis' data-tippy-content="Nock axis"><code>++axis</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#base'><code>++base</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#bean'><code>++bean</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#beer'><code>++beer</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#beet'><code>++beet</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#chum'><code>++chum</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#coil'><code>++coil</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#foot'><code>++foot</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#limb'><code>++limb</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#line'><code>++line</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#metl'><code>++metl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#nock'><code>++nock</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#noun'><code>++noun</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#null'><code>++null</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#port'><code>++port</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#span'><code>++span</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#tiki'><code>++tiki</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#toga'><code>++toga</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#tone'><code>++tone</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#tuna'><code>++tuna</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#tusk'><code>++tusk</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#tyke'><code>++tyke</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#typo'><code>++typo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#tyre'><code>++tyre</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#vase'><code>++vase</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#vise'><code>++vise</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#wing'><code>++wing</code></a>
 
 ### 5a: compiler utilities
 
-<a href='https://urbit.org/docs/reference/library/5a.md'>_(To be documented)_</a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/5a.md'>_(To be documented)_</a>
 
 ### 5b: macro expansion
 
-<a href='https://urbit.org/docs/reference/library/5b.md'>_(To be documented)_</a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/5b.md'>_(To be documented)_</a>
 
 ### 5c: compiler backend and prettyprinter
 
-<a href='https://urbit.org/docs/reference/library/5c.md'>_(To be documented)_</a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/5c.md'>_(To be documented)_</a>
 
 ### 5d: parser
 
-<a href='https://urbit.org/docs/reference/library/5d.md'>_(To be documented)_</a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/5d.md'>_(To be documented)_</a>
 
 ### 5e: caching compiler
 
-<a href='https://urbit.org/docs/reference/library/5e.md'>_(To be documented)_</a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/5e.md'>_(To be documented)_</a>
 
 ### 5f: molds and mold builders
 
-<a href='https://urbit.org/docs/reference/library/5f.md#mane'><code>++mane</code></a>
-<a href='https://urbit.org/docs/reference/library/5f.md#manx'><code>++manx</code></a>
-<a href='https://urbit.org/docs/reference/library/5f.md#marl'><code>++marl</code></a>
-<a href='https://urbit.org/docs/reference/library/5f.md#mars'><code>++mars</code></a>
-<a href='https://urbit.org/docs/reference/library/5f.md#mart'><code>++mart</code></a>
-<a href='https://urbit.org/docs/reference/library/5f.md#marx'><code>++marx</code></a>
-<a href='https://urbit.org/docs/reference/library/5f.md#pass'><code>++pass</code></a>
-<a href='https://urbit.org/docs/reference/library/5f.md#ring'><code>++ring</code></a>
-<a href='https://urbit.org/docs/reference/library/5f.md#time'><code>++time</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/5f.md#mane'><code>++mane</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/5f.md#manx'><code>++manx</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/5f.md#marl'><code>++marl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/5f.md#mars'><code>++mars</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/5f.md#mart'><code>++mart</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/5f.md#marx'><code>++marx</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/5f.md#pass'><code>++pass</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/5f.md#ring'><code>++ring</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/5f.md#time'><code>++time</code></a>
 
 ### 5g: profiling support
 
-<a href='https://urbit.org/docs/reference/library/5g.md'>_(To be documented)_</a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/5g.md'>_(To be documented)_</a>

--- a/reference/library/_index.md
+++ b/reference/library/_index.md
@@ -44,80 +44,80 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### b
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#bal-to'><code>+-bal:to</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#bar'><code>++bar</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#bas'><code>++bas</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#base'><code>++base</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#bass'><code>++bass</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#bay-ag'><code>++bay:ag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#bean'><code>++bean</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#beer'><code>++beer</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#beet'><code>++beet</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#bend'><code>++bend</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#bet'><code>++bet</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#bex'><code>++bex</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bif-ff'><code>++bif:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#bif-by'><code>+-bif:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#bif-in'><code>+-bif:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#biff'><code>++biff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#bin'><code>++bin</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#bind'><code>++bind</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#bip-ag'><code>++bip:ag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-ff'><code>++bit:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rd'><code>++bit:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rh'><code>++bit:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rs'><code>++bit:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rq'><code>++bit:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#bix-ab'><code>++bix:ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#bisk-so'><code>++bisk:so</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#bloq'><code>++bloq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#bond'><code>++bond</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#boss'><code>++boss</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#both'><code>++both</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#buc'><code>++buc</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#but'><code>++but</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#bal-to' data-tippy-content="Balance queue"><code>+-bal:to</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#bar' data-tippy-content="Parse | (bar)"><code>++bar</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#bas' data-tippy-content="Parse \ (bas)"><code>++bas</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#base' data-tippy-content="Base type"><code>++base</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#bass' data-tippy-content="Parser modifier (LSB-ordered ++list as atom of ++base)"><code>++bass</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#bay-ag' data-tippy-content="Parses binary number"><code>++bay:ag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#bean' data-tippy-content="Boolean"><code>++bean</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#beer' data-tippy-content="Tape builder"><code>++beer</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#beet' data-tippy-content="XML interpolation cases"><code>++beet</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#bend' data-tippy-content="Conditional composer"><code>++bend</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#bet' data-tippy-content="Parse hep and lus axis syntax"><code>++bet</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#bex' data-tippy-content="Binary exponent"><code>++bex</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bif-ff' data-tippy-content="Converts from fn to @r"><code>++bif:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#bif-by' data-tippy-content="Bifurcate map"><code>+-bif:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#bif-in' data-tippy-content="Bifurcate set"><code>+-bif:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#biff' data-tippy-content="Unit as argument"><code>++biff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#bin' data-tippy-content="Binary to atom"><code>++bin</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#bind' data-tippy-content="Non-unit function to unit, producing unit"><code>++bind</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#bip-ag' data-tippy-content="Parse IPv6"><code>++bip:ag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-ff' data-tippy-content="fn to @r with rounding"><code>++bit:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rd' data-tippy-content="fn to double-precision binary float"><code>++bit:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rh' data-tippy-content="fn to half-precision float"><code>++bit:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rs' data-tippy-content="fn to single-precision float"><code>++bit:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rq' data-tippy-content="fn to quad-precision float"><code>++bit:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#bix-ab' data-tippy-content="Parse hex pair"><code>++bix:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#bisk-so' data-tippy-content="Parse odor-atom pair"><code>++bisk:so</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#bloq' data-tippy-content="Blocksize"><code>++bloq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#bond' data-tippy-content="Replace null"><code>++bond</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#boss' data-tippy-content="Parser modifier: LSB"><code>++boss</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#both' data-tippy-content="Group unit values into pair"><code>++both</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#buc' data-tippy-content="Parse $ (buc)"><code>++buc</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#but' data-tippy-content="Parse binary digit"><code>++but</code></a>
 
 ### c
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#cab'><code>++cab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#can'><code>++can</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1b.md#cap'><code>++cap</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#cass'><code>++cass</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#cat'><code>++cat</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#cen'><code>++cen</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#cet-yo'><code>++cet:yo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#char'><code>++char</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#chum'><code>++chum</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#cit'><code>++cit</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#clap'><code>++clap</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#cmp-si'><code>++cmp:si</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4k.md#co'><code>++co</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#coil'><code>++coil</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#coin'><code>++coin</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#col'><code>++col</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#cold'><code>++cold</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#com'><code>++com</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#comp'><code>++comp</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2d.md#con'><code>++con</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#cook'><code>++cook</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#cord'><code>++cord</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#cork'><code>++cork</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#corl'><code>++corl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#crip'><code>++crip</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#crub-so'><code>++crub:so</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2p.md#cue'><code>++cue</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#curr'><code>++curr</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#cury'><code>++cury</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#cuss'><code>++cuss</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#cut'><code>++cut</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#cab' data-tippy-content="Parse _ (cab)"><code>++cab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#can' data-tippy-content="Assemble"><code>++can</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1b.md#cap' data-tippy-content="Tree head"><code>++cap</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#cass' data-tippy-content="To lowercase"><code>++cass</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#cat' data-tippy-content="Concatenate"><code>++cat</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#cen' data-tippy-content="Parse % (cen)"><code>++cen</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#cet-yo' data-tippy-content="Days in a century"><code>++cet:yo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#char' data-tippy-content="Character"><code>++char</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#chum' data-tippy-content="Jet hint information"><code>++chum</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#cit' data-tippy-content="Octal digit"><code>++cit</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#clap' data-tippy-content="Apply function to two units"><code>++clap</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#cmp-si' data-tippy-content="Compare (signed integer)"><code>++cmp:si</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4k.md#co' data-tippy-content="Literal rendering engine"><code>++co</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#coil' data-tippy-content="Tuple of core information"><code>++coil</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#coin' data-tippy-content="Noun-literal syntax cases"><code>++coin</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#col' data-tippy-content="Parse : (col)"><code>++col</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#cold' data-tippy-content="Replace with constant"><code>++cold</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#com' data-tippy-content="Parse , (com)"><code>++com</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#comp' data-tippy-content="Arbitrary compose"><code>++comp</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2d.md#con' data-tippy-content="Binary OR"><code>++con</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#cook' data-tippy-content="Apply gate"><code>++cook</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#cord' data-tippy-content="UTF-8 text"><code>++cord</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#cork' data-tippy-content="Compose forward"><code>++cork</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#corl' data-tippy-content="Compose backward"><code>++corl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#crip' data-tippy-content="Tape to cord"><code>++crip</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#crub-so' data-tippy-content="Parse @da, @dr, @p, @t"><code>++crub:so</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2p.md#cue' data-tippy-content="Unpack atom to noun"><code>++cue</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#curr' data-tippy-content="Right-curry a gate"><code>++curr</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#cury' data-tippy-content="Curry left a gate"><code>++cury</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#cuss' data-tippy-content="To uppercase"><code>++cuss</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#cut' data-tippy-content="Slice"><code>++cut</code></a>
 
 ### d
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#d-ne'><code>++d:ne</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#date'><code>++date</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#day-yo'><code>++day:yo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#dec'><code>++dec</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#def-by'><code>+-def:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#d-ne' data-tippy-content="Render decimal"><code>++d:ne</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#date' data-tippy-content="Point in time"><code>++date</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#day-yo' data-tippy-content="Seconds in day"><code>++day:yo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#dec' data-tippy-content="Decrement"><code>++dec</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#def-by' data-tippy-content="Difference (map)"><code>+-def:by</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#del-by'><code>+-del:by</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#del-in'><code>+-del:in</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2j.md#del-ju'><code>+-del:ju</code></a>
@@ -812,7 +812,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### 1a: basic arithmetic
 
 <a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#add' data-tippy-content="Add"><code>++add</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#dec'><code>++dec</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#dec' data-tippy-content="Decrement"><code>++dec</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#div'><code>++div</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#dvr'><code>++dvr</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/1a.md#gte'><code>++gte</code></a>
@@ -827,13 +827,13 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 1b: tree addressing
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1b.md#cap'><code>++cap</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1b.md#cap' data-tippy-content="Tree head"><code>++cap</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/1b.md#mas'><code>++mas</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/1b.md#peg'><code>++peg</code></a>
 
 ### 1c: molds and mold builders
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#bloq'><code>++bloq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#bloq' data-tippy-content="Blocksize"><code>++bloq</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#each'><code>++each</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#gate'><code>++gate</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/1c.md#list'><code>++list</code></a>
@@ -848,11 +848,11 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 2a: unit logic
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#biff'><code>++biff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#bind'><code>++bind</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#bond'><code>++bond</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#both'><code>++both</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#clap'><code>++clap</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#biff' data-tippy-content="Unit as argument"><code>++biff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#bind' data-tippy-content="Non-unit function to unit, producing unit"><code>++bind</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#bond' data-tippy-content="Replace null"><code>++bond</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#both' data-tippy-content="Group unit values into pair"><code>++both</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#clap' data-tippy-content="Apply function to two units"><code>++clap</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#drop'><code>++drop</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#fall'><code>++fall</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2a.md#lift'><code>++lift</code></a>
@@ -904,10 +904,10 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#sit-fe'><code>++sit:fe</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#sum-fe'><code>++sum:fe</code></a>
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#bex'><code>++bex</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#can'><code>++can</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#cat'><code>++cat</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#cut'><code>++cut</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#bex' data-tippy-content="Binary exponent"><code>++bex</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#can' data-tippy-content="Assemble"><code>++can</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#cat' data-tippy-content="Concatenate"><code>++cat</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#cut' data-tippy-content="Slice"><code>++cut</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#end'><code>++end</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#fil'><code>++fil</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2c.md#lsh'><code>++lsh</code></a>
@@ -921,7 +921,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 2d: bit logic
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2d.md#con'><code>++con</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2d.md#con' data-tippy-content="Binary OR"><code>++con</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2d.md#dis'><code>++dis</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2d.md#mix'><code>++mix</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2d.md#not'><code>++not</code></a>
@@ -953,7 +953,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#all-in' data-tippy-content="Logical AND (set and wet gate)"><code>+-all:in</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#any-in' data-tippy-content="Logical OR (set and gate)"><code>+-any:in</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#apt-in' data-tippy-content="Check correctness (set)"><code>+-apt:in</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#bif-in'><code>+-bif:in</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#bif-in' data-tippy-content="Bifurcate set"><code>+-bif:in</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#del-in'><code>+-del:in</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#dif-in'><code>+-dif:in</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2h.md#dig-in'><code>+-dig:in</code></a>
@@ -973,8 +973,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#all-by' data-tippy-content="Logical AND (map and wet gate)"><code>+-all:by</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#any-by' data-tippy-content="Logical OR (map and wet gate)"><code>+-any:by</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#apt-by' data-tippy-content="Check correctness (map)"><code>+-apt:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#bif-by'><code>+-bif:by</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#def-by'><code>+-def:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#bif-by' data-tippy-content="Bifurcate map"><code>+-bif:by</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#def-by' data-tippy-content="Difference (map)"><code>+-def:by</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#del-by'><code>+-del:by</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#dep-by'><code>+-dep:by</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2i.md#dig-by'><code>+-dig:by</code></a>
@@ -1009,7 +1009,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### 2k: queue logic
 
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#to'><code>++to</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#bal-to'><code>+-bal:to</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#bal-to' data-tippy-content="Balance queue"><code>+-bal:to</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#dep-to'><code>+-dep:to</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#gas-to'><code>+-gas:to</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2k.md#get-to'><code>+-get:to</code></a>
@@ -1040,10 +1040,10 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 2n: functional hacks
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#cork'><code>++cork</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#corl'><code>++corl</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#curr'><code>++curr</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#cury'><code>++cury</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#cork' data-tippy-content="Compose forward"><code>++cork</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#corl' data-tippy-content="Compose backward"><code>++corl</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#curr' data-tippy-content="Right-curry a gate"><code>++curr</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#cury' data-tippy-content="Curry left a gate"><code>++cury</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#hard'><code>++hard</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#head'><code>++head</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2n.md#mean'><code>++mean</code></a>
@@ -1063,16 +1063,16 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 2p: serialization
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2p.md#cue'><code>++cue</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2p.md#cue' data-tippy-content="Unpack atom to noun"><code>++cue</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2p.md#jam'><code>++jam</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2p.md#mat'><code>++mat</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2p.md#rub'><code>++rub</code></a>
 
 ### 2q: molds and mold builders
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#char'><code>++char</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#cord'><code>++cord</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#date'><code>++date</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#char' data-tippy-content="Character"><code>++char</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#cord' data-tippy-content="UTF-8 text"><code>++cord</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#date' data-tippy-content="Point in time"><code>++date</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#knot'><code>++knot</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#tang'><code>++tang</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/2q.md#tank'><code>++tank</code></a>
@@ -1095,7 +1095,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#si'><code>++si</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#abs-si' data-tippy-content="Absolute value (signed integer)"><code>++abs:si</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#cmp-si'><code>++cmp:si</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#cmp-si' data-tippy-content="Compare (signed integer)"><code>++cmp:si</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#dif-si'><code>++dif:si</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#dul-si'><code>++dul:si</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3a.md#fra-si'><code>++fra:si</code></a>
@@ -1117,8 +1117,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#ff'><code>++ff</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#add-ff' data-tippy-content="Add (floating point)"><code>++add:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bif-ff'><code>++bif:ff</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-ff'><code>++bit:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bif-ff' data-tippy-content="Converts from fn to @r"><code>++bif:ff</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-ff' data-tippy-content="fn to @r with rounding"><code>++bit:ff</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#div-ff'><code>++div:ff</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#drg-ff'><code>++drg:ff</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#equ-ff'><code>++equ:ff</code></a>
@@ -1186,7 +1186,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rd'><code>++rd</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#add-rd' data-tippy-content="Add (double-precision float)"><code>++add:rd</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rd'><code>++bit:rd</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rd' data-tippy-content="fn to double-precision binary float"><code>++bit:rd</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#div-rd'><code>++div:rd</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#drg-rd'><code>++drg:rd</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#equ-rd'><code>++equ:rd</code></a>
@@ -1209,7 +1209,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rh'><code>++rh</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#add-rh' data-tippy-content="Add (half-precision float)"><code>++add:rh</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rh'><code>++bit:rh</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rh' data-tippy-content="fn to half-precision float"><code>++bit:rh</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#div-rh'><code>++div:rh</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#drg-rh'><code>++drg:rh</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#equ-rh'><code>++equ:rh</code></a>
@@ -1234,7 +1234,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rs'><code>++rs</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#add-rs' data-tippy-content="Add (single-precision float)"><code>++add:rs</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rs'><code>++bit:rs</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rs' data-tippy-content="fn to single-precision float"><code>++bit:rs</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#div-rs'><code>++div:rs</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#drg-rs'><code>++drg:rs</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#equ-rs'><code>++equ:rs</code></a>
@@ -1257,7 +1257,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#rq'><code>++rq</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#add-rq' data-tippy-content="Add (quad-precision float)"><code>++add:rq</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rq'><code>++bit:rq</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#bit-rq' data-tippy-content="fn to quad-precision float"><code>++bit:rq</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#div-rq'><code>++div:rq</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#drg-rq'><code>++drg:rq</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3b.md#equ-rq'><code>++equ:rq</code></a>
@@ -1290,8 +1290,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### 3c: urbit time
 
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#yo'><code>++yo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#cet-yo'><code>++cet:yo</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#day-yo'><code>++day:yo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#cet-yo' data-tippy-content="Days in a century"><code>++cet:yo</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#day-yo' data-tippy-content="Seconds in day"><code>++day:yo</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#era-yo'><code>++era:yo</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#hor-yo'><code>++hor:yo</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3c.md#jes-yo'><code>++jes:yo</code></a>
@@ -1355,7 +1355,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 3g: molds and mold builders
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#coin'><code>++coin</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#coin' data-tippy-content="Noun-literal syntax cases"><code>++coin</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#dime'><code>++dime</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#edge'><code>++edge</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/3g.md#hair'><code>++hair</code></a>
@@ -1393,9 +1393,9 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#ruv-at'><code>++ruv:at</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#rux-at'><code>++rux:at</code></a>
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#cass'><code>++cass</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#crip'><code>++crip</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#cuss'><code>++cuss</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#cass' data-tippy-content="To lowercase"><code>++cass</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#crip' data-tippy-content="Tape to cord"><code>++crip</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#cuss' data-tippy-content="To uppercase"><code>++cuss</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#mesc'><code>++mesc</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#runt'><code>++runt</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4b.md#sand'><code>++sand</code></a>
@@ -1433,8 +1433,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 4e: parsing (combinators)
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#bend'><code>++bend</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#comp'><code>++comp</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#bend' data-tippy-content="Conditional composer"><code>++bend</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#comp' data-tippy-content="Arbitrary compose"><code>++comp</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#fail'><code>++fail</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#glue'><code>++glue</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4e.md#less'><code>++less</code></a>
@@ -1446,10 +1446,10 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 4f: parsing (rule builders)
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#bass'><code>++bass</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#boss'><code>++boss</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#cold'><code>++cold</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#cook'><code>++cook</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#bass' data-tippy-content="Parser modifier (LSB-ordered ++list as atom of ++base)"><code>++bass</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#boss' data-tippy-content="Parser modifier: LSB"><code>++boss</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#cold' data-tippy-content="Replace with constant"><code>++cold</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#cook' data-tippy-content="Apply gate"><code>++cook</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#easy'><code>++easy</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#full'><code>++full</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4f.md#funk'><code>++funk</code></a>
@@ -1483,13 +1483,13 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### 4h: parsing (ascii glyphs)
 
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#ace' data-tippy-content="Parse space"><code>++ace</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#bar'><code>++bar</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#bas'><code>++bas</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#buc'><code>++buc</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#cab'><code>++cab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#cen'><code>++cen</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#col'><code>++col</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#com'><code>++com</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#bar' data-tippy-content="Parse | (bar)"><code>++bar</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#bas' data-tippy-content="Parse \ (bas)"><code>++bas</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#buc' data-tippy-content="Parse $ (buc)"><code>++buc</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#cab' data-tippy-content="Parse _ (cab)"><code>++cab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#cen' data-tippy-content="Parse % (cen)"><code>++cen</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#col' data-tippy-content="Parse : (col)"><code>++col</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#com' data-tippy-content="Parse , (comma)"><code>++com</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#doq'><code>++doq</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#dot'><code>++dot</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4h.md#fas'><code>++fas</code></a>
@@ -1521,10 +1521,10 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#alf' data-tippy-content="Parse alphabetic characters"><code>++alf</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#aln' data-tippy-content="Parse alphanumeric characters"><code>++aln</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#alp' data-tippy-content="Parse alphanumeric characters and -"><code>++alp</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#bet'><code>++bet</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#bin'><code>++bin</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#but'><code>++but</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#cit'><code>++cit</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#bet' data-tippy-content="Parse hep and lus axis syntax"><code>++bet</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#bin' data-tippy-content="Binary to atom"><code>++bin</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#but' data-tippy-content="Parse binary digit"><code>++but</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#cit' data-tippy-content="Octal digit"><code>++cit</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#dem'><code>++dem</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#dit'><code>++dit</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4i.md#dog'><code>++dog</code></a>
@@ -1558,7 +1558,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### 4j: parsing (bases and base digits)
 
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#ab' data-tippy-content="Primitive parser engine"><code>++ab</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#bix-ab'><code>++bix:ab</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#bix-ab' data-tippy-content="Parse hex pair"><code>++bix:ab</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#hif-ab'><code>++hif:ab</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#huf-ab'><code>++huf:ab</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#hyf-ab'><code>++hyf:ab</code></a>
@@ -1594,8 +1594,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#ag' data-tippy-content="Top-level atom parser engine"><code>++ag</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#ape-ag' data-tippy-content="Parse 0 or rule"><code>++ape:ag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#bay-ag'><code>++bay:ag</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#bip-ag'><code>++bip:ag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#bay-ag' data-tippy-content="Parses binary number"><code>++bay:ag</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#bip-ag' data-tippy-content="Parse IPv6"><code>++bip:ag</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#dem-ag'><code>++dem:ag</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#dim-ag'><code>++dim:ag</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#dum-ag'><code>++dum:ag</code></a>
@@ -1612,14 +1612,14 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#zug-mu'><code>++zug:mu</code></a>
 
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#ne'><code>++ne</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#d-ne'><code>++d:ne</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#d-ne' data-tippy-content="Render decimal"><code>++d:ne</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#v-ne'><code>++v:ne</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#w-ne'><code>++w:ne</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4j.md#x-ne'><code>++x:ne</code></a>
 
 ### 4k: parsing (atom printing)
 
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4k.md#co'><code>++co</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4k.md#co' data-tippy-content="Literal rendering engine"><code>++co</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4k.md#rear-co'><code>++rear:co</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4k.md#rend-co'><code>++rend:co</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4k.md#rent-co'><code>++rent:co</code></a>
@@ -1627,8 +1627,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### 4l: parsing (atom parsing)
 
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#so'><code>++so</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#bisk-so'><code>++bisk:so</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#crub-so'><code>++crub:so</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#bisk-so' data-tippy-content="Parse odor-atom pair"><code>++bisk:so</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#crub-so' data-tippy-content="Parse @da, @dr, @p, @t"><code>++crub:so</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#nuck-so'><code>++nuck:so</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#nusk-so'><code>++nusk:so</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4l.md#perd-so'><code>++perd:so</code></a>
@@ -1666,12 +1666,12 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#abel' data-tippy-content="Compiler alias"><code>++abel</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#aura' data-tippy-content="'Type' of atom"><code>++aura</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#axis' data-tippy-content="Nock axis"><code>++axis</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#base'><code>++base</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#bean'><code>++bean</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#beer'><code>++beer</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#beet'><code>++beet</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#chum'><code>++chum</code></a>
-<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#coil'><code>++coil</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#base' data-tippy-content="Base type"><code>++base</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#bean' data-tippy-content="Boolean"><code>++bean</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#beer' data-tippy-content="Tape builder"><code>++beer</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#beet' data-tippy-content="XML interpolation cases"><code>++beet</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#chum' data-tippy-content="Jet hint information"><code>++chum</code></a>
+<a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#coil' data-tippy-content="Tuple of core information"><code>++coil</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#foot'><code>++foot</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#limb'><code>++limb</code></a>
 <a class="stdlib" href='https://urbit.org/docs/reference/library/4o.md#line'><code>++line</code></a>

--- a/reference/library/_index.md
+++ b/reference/library/_index.md
@@ -332,209 +332,209 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#line' data-tippy-content="(Undocumented)"><code>++line</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#lip-ag' data-tippy-content="Parse IPv4 address"><code>++lip:ag</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#list' data-tippy-content="Mold constructor (list)"><code>++list</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#lone'><code>++lone</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#lor'><code>++lor</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#low'><code>++low</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#lsh'><code>++lsh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#lte'><code>++lte</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-ff'><code>++lte:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-fl'><code>++lte:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rd'><code>++lte:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rh'><code>++lte:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rs'><code>++lte:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rq'><code>++lte:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#lth'><code>++lth</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-ff'><code>++lth:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-fl'><code>++lth:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rd'><code>++lth:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rh'><code>++lth:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rs'><code>++lth:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rq'><code>++lth:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lug-fl'><code>++lug:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#lus'><code>++lus</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4d/#lust'><code>++lust</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#less'><code>++less</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#ly'><code>++ly</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#lone' data-tippy-content="Mold generator (face on mold)"><code>++lone</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#lor' data-tippy-content="Leg order"><code>++lor</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#low' data-tippy-content="Parse lowercase letter"><code>++low</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#lsh' data-tippy-content="Left-shift"><code>++lsh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#lte' data-tippy-content="Less than / equal (atom)"><code>++lte</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-ff' data-tippy-content="Less than / equal (IEEE float)"><code>++lte:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-fl' data-tippy-content="Less than / equal (producing flag)"><code>++lte:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rd' data-tippy-content="Less than / equal (double-precision float)"><code>++lte:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rh' data-tippy-content="Less than / equal (half-precision float)"><code>++lte:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rs' data-tippy-content="Less than / equal (single-precision float)"><code>++lte:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rq' data-tippy-content="Less than / equal (quad-precision float)"><code>++lte:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#lth' data-tippy-content="Less than (atom)"><code>++lth</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-ff' data-tippy-content="Less than (IEEE float)"><code>++lth:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-fl' data-tippy-content="Less than (signed and unsigned integer cell)"><code>++lth:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rd' data-tippy-content="Less than (double-precision float)"><code>++lth:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rh' data-tippy-content="Less than (half-precision float)"><code>++lth:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rs' data-tippy-content="Less than (single-precision float)"><code>++lth:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rq' data-tippy-content="Less than (quad-precision float)"><code>++lth:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lug-fl' data-tippy-content="Central rounding mechanism"><code>++lug:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#lus' data-tippy-content="Parse + (lus)"><code>++lus</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4d/#lust' data-tippy-content="Detect new line"><code>++lust</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#less' data-tippy-content="Parse unless"><code>++less</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#ly' data-tippy-content="List from raw noun"><code>++ly</code></a>
 
 ### m
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rd'><code>++ma:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rh'><code>++ma:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rs'><code>++ma:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rq'><code>++ma:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mack'><code>++mack</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2l/#malt'><code>++malt</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#map'><code>++map</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#mar-by'><code>+-mar:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#mas'><code>++mas</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#mask'><code>++mask</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#mat'><code>++mat</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#mate'><code>++mate</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#max'><code>++max</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#me-ff'><code>++me:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#mean'><code>++mean</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#mes'><code>++mes</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#mesc'><code>++mesc</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#met'><code>++met</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#metl'><code>++metl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#min'><code>++min</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mink'><code>++mink</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#mit-yo'><code>++mit:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#mix'><code>++mix</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mock'><code>++mock</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#mod'><code>++mod</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#moh-yo'><code>++moh:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2l/#molt'><code>++molt</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mong'><code>++mong</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mook'><code>++mook</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#more'><code>++more</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#most'><code>++most</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#moy-yo'><code>++moy:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#mu'><code>++mu</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#mug'><code>++mug</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#muk'><code>++muk</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#mul'><code>++mul</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-ff'><code>++mul:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-fl'><code>++mul:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rd'><code>++mul:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rh'><code>++mul:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rs'><code>++mul:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rq'><code>++mul:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mule'><code>++mule</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mute'><code>++mute</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#mum'><code>++mum</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#murn'><code>++murn</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#my'><code>++my</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#my-nl'><code>++my:nl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rd' data-tippy-content="Initialize ff (rd core)"><code>++ma:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rh' data-tippy-content="Initialize ff (rh core)"><code>++ma:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rs' data-tippy-content="Initialize ff (rs core)"><code>++ma:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rq' data-tippy-content="Initialize ff (rq core)"><code>++ma:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mack' data-tippy-content="Nock subject to unit"><code>++mack</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2l/#malt' data-tippy-content="Map from list"><code>++malt</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#map' data-tippy-content="Mold generator (map)"><code>++map</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#mar-by' data-tippy-content="Assert and add (map)"><code>+-mar:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#mas' data-tippy-content="Address within head/tail"><code>++mas</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#mask' data-tippy-content="Match character"><code>++mask</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#mat' data-tippy-content="Length-encode"><code>++mat</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#mate' data-tippy-content="Choose"><code>++mate</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#max' data-tippy-content="Maximum"><code>++max</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#me-ff' data-tippy-content="Minimum exponent of ff"><code>++me:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#mean' data-tippy-content="Crash and printf"><code>++mean</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#mes' data-tippy-content="Parse hexabyte"><code>++mes</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#mesc' data-tippy-content="Escape special characters"><code>++mesc</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#met' data-tippy-content="Measure"><code>++met</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#metl' data-tippy-content="(Undocumented)"><code>++metl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#min' data-tippy-content="Minimum (atom)"><code>++min</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mink' data-tippy-content="Mock (virtual Nock) interpreter"><code>++mink</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#mit-yo' data-tippy-content="Seconds in minute"><code>++mit:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#mix' data-tippy-content="Binary XOR (atom)"><code>++mix</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mock' data-tippy-content="Compute formula on subject with hint"><code>++mock</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#mod' data-tippy-content="Modulus (atom)"><code>++mod</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#moh-yo' data-tippy-content="Days in month"><code>++moh:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2l/#molt' data-tippy-content="Map from pair list"><code>++molt</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mong' data-tippy-content="Slam gate with sample"><code>++mong</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mook' data-tippy-content="Intelligently render crash annotation"><code>++mook</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#more' data-tippy-content="Parse list with delimiter"><code>++more</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#most' data-tippy-content="Parse list of at least one match"><code>++most</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#moy-yo' data-tippy-content="Days in months of leap-year"><code>++moy:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#mu' data-tippy-content="Core used to scramble 16-bit atoms"><code>++mu</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#mug' data-tippy-content="FNV-1a scrambler"><code>++mug</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#muk' data-tippy-content="Standard MurmurHash3"><code>++muk</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#mul' data-tippy-content="Multiply (atom)"><code>++mul</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-ff' data-tippy-content="Multiply (IEEE float)"><code>++mul:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-fl' data-tippy-content="Multiply (signed and unsigned integer cell)"><code>++mul:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rd' data-tippy-content="Multiply (double-precision float)"><code>++mul:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rh' data-tippy-content="Multiply (quad-precision float)"><code>++mul:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rs' data-tippy-content="Multiply (single-precision float)"><code>++mul:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rq' data-tippy-content="Multiply (quad-precision float)"><code>++mul:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mule' data-tippy-content="Typed virtual"><code>++mule</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mute' data-tippy-content="Untyped virtual"><code>++mute</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#mum' data-tippy-content="31-bit MurmurHash3 scrambler"><code>++mum</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#murn' data-tippy-content="Maybe transform"><code>++murn</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#my' data-tippy-content="Map from raw noun"><code>++my</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#my-nl' data-tippy-content="Construct map from null-terminated noun"><code>++my:nl</code></a>
 
 ### n
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#nail'><code>++nail</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#nap-to'><code>+-nap:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ne'><code>++ne</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ned-fl'><code>++ned:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#need'><code>++need</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#net-fe'><code>++net:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#new-si'><code>++new:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#next'><code>++next</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#nip-to'><code>+-nip:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#nix'><code>++nix</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#nl'><code>++nl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#nock'><code>++nock</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#not'><code>++not</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#noun'><code>++noun</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#nuck-so'><code>++nuck:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#nud'><code>++nud</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#null'><code>++null</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#nusk-so'><code>++nusk:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#nail' data-tippy-content="Location, remainder of parsed text"><code>++nail</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#nap-to' data-tippy-content="Remove head of queue"><code>+-nap:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ne' data-tippy-content="Digit rendering engine"><code>++ne</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ned-fl' data-tippy-content="Require float"><code>++ned:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#need' data-tippy-content="Unwrap unit"><code>++need</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#net-fe' data-tippy-content="Flip endianness"><code>++net:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#new-si' data-tippy-content="Atom to @s"><code>++new:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#next' data-tippy-content="Consume character"><code>++next</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#nip-to' data-tippy-content="Remove root of queue"><code>+-nip:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#nix' data-tippy-content="Parse letters and -"><code>++nix</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#nl' data-tippy-content="Noun to container operations"><code>++nl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#nock' data-tippy-content="Virtual machine (see Nock)"><code>++nock</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#not' data-tippy-content="Binary NOT (atom)"><code>++not</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#noun' data-tippy-content="(Undocumented)"><code>++noun</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#nuck-so' data-tippy-content="Top-level coin parser"><code>++nuck:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#nud' data-tippy-content="Parse numeric character"><code>++nud</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#null' data-tippy-content="(Undocumented)"><code>++null</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#nusk-so' data-tippy-content="Parse coin literal with escapes"><code>++nusk:so</code></a>
 
 ### o
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#ob'><code>++ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#og'><code>++og</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#old-si'><code>++old:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#oust'><code>++oust</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#out-fe'><code>++out:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#ob' data-tippy-content="Reversible scrambling v2"><code>++ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#og' data-tippy-content="Container arm for SHA-256 powered RNG"><code>++og</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#old-si' data-tippy-content="Sign and absolute value"><code>++old:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#oust' data-tippy-content="Remove from list"><code>++oust</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#out-fe' data-tippy-content="Maximum integer value"><code>++out:fe</code></a>
 
 ### p
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#pa-ff'><code>++pa:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#pair'><code>++pair</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pam'><code>++pam</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pat'><code>++pat</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#path'><code>++path</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#peg'><code>++peg</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pel'><code>++pel</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#per'><code>++per</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#perd-so'><code>++perd:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#pev-ab'><code>++pev:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#pew-ab'><code>++pew:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#pfix'><code>++pfix</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#pint'><code>++pint</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#piv-ab'><code>++piv:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#piw-ab'><code>++piw:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#plug'><code>++plug</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#plus'><code>++plus</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#po'><code>++po</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#pole'><code>++pole</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#port'><code>++port</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#pose'><code>++pose</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2g/#pow'><code>++pow</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#prc-fl'><code>++prc:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#prn'><code>++prn</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#pro-fo'><code>++pro:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#pro-si'><code>++pro:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#put-by'><code>+-put:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#put-in'><code>+-put:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#put-ju'><code>+-put:ju</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#put-to'><code>+-put:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#pa-ff' data-tippy-content="Initialize fl from ff core"><code>++pa:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#pair' data-tippy-content="Mold of pair of types"><code>++pair</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pam' data-tippy-content="Parse & (pam)"><code>++pam</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pat' data-tippy-content="Parse @ (pat)"><code>++pat</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#path' data-tippy-content="Filesystem path"><code>++path</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#peg' data-tippy-content="Address within address"><code>++peg</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pel' data-tippy-content="Parse ( (pel)"><code>++pel</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#per' data-tippy-content="Parse ) (per)"><code>++per</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#perd-so' data-tippy-content="Parses dime/tiple without standard prefixes"><code>++perd:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#pev-ab' data-tippy-content="Parse <=5 in base 32"><code>++pev:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#pew-ab' data-tippy-content="Parse <= 5 in base 64"><code>++pew:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#pfix' data-tippy-content="Discard first rule"><code>++pfix</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#pint' data-tippy-content="Parsing range"><code>++pint</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#piv-ab' data-tippy-content="Parse 5 digits in base 32"><code>++piv:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#piw-ab' data-tippy-content="Parse 5 digits in base 64"><code>++piw:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#plug' data-tippy-content="Parse to tuple"><code>++plug</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#plus' data-tippy-content="List of at least one match"><code>++plus</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#po' data-tippy-content="Phonetic base"><code>++po</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#pole' data-tippy-content="Mold generator of faceless list"><code>++pole</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#port' data-tippy-content="(Undocumented)"><code>++port</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#pose' data-tippy-content="Parse options"><code>++pose</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2g/#pow' data-tippy-content="Computes a to the power of b"><code>++pow</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#prc-fl' data-tippy-content="Force precision of 2 or greater (floating point)"><code>++prc:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#prn' data-tippy-content="Parse any printable character"><code>++prn</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#pro-fo' data-tippy-content="Multiplies b and c modulo a"><code>++pro:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#pro-si' data-tippy-content="Multiply to signed integer"><code>++pro:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#put-by' data-tippy-content="Add key-value pair (map)"><code>+-put:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#put-in' data-tippy-content="Put b in a (set)"><code>+-put:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#put-ju' data-tippy-content="Add key-set pair (jar)"><code>+-put:ju</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#put-to' data-tippy-content="Insert into queue"><code>+-put:to</code></a>
 
 ### q
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#qad-yo'><code>++qad:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qeb-ab'><code>++qeb:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#qeu'><code>++qeu</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qex-ab'><code>++qex:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qib-ab'><code>++qib:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#qit'><code>++qit</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qix-ab'><code>++qix:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#quip'><code>++quip</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#qut'><code>++qut</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#qad-yo' data-tippy-content="Seconds in 4 years"><code>++qad:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qeb-ab' data-tippy-content="Parse <=4 binary digits"><code>++qeb:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#qeu' data-tippy-content="Mold generator (queue)"><code>++qeu</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qex-ab' data-tippy-content="Parse <=4 hexadecimal digits"><code>++qex:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qib-ab' data-tippy-content="Parse 4 binary digits"><code>++qib:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#qit' data-tippy-content="Parse character to cord atom"><code>++qit</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qix-ab' data-tippy-content="Parse 4 hexadecimal digits"><code>++qix:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#quip' data-tippy-content="Mold generator (tuple of list and type)"><code>++quip</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#qut' data-tippy-content="Parse cord"><code>++qut</code></a>
 
 ### r
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#r-at'><code>++r:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#rad-og'><code>++rad:og</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#rads-og'><code>++rads:og</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#raku-ob'><code>++raku:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#ram-re'><code>++ram:re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rap'><code>++rap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rash'><code>++rash</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rau-fl'><code>++rau:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#raw-og'><code>++raw:og</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#raws-og'><code>++raws:og</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#re'><code>++re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rear-co'><code>++rear:co</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#reap'><code>++reap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#reel'><code>++reel</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#rem-si'><code>++rem:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rend-co'><code>++rend:co</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rent-co'><code>++rent:co</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rep'><code>++rep</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rep-by'><code>+-rep:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#rep-in'><code>+-rep:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rf-at'><code>++rf:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rib-by'><code>+-rib:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#rig-re'><code>++rig:re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rip'><code>++rip</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rn-at'><code>++rn:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rol-fe'><code>++rol:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#roll'><code>++roll</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#r-at' data-tippy-content="(Undocumented)"><code>++r:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#rad-og' data-tippy-content="Random in range"><code>++rad:og</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#rads-og' data-tippy-content="Random continuation"><code>++rads:og</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#raku-ob' data-tippy-content="Key list"><code>++raku:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#ram-re' data-tippy-content="Flatten tank to tape"><code>++ram:re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rap' data-tippy-content="Assemble non-zero"><code>++rap</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rash' data-tippy-content="Parse or crash"><code>++rash</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rau-fl' data-tippy-content="Various roundings (floating point)"><code>++rau:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#raw-og' data-tippy-content="Random bits"><code>++raw:og</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#raws-og' data-tippy-content="Random bits continuation"><code>++raws:og</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#re' data-tippy-content="Pretty-printing engine (tank)"><code>++re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rear-co' data-tippy-content="Prepend and render atom as tape"><code>++rear:co</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#reap' data-tippy-content="Replicate (list)"><code>++reap</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#reel' data-tippy-content="Right fold (list)"><code>++reel</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#rem-si' data-tippy-content="Remainder (signed integer)"><code>++rem:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rend-co' data-tippy-content="Render coin lot as tape"><code>++rend:co</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rent-co' data-tippy-content="Render coin lot as span"><code>++rent:co</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rep' data-tippy-content="Assemble single"><code>++rep</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rep-by' data-tippy-content="Replace by product (map)"><code>+-rep:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#rep-in' data-tippy-content="Accumulate elements (set)"><code>+-rep:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rf-at' data-tippy-content="(Undocumented)"><code>++rf:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rib-by' data-tippy-content="Replace values with accumulator (map)"><code>+-rib:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#rig-re' data-tippy-content="Wrap tape in / (tank)"><code>++rig:re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rip' data-tippy-content="Disassemble"><code>++rip</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rn-at' data-tippy-content="(Undocumented)"><code>++rn:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rol-fe' data-tippy-content="Roll left"><code>++rol:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#roll' data-tippy-content="Left fold (list)"><code>++roll</code></a>
 <code>++rood</code>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#ror-fe'><code>++ror:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rou-fl'><code>++rou:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#royl-so'><code>++royl:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#royl-cell-so'><code>++royl-cell:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rsh'><code>++rsh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rt-at'><code>++rt:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rta-at'><code>++rta:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rtam-at'><code>++rtam:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#rub'><code>++rub</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rub-at'><code>++rub:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rud-at'><code>++rud:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#rule'><code>++rule</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rum-at'><code>++rum:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#run-by'><code>+-run:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#run-in'><code>+-run:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#rund-ob'><code>++rund:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#runt'><code>++runt</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rup-at'><code>++rup:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rush'><code>++rush</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rust'><code>++rust</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rut-by'><code>+-rut:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#ruv-at'><code>++ruv:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rux-at'><code>++rux:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#rynd-ob'><code>++rynd:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#ror-fe' data-tippy-content="Roll right"><code>++ror:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rou-fl' data-tippy-content="Round to nearest float with 113-bit significand"><code>++rou:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#royl-so' data-tippy-content="Parse dime float"><code>++royl:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#royl-cell-so' data-tippy-content="(Undocumented)"><code>++royl-cell:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rsh' data-tippy-content="Right-shift"><code>++rsh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rt-at' data-tippy-content="(Undocumented)"><code>++rt:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rta-at' data-tippy-content="(Undocumented)"><code>++rta:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rtam-at' data-tippy-content="(Undocumented)"><code>++rtam:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#rub' data-tippy-content="Length-decode"><code>++rub</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rub-at' data-tippy-content="(Undocumented)"><code>++rub:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rud-at' data-tippy-content="(Undocumented)"><code>++rud:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#rule' data-tippy-content="Parsing rule (match this with _)"><code>++rule</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rum-at' data-tippy-content="(Undocumented)"><code>++rum:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#run-by' data-tippy-content="Transform values (map)"><code>+-run:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#run-in' data-tippy-content="Apply gate to set"><code>+-run:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#rund-ob' data-tippy-content="Reverse single Feistel-like"><code>++rund:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#runt' data-tippy-content="Prepend n times"><code>++runt</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rup-at' data-tippy-content="(Undocumented)"><code>++rup:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rush' data-tippy-content="Parse or null"><code>++rush</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rust' data-tippy-content="Parse tape or null"><code>++rust</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rut-by' data-tippy-content="Transform nodes (map)"><code>+-rut:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#ruv-at' data-tippy-content="(Undocumented)"><code>++ruv:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rux-at' data-tippy-content="(Undocumented)"><code>++rux:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#rynd-ob' data-tippy-content="Reverse Feistel-like cipher"><code>++rynd:ob</code></a>
 
 ### s
 
@@ -817,19 +817,19 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#dvr' data-tippy-content="Divide (with remainder)"><code>++dvr</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#gte' data-tippy-content="Greater than / equal"><code>++gte</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#gth' data-tippy-content="Greater than"><code>++gth</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#lte'><code>++lte</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#lth'><code>++lth</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#max'><code>++max</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#min'><code>++min</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#mod'><code>++mod</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#mul'><code>++mul</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#lte' data-tippy-content="Less than / equal (atom)"><code>++lte</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#lth' data-tippy-content="Less than (atom)"><code>++lth</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#max' data-tippy-content="Maximum"><code>++max</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#min' data-tippy-content="Minimum (atom)"><code>++min</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#mod' data-tippy-content="Modulus (atom)"><code>++mod</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#mul' data-tippy-content="Multiply (atom)"><code>++mul</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1a/#sub'><code>++sub</code></a>
 
 ### 1b: tree addressing
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#cap' data-tippy-content="Tree head"><code>++cap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#mas'><code>++mas</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#peg'><code>++peg</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#mas' data-tippy-content="Address within head/tail"><code>++mas</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1b/#peg' data-tippy-content="Address within address"><code>++peg</code></a>
 
 ### 1c: molds and mold builders
 
@@ -837,10 +837,10 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#each' data-tippy-content="Mold of fork between two types"><code>++each</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#gate' data-tippy-content="Function"><code>++gate</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#list' data-tippy-content="Mold constructor (list)"><code>++list</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#lone'><code>++lone</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#pair'><code>++pair</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#pole'><code>++pole</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#quip'><code>++quip</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#lone' data-tippy-content="Mold generator (face on mold)"><code>++lone</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#pair' data-tippy-content="Mold of pair of types"><code>++pair</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#pole' data-tippy-content="Mold generator of faceless list"><code>++pole</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#quip' data-tippy-content="Mold generator (tuple of list and type)"><code>++quip</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#trap'><code>++trap</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#tree'><code>++tree</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/1c/#trel'><code>++trel</code></a>
@@ -856,8 +856,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#drop' data-tippy-content="Unit to list"><code>++drop</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#fall' data-tippy-content="Give unit a default value"><code>++fall</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#lift' data-tippy-content="Curried bind"><code>++lift</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#mate'><code>++mate</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#need'><code>++need</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#mate' data-tippy-content="Choose"><code>++mate</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#need' data-tippy-content="Unwrap unit"><code>++need</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2a/#some'><code>++some</code></a>
 
 ### 2b: list logic
@@ -871,11 +871,11 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#levy' data-tippy-content="Logical AND on list"><code>++levy</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#lien' data-tippy-content="Logical OR on list"><code>++lien</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#limo' data-tippy-content="Construct list from null-terminated tuple"><code>++limo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#murn'><code>++murn</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#oust'><code>++oust</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#reap'><code>++reap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#reel'><code>++reel</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#roll'><code>++roll</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#murn' data-tippy-content="Maybe transform"><code>++murn</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#oust' data-tippy-content="Remove from list"><code>++oust</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#reap' data-tippy-content="Replicate (list)"><code>++reap</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#reel' data-tippy-content="Right fold (list)"><code>++reel</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#roll' data-tippy-content="Left fold (list)"><code>++roll</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#scag'><code>++scag</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#skid'><code>++skid</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2b/#skim'><code>++skim</code></a>
@@ -897,10 +897,10 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#fe' data-tippy-content="Modulo bloq"><code>++fe</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#dif-fe' data-tippy-content="Difference between atoms (modular basis)"><code>++dif:fe</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#inv-fe' data-tippy-content="Inverse order of modular field"><code>++inv:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#net-fe'><code>++net:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#out-fe'><code>++out:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rol-fe'><code>++rol:fe</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#ror-fe'><code>++ror:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#net-fe' data-tippy-content="Flip endianness"><code>++net:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#out-fe' data-tippy-content="Maximum integer value"><code>++out:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rol-fe' data-tippy-content="Roll left"><code>++rol:fe</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#ror-fe' data-tippy-content="Roll right"><code>++ror:fe</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#sit-fe'><code>++sit:fe</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#sum-fe'><code>++sum:fe</code></a>
 
@@ -910,12 +910,12 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#cut' data-tippy-content="Slice"><code>++cut</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#end' data-tippy-content="Tail"><code>++end</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#fil' data-tippy-content="Fill bloqstream"><code>++fil</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#lsh'><code>++lsh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#met'><code>++met</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rap'><code>++rap</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rep'><code>++rep</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rip'><code>++rip</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rsh'><code>++rsh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#lsh' data-tippy-content="Left-shift"><code>++lsh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#met' data-tippy-content="Measure"><code>++met</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rap' data-tippy-content="Assemble non-zero"><code>++rap</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rep' data-tippy-content="Assemble single"><code>++rep</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rip' data-tippy-content="Disassemble"><code>++rip</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#rsh' data-tippy-content="Right-shift"><code>++rsh</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#swp'><code>++swp</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2c/#xeb'><code>++xeb</code></a>
 
@@ -923,15 +923,15 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#con' data-tippy-content="Binary OR"><code>++con</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#dis' data-tippy-content="Binary AND (atoms)"><code>++dis</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#mix'><code>++mix</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#not'><code>++not</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#mix' data-tippy-content="Binary XOR (atom)"><code>++mix</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2d/#not' data-tippy-content="Binary NOT (atom)"><code>++not</code></a>
 
 ### 2e: insecure hashing
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#fnv' data-tippy-content="FNV scrambler"><code>++fnv</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#mug'><code>++mug</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#muk'><code>++muk</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#mum'><code>++mum</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#mug' data-tippy-content="FNV-1a scrambler"><code>++mug</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#muk' data-tippy-content="Standard MurmurHash3"><code>++muk</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2e/#mum' data-tippy-content="31-bit MurmurHash3 scrambler"><code>++mum</code></a>
 
 ### 2f: noun ordering
 
@@ -939,12 +939,12 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#dor' data-tippy-content="Numeric order"><code>++dor</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#gor' data-tippy-content="Hash order"><code>++gor</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#hor' data-tippy-content="Horizontal hash order"><code>++hor</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#lor'><code>++lor</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#lor' data-tippy-content="Leg order"><code>++lor</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2f/#vor'><code>++vor</code></a>
 
 ### 2g: unsigned powers
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2g/#pow'><code>++pow</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2g/#pow' data-tippy-content="Computes a to the power of b"><code>++pow</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2g/#sqt'><code>++sqt</code></a>
 
 ### 2h: set logic
@@ -960,9 +960,9 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#gas-in' data-tippy-content="Concatenate (set)"><code>+-gas:in</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#has-in' data-tippy-content="Key existence check (set)"><code>+-has:in</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#int-in' data-tippy-content="Intersection (set)"><code>+-int:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#put-in'><code>+-put:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#rep-in'><code>+-rep:in</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#run-in'><code>+-run:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#put-in' data-tippy-content="Put b in a (set)"><code>+-put:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#rep-in' data-tippy-content="Accumulate elements (set)"><code>+-rep:in</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#run-in' data-tippy-content="Apply gate to set"><code>+-run:in</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#tap-in'><code>+-tap:in</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#uni-in'><code>+-uni:in</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2h/#wyt-in'><code>+-wyt:in</code></a>
@@ -983,12 +983,12 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#got-by' data-tippy-content="Assert for value (map)"><code>+-got:by</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#has-by' data-tippy-content="Key existence check (map)"><code>+-has:by</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#int-by' data-tippy-content="Intersection (map)"><code>+-int:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#mar-by'><code>+-mar:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#put-by'><code>+-put:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rep-by'><code>+-rep:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rib-by'><code>+-rib:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#run-by'><code>+-run:by</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rut-by'><code>+-rut:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#mar-by' data-tippy-content="Assert and add (map)"><code>+-mar:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#put-by' data-tippy-content="Add key-value pair (map)"><code>+-put:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rep-by' data-tippy-content="Replace by product (map)"><code>+-rep:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rib-by' data-tippy-content="Replace values with accumulator (map)"><code>+-rib:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#run-by' data-tippy-content="Transform values (map)"><code>+-run:by</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#rut-by' data-tippy-content="Transform nodes (map)"><code>+-rut:by</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#tap-by'><code>+-tap:by</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#uni-by'><code>+-uni:by</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2i/#urn-by'><code>+-urn:by</code></a>
@@ -1004,7 +1004,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#del-ju' data-tippy-content="Delete (jug)"><code>+-del:ju</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#get-ju' data-tippy-content="Retrieve set"><code>+-get:ju</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#has-ju' data-tippy-content="Check contents (jug)"><code>+-has:ju</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#put-ju'><code>+-put:ju</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2j/#put-ju' data-tippy-content="Add key-set pair (jar)"><code>+-put:ju</code></a>
 
 ### 2k: queue logic
 
@@ -1013,29 +1013,29 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#dep-to' data-tippy-content="Maximum depth (queue)"><code>+-dep:to</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#gas-to' data-tippy-content="Push list into queue"><code>+-gas:to</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#get-to' data-tippy-content="Head-tail pair"><code>+-get:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#nap-to'><code>+-nap:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#nip-to'><code>+-nip:to</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#put-to'><code>+-put:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#nap-to' data-tippy-content="Remove head of queue"><code>+-nap:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#nip-to' data-tippy-content="Remove root of queue"><code>+-nip:to</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#put-to' data-tippy-content="Insert into queue"><code>+-put:to</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#tap-to'><code>+-tap:to</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2k/#top-to'><code>+-top:to</code></a>
 
 ### 2l: container from container
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2l/#malt'><code>++malt</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2l/#molt'><code>++molt</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2l/#malt' data-tippy-content="Map from list"><code>++malt</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2l/#molt' data-tippy-content="Map from pair list"><code>++molt</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2l/#silt'><code>++silt</code></a>
 
 ### 2m: container from noun
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#nl'><code>++nl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#nl' data-tippy-content="Noun to container operations"><code>++nl</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#le-nl' data-tippy-content="Construct list from null-terminated noun"><code>++le:nl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#my-nl'><code>++my:nl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#my-nl' data-tippy-content="Construct map from null-terminated noun"><code>++my:nl</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#si-nl'><code>++si:nl</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#snag-nl'><code>++snag:nl</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#weld-nl'><code>++weld:nl</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#ly'><code>++ly</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#my'><code>++my</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#ly' data-tippy-content="List from raw noun"><code>++ly</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#my' data-tippy-content="Map from raw noun"><code>++my</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2m/#sy'><code>++sy</code></a>
 
 ### 2n: functional hacks
@@ -1046,7 +1046,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#cury' data-tippy-content="Curry left a gate"><code>++cury</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#hard' data-tippy-content="Force remold"><code>++hard</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#head' data-tippy-content="Get head of cell"><code>++head</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#mean'><code>++mean</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#mean' data-tippy-content="Crash and printf"><code>++mean</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#same'><code>++same</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#slog'><code>++slog</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2n/#soft'><code>++soft</code></a>
@@ -1057,16 +1057,16 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#jar' data-tippy-content="Mold generator (jar)"><code>++jar</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#jug' data-tippy-content="Mold generator (jug)"><code>++jug</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#map'><code>++map</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#qeu'><code>++qeu</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#map' data-tippy-content="Mold generator (map)"><code>++map</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#qeu' data-tippy-content="Mold generator (queue)"><code>++qeu</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2o/#set'><code>++set</code></a>
 
 ### 2p: serialization
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#cue' data-tippy-content="Unpack atom to noun"><code>++cue</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#jam' data-tippy-content="Pack noun to atom"><code>++jam</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#mat'><code>++mat</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#rub'><code>++rub</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#mat' data-tippy-content="Length-encode"><code>++mat</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/2p/#rub' data-tippy-content="Length-decode"><code>++rub</code></a>
 
 ### 2q: molds and mold builders
 
@@ -1089,7 +1089,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#exp-fo' data-tippy-content="Exponent (modular base)"><code>++exp:fo</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fra-fo' data-tippy-content="Divide (modular base)"><code>++fra:fo</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#inv-fo' data-tippy-content="Inverse (signed modulus)"><code>++inv:fo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#pro-fo'><code>++pro:fo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#pro-fo' data-tippy-content="Multiplies b and c modulo a"><code>++pro:fo</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#sit-fo'><code>++sit:fo</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#sum-fo'><code>++sum:fo</code></a>
 
@@ -1099,10 +1099,10 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dif-si' data-tippy-content="Subtraction (signed integer)"><code>++dif:si</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#dul-si' data-tippy-content="Modulus (signed integer)"><code>++dul:si</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#fra-si' data-tippy-content="Divide (signed integer)"><code>++fra:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#new-si'><code>++new:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#old-si'><code>++old:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#pro-si'><code>++pro:si</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#rem-si'><code>++rem:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#new-si' data-tippy-content="Atom to @s"><code>++new:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#old-si' data-tippy-content="Sign and absolute value"><code>++old:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#pro-si' data-tippy-content="Multiply to signed integer"><code>++pro:si</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#rem-si' data-tippy-content="Remainder (signed integer)"><code>++rem:si</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#sum-si'><code>++sum:si</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#sun-si'><code>++sun:si</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3a/#syn-si'><code>++syn:si</code></a>
@@ -1127,11 +1127,11 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-ff' data-tippy-content="Decimal float to @r"><code>++grd:ff</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-ff' data-tippy-content="Greater than / equal (IEEE float)"><code>++gte:ff</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-ff' data-tippy-content="Greater than (IEEE float)"><code>++gth:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-ff'><code>++lte:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-ff'><code>++lth:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#me-ff'><code>++me:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-ff'><code>++mul:ff</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#pa-ff'><code>++pa:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-ff' data-tippy-content="Less than / equal (IEEE float)"><code>++lte:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-ff' data-tippy-content="Less than (IEEE float)"><code>++lth:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#me-ff' data-tippy-content="Minimum exponent of ff"><code>++me:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-ff' data-tippy-content="Multiply (IEEE float)"><code>++mul:ff</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#pa-ff' data-tippy-content="Initialize fl from ff core"><code>++pa:ff</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-ff'><code>++san:ff</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sb-ff'><code>++sb:ff</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sea-ff'><code>++sea:ff</code></a>
@@ -1161,14 +1161,14 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#inv-fl' data-tippy-content="Inverse"><code>++inv:fl</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lfe-fl' data-tippy-content="Maximum"><code>++lfe:fl</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lfn-fl' data-tippy-content="Largest normal float"><code>++lfn:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-fl'><code>++lte:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-fl'><code>++lth:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lug-fl'><code>++lug:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-fl'><code>++mul:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ned-fl'><code>++ned:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#prc-fl'><code>++prc:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rau-fl'><code>++rau:fl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rou-fl'><code>++rou:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-fl' data-tippy-content="Less than / equal (producing flag)"><code>++lte:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-fl' data-tippy-content="Less than (signed and unsigned integer cell)"><code>++lth:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lug-fl' data-tippy-content="Central rounding mechanism"><code>++lug:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-fl' data-tippy-content="Multiply (signed and unsigned integer cell)"><code>++mul:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ned-fl' data-tippy-content="Require float"><code>++ned:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#prc-fl' data-tippy-content="Force precision of 2 or greater (floating point)"><code>++prc:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rau-fl' data-tippy-content="Various roundings (floating point)"><code>++rau:fl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#rou-fl' data-tippy-content="Round to nearest float with 113-bit significand"><code>++rou:fl</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-fl'><code>++san:fl</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#shf-fl'><code>++shf:fl</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#spd-fl'><code>++spd:fl</code></a>
@@ -1195,10 +1195,10 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rd' data-tippy-content="Decimal float to @rd"><code>++grd:rd</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rd' data-tippy-content="Greater than / equal (double-precision float)"><code>++gte:rd</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rd' data-tippy-content="Greater than (double-precision float)"><code>++gth:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rd'><code>++lte:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rd'><code>++lth:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rd'><code>++ma:rd</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rd'><code>++mul:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rd' data-tippy-content="Less than / equal (double-precision float)"><code>++lte:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rd' data-tippy-content="Less than (double-precision float)"><code>++lth:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rd' data-tippy-content="Initialize ff (rd core)"><code>++ma:rd</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rd' data-tippy-content="Multiply (double-precision float)"><code>++mul:rd</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-rd'><code>++san:rd</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sea-rd'><code>++sea:rd</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sig-rd'><code>++sig:rd</code></a>
@@ -1219,10 +1219,10 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rh' data-tippy-content="Decimal float to @rh"><code>++grd:rh</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rh' data-tippy-content="Greater than / equal (half-precision float)"><code>++gte:rh</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rh' data-tippy-content="Greater than (half-precision float)"><code>++gth:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rh'><code>++lte:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rh'><code>++lth:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rh'><code>++ma:rh</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rh'><code>++mul:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rh' data-tippy-content="Less than / equal (half-precision float)"><code>++lte:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rh' data-tippy-content="Less than (half-precision float)"><code>++lth:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rh' data-tippy-content="Initialize ff (rh core)"><code>++ma:rh</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rh' data-tippy-content="Multiply (quad-precision float)"><code>++mul:rh</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-rh'><code>++san:rh</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sea-rh'><code>++sea:rh</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sig-rh'><code>++sig:rh</code></a>
@@ -1243,10 +1243,10 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rs' data-tippy-content="Decimal float to @rs"><code>++grd:rs</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rs' data-tippy-content="Greater than / equal (single-precision float)"><code>++gte:rs</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rs' data-tippy-content="Greater than (single-precision float)"><code>++gth:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rs'><code>++lte:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rs'><code>++lth:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rs'><code>++ma:rs</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rs'><code>++mul:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rs' data-tippy-content="Less than / equal (single-precision float)"><code>++lte:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rs' data-tippy-content="Less than (single-precision float)"><code>++lth:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rs' data-tippy-content="Initialize ff (rs core)"><code>++ma:rs</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rs' data-tippy-content="Multiply (single-precision float)"><code>++mul:rs</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-rs'><code>++san:rs</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sea-rs'><code>++sea:rs</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sig-rs'><code>++sig:rs</code></a>
@@ -1266,10 +1266,10 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#grd-rq' data-tippy-content="Decimal float to @rq"><code>++grd:rq</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gte-rq' data-tippy-content="Greater than / equal (quad-precision float)"><code>++gte:rq</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#gth-rq' data-tippy-content="Greater than (quad-precision float)"><code>++gth:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rq'><code>++lte:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rq'><code>++lth:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rq'><code>++ma:rq</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rq'><code>++mul:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lte-rq' data-tippy-content="Less than / equal (quad-precision float)"><code>++lte:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#lth-rq' data-tippy-content="Less than (quad-precision float)"><code>++lth:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#ma-rq' data-tippy-content="Initialize ff (rq core)"><code>++ma:rq</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#mul-rq' data-tippy-content="Multiply (quad-precision float)"><code>++mul:rq</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#san-rq'><code>++san:rq</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sea-rq'><code>++sea:rq</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3b/#sig-rq'><code>++sig:rq</code></a>
@@ -1295,10 +1295,10 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#era-yo' data-tippy-content="Leap-year period"><code>++era:yo</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#hor-yo' data-tippy-content="Seconds in hour"><code>++hor:yo</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#jes-yo' data-tippy-content="Maximum 64-bit timestamp"><code>++jes:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#mit-yo'><code>++mit:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#moh-yo'><code>++moh:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#moy-yo'><code>++moy:yo</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#qad-yo'><code>++qad:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#mit-yo' data-tippy-content="Seconds in minute"><code>++mit:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#moh-yo' data-tippy-content="Days in month"><code>++moh:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#moy-yo' data-tippy-content="Days in months of leap-year"><code>++moy:yo</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#qad-yo' data-tippy-content="Seconds in 4 years"><code>++qad:yo</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yer-yo'><code>++yer:yo</code></a>
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3c/#yall'><code>++yall</code></a>
@@ -1311,11 +1311,11 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 3d: SHA hash family
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#og'><code>++og</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#rad-og'><code>++rad:og</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#rads-og'><code>++rads:og</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#raw-og'><code>++raw:og</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#raws-og'><code>++raws:og</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#og' data-tippy-content="Container arm for SHA-256 powered RNG"><code>++og</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#rad-og' data-tippy-content="Random in range"><code>++rad:og</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#rads-og' data-tippy-content="Random continuation"><code>++rads:og</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#raw-og' data-tippy-content="Random bits"><code>++raw:og</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#raws-og' data-tippy-content="Random bits continuation"><code>++raws:og</code></a>
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shad'><code>++shad</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3d/#shaf'><code>++shaf</code></a>
@@ -1334,13 +1334,13 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 3f: scrambling
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#ob'><code>++ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#ob' data-tippy-content="Reversible scrambling v2"><code>++ob</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#feen-ob' data-tippy-content="Conceal structure v2"><code>++feen:ob</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#fend-ob' data-tippy-content="Restore structure v2"><code>++fend:ob</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#fice-ob' data-tippy-content="Feistel-like cipher"><code>++fice:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#raku-ob'><code>++raku:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#rund-ob'><code>++rund:ob</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#rynd-ob'><code>++rynd:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#raku-ob' data-tippy-content="Key list"><code>++raku:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#rund-ob' data-tippy-content="Reverse single Feistel-like"><code>++rund:ob</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#rynd-ob' data-tippy-content="Reverse Feistel-like cipher"><code>++rynd:ob</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#teil-ob'><code>++teil:ob</code></a>
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3f/#un'><code>++un</code></a>
@@ -1360,10 +1360,10 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#edge' data-tippy-content="Parsing location metadata"><code>++edge</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#hair' data-tippy-content="Parsing line and column"><code>++hair</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#like' data-tippy-content="Generic edge"><code>++like</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#nail'><code>++nail</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#path'><code>++path</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#pint'><code>++pint</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#rule'><code>++rule</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#nail' data-tippy-content="Location, remainder of parsed text"><code>++nail</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#path' data-tippy-content="Filesystem path"><code>++path</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#pint' data-tippy-content="Parsing range"><code>++pint</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#rule' data-tippy-content="Parsing rule (match this with _)"><code>++rule</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#spot'><code>++spot</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#tone'><code>++tone</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/3g/#toon'><code>++toon</code></a>
@@ -1371,7 +1371,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 4a: exotic bases
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#po'><code>++po</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#po' data-tippy-content="Phonetic base"><code>++po</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#ind-po' data-tippy-content="Parse suffix"><code>++ind:po</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#ins-po' data-tippy-content="Parse prefix"><code>++ins:po</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4a/#tod-po'><code>++tod:po</code></a>
@@ -1380,24 +1380,24 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### 4b: text processing
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#at' data-tippy-content="(Undocumented)"><code>++at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#r-at'><code>++r:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rf-at'><code>++rf:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rn-at'><code>++rn:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rt-at'><code>++rt:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rta-at'><code>++rta:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rtam-at'><code>++rtam:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rub-at'><code>++rub:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rud-at'><code>++rud:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rum-at'><code>++rum:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rup-at'><code>++rup:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#ruv-at'><code>++ruv:at</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rux-at'><code>++rux:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#r-at' data-tippy-content="(Undocumented)"><code>++r:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rf-at' data-tippy-content="(Undocumented)"><code>++rf:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rn-at' data-tippy-content="(Undocumented)"><code>++rn:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rt-at' data-tippy-content="(Undocumented)"><code>++rt:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rta-at' data-tippy-content="(Undocumented)"><code>++rta:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rtam-at' data-tippy-content="(Undocumented)"><code>++rtam:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rub-at' data-tippy-content="(Undocumented)"><code>++rub:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rud-at' data-tippy-content="(Undocumented)"><code>++rud:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rum-at' data-tippy-content="(Undocumented)"><code>++rum:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rup-at' data-tippy-content="(Undocumented)"><code>++rup:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#ruv-at' data-tippy-content="(Undocumented)"><code>++ruv:at</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#rux-at' data-tippy-content="(Undocumented)"><code>++rux:at</code></a>
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#cass' data-tippy-content="To lowercase"><code>++cass</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#crip' data-tippy-content="Tape to cord"><code>++crip</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#cuss' data-tippy-content="To uppercase"><code>++cuss</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#mesc'><code>++mesc</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#runt'><code>++runt</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#mesc' data-tippy-content="Escape special characters"><code>++mesc</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#runt' data-tippy-content="Prepend n times"><code>++runt</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#sand'><code>++sand</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#sane'><code>++sane</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4b/#teff'><code>++teff</code></a>
@@ -1414,11 +1414,11 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 4c: tank printer
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#re'><code>++re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#re' data-tippy-content="Pretty-printing engine (tank)"><code>++re</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#din-re' data-tippy-content="(Undocumented)"><code>++din:re</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#fit-re' data-tippy-content="Fit on one line test"><code>++fit:re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#ram-re'><code>++ram:re</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#rig-re'><code>++rig:re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#ram-re' data-tippy-content="Flatten tank to tape"><code>++ram:re</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#rig-re' data-tippy-content="Wrap tape in / (tank)"><code>++rig:re</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#wig-re'><code>++wig:re</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4c/#win-re'><code>++win:re</code></a>
 
@@ -1429,7 +1429,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### 4d: parsing (tracing)
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4d/#last' data-tippy-content="Further trace"><code>++last</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4d/#lust'><code>++lust</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4d/#lust' data-tippy-content="Detect new line"><code>++lust</code></a>
 
 ### 4e: parsing (combinators)
 
@@ -1437,10 +1437,10 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#comp' data-tippy-content="Arbitrary compose"><code>++comp</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#fail' data-tippy-content="Never parse"><code>++fail</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#glue' data-tippy-content="Skip delimiter"><code>++glue</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#less'><code>++less</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#pfix'><code>++pfix</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#plug'><code>++plug</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#pose'><code>++pose</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#less' data-tippy-content="Parse unless"><code>++less</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#pfix' data-tippy-content="Discard first rule"><code>++pfix</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#plug' data-tippy-content="Parse to tuple"><code>++plug</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#pose' data-tippy-content="Parse options"><code>++pose</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#sfix'><code>++sfix</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4e/#simu'><code>++simu</code></a>
 
@@ -1458,11 +1458,11 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#jest' data-tippy-content="Match a cord"><code>++jest</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#just' data-tippy-content="Match a single character"><code>++just</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#knee' data-tippy-content="Recursive parsers"><code>++knee</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#mask'><code>++mask</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#more'><code>++more</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#most'><code>++most</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#next'><code>++next</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#plus'><code>++plus</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#mask' data-tippy-content="Match character"><code>++mask</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#more' data-tippy-content="Parse list with delimiter"><code>++more</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#most' data-tippy-content="Parse list of at least one match"><code>++most</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#next' data-tippy-content="Consume character"><code>++next</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#plus' data-tippy-content="List of at least one match"><code>++plus</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#sear'><code>++sear</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#shim'><code>++shim</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4f/#slug'><code>++slug</code></a>
@@ -1475,9 +1475,9 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 4g: parsing (outside caller)
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rash'><code>++rash</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rush'><code>++rush</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rust'><code>++rust</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rash' data-tippy-content="Parse or crash"><code>++rash</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rush' data-tippy-content="Parse or null"><code>++rush</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#rust' data-tippy-content="Parse tape or null"><code>++rust</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4g/#scan'><code>++scan</code></a>
 
 ### 4h: parsing (ascii glyphs)
@@ -1500,11 +1500,11 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#kel' data-tippy-content="Parse { (kel)"><code>++kel</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ker' data-tippy-content="Parse } (ker)"><code>++ker</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ket' data-tippy-content="Parse ^ (ket)"><code>++ket</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#lus'><code>++lus</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pam'><code>++pam</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pat'><code>++pat</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pel'><code>++pel</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#per'><code>++per</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#lus' data-tippy-content="Parse + (lus)"><code>++lus</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pam' data-tippy-content="Parse & (pam)"><code>++pam</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pat' data-tippy-content="Parse @ (pat)"><code>++pat</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#pel' data-tippy-content="Parse ( (pel)"><code>++pel</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#per' data-tippy-content="Parse ) (per)"><code>++per</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#sel'><code>++sel</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#sem'><code>++sem</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4h/#ser'><code>++ser</code></a>
@@ -1542,13 +1542,13 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hig' data-tippy-content="Parse single uppercase letter"><code>++hig</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#hit' data-tippy-content="Parse single hexadecimal digit"><code>++hit</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#iny' data-tippy-content="Indentation block"><code>++iny</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#low'><code>++low</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#mes'><code>++mes</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#nix'><code>++nix</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#nud'><code>++nud</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#prn'><code>++prn</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#qit'><code>++qit</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#qut'><code>++qut</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#low' data-tippy-content="Parse lowercase letter"><code>++low</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#mes' data-tippy-content="Parse hexabyte"><code>++mes</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#nix' data-tippy-content="Parse letters and -"><code>++nix</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#nud' data-tippy-content="Parse numeric character"><code>++nud</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#prn' data-tippy-content="Parse any printable character"><code>++prn</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#qit' data-tippy-content="Parse character to cord atom"><code>++qit</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#qut' data-tippy-content="Parse cord"><code>++qut</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#soz'><code>++soz</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#sym'><code>++sym</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4i/#ven'><code>++ven</code></a>
@@ -1562,14 +1562,14 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hif-ab' data-tippy-content="Parse phonetic pair"><code>++hif:ab</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#huf-ab' data-tippy-content="Parse two phonetic pairs"><code>++huf:ab</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#hyf-ab' data-tippy-content="Parse 8 phonetic bytes"><code>++hyf:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#pev-ab'><code>++pev:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#pew-ab'><code>++pew:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#piv-ab'><code>++piv:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#piw-ab'><code>++piw:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qeb-ab'><code>++qeb:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qex-ab'><code>++qex:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qib-ab'><code>++qib:ab</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qix-ab'><code>++qix:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#pev-ab' data-tippy-content="Parse <=5 in base 32"><code>++pev:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#pew-ab' data-tippy-content="Parse <= 5 in base 64"><code>++pew:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#piv-ab' data-tippy-content="Parse 5 digits in base 32"><code>++piv:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#piw-ab' data-tippy-content="Parse 5 digits in base 64"><code>++piw:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qeb-ab' data-tippy-content="Parse <=4 binary digits"><code>++qeb:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qex-ab' data-tippy-content="Parse <=4 hexadecimal digits"><code>++qex:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qib-ab' data-tippy-content="Parse 4 binary digits"><code>++qib:ab</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#qix-ab' data-tippy-content="Parse 4 hexadecimal digits"><code>++qix:ab</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#seb-ab'><code>++seb:ab</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sed-ab'><code>++sed:ab</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#sev-ab'><code>++sev:ab</code></a>
@@ -1606,12 +1606,12 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#vum-ag'><code>++vum:ag</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#wiz-ag'><code>++wiz:ag</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#mu'><code>++mu</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#mu' data-tippy-content="Core used to scramble 16-bit atoms"><code>++mu</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#zag-mu'><code>++zag:mu</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#zig-mu'><code>++zig:mu</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#zug-mu'><code>++zug:mu</code></a>
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ne'><code>++ne</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#ne' data-tippy-content="Digit rendering engine"><code>++ne</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#d-ne' data-tippy-content="Render decimal"><code>++d:ne</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#v-ne'><code>++v:ne</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4j/#w-ne'><code>++w:ne</code></a>
@@ -1620,20 +1620,20 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### 4k: parsing (atom printing)
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#co' data-tippy-content="Literal rendering engine"><code>++co</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rear-co'><code>++rear:co</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rend-co'><code>++rend:co</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rent-co'><code>++rent:co</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rear-co' data-tippy-content="Prepend and render atom as tape"><code>++rear:co</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rend-co' data-tippy-content="Render coin lot as tape"><code>++rend:co</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4k/#rent-co' data-tippy-content="Render coin lot as span"><code>++rent:co</code></a>
 
 ### 4l: parsing (atom parsing)
 
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#so'><code>++so</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#bisk-so' data-tippy-content="Parse odor-atom pair"><code>++bisk:so</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#crub-so' data-tippy-content="Parse @da, @dr, @p, @t"><code>++crub:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#nuck-so'><code>++nuck:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#nusk-so'><code>++nusk:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#perd-so'><code>++perd:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#royl-so'><code>++royl:so</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#royl-cell-so'><code>++royl-cell:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#nuck-so' data-tippy-content="Top-level coin parser"><code>++nuck:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#nusk-so' data-tippy-content="Parse coin literal with escapes"><code>++nusk:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#perd-so' data-tippy-content="Parses dime/tiple without standard prefixes"><code>++perd:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#royl-so' data-tippy-content="Parse dime float"><code>++royl:so</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#royl-cell-so' data-tippy-content="(Undocumented)"><code>++royl-cell:so</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#tash-so'><code>++tash:so</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#twid-so'><code>++twid:so</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4l/#zust-so'><code>++zust:so</code></a>
@@ -1653,13 +1653,13 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### 4n: parsing (virtualization)
 
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mack'><code>++mack</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mink'><code>++mink</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mock'><code>++mock</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mong'><code>++mong</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mook'><code>++mook</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mule'><code>++mule</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mute'><code>++mute</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mack' data-tippy-content="Nock subject to unit"><code>++mack</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mink' data-tippy-content="Mock (virtual Nock) interpreter"><code>++mink</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mock' data-tippy-content="Compute formula on subject with hint"><code>++mock</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mong' data-tippy-content="Slam gate with sample"><code>++mong</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mook' data-tippy-content="Intelligently render crash annotation"><code>++mook</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mule' data-tippy-content="Typed virtual"><code>++mule</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4n/#mute' data-tippy-content="Untyped virtual"><code>++mute</code></a>
 
 ### 4o: parsing (molds)
 
@@ -1675,11 +1675,11 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#foot' data-tippy-content="Cases of arms by variance model"><code>++foot</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#limb' data-tippy-content="Reference into subject by name/axis"><code>++limb</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#line' data-tippy-content="(Undocumented)"><code>++line</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#metl'><code>++metl</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#nock'><code>++nock</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#noun'><code>++noun</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#null'><code>++null</code></a>
-<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#port'><code>++port</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#metl' data-tippy-content="(Undocumented)"><code>++metl</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#nock' data-tippy-content="Virtual machine (see Nock)"><code>++nock</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#noun' data-tippy-content="(Undocumented)"><code>++noun</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#null' data-tippy-content="(Undocumented)"><code>++null</code></a>
+<a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#port' data-tippy-content="(Undocumented)"><code>++port</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#span'><code>++span</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#tiki'><code>++tiki</code></a>
 <a class="tooltip" href='https://urbit.org/docs/reference/library/4o/#toga'><code>++toga</code></a>

--- a/reference/library/_index.md
+++ b/reference/library/_index.md
@@ -13,1718 +13,1718 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 
 ### a
 
-[`++ab`](@/docs/reference/library/4j.md#ab)
-[`++abs:fl`](@/docs/reference/library/3b.md#abs-fl)
-[`++abs:si`](@/docs/reference/library/3a.md#abs-si)
-[`++abel`](@/docs/reference/library/4o.md#abel)
-[`++ace`](@/docs/reference/library/4h.md#ace)
-[`++add`](@/docs/reference/library/1a.md#add)
-[`++add:ff`](@/docs/reference/library/3b.md#add-ff)
-[`++add:fl`](@/docs/reference/library/3b.md#add-fl)
-[`+-add:ja`](@/docs/reference/library/2j.md#add-ja)
-[`++add:rd`](@/docs/reference/library/3b.md#add-rd)
-[`++add:rh`](@/docs/reference/library/3b.md#add-rh)
-[`++add:rs`](@/docs/reference/library/3b.md#add-rs)
-[`++add:rq`](@/docs/reference/library/3b.md#add-rq)
-[`++ag`](@/docs/reference/library/4j.md#ag)
-[`++alf`](@/docs/reference/library/4i.md#alf)
-[`+-all:by`](@/docs/reference/library/2i.md#all-by)
-[`+-all:in`](@/docs/reference/library/2h.md#all-in)
-[`++aln`](@/docs/reference/library/4i.md#aln)
-[`++alp`](@/docs/reference/library/4i.md#alp)
-[`+-any:by`](@/docs/reference/library/2i.md#any-by)
-[`+-any:in`](@/docs/reference/library/2h.md#any-in)
-[`++aor`](@/docs/reference/library/2f.md#aor)
-[`++ape:ag`](@/docs/reference/library/4j.md#ape-ag)
-[`+-apt:by`](@/docs/reference/library/2i.md#apt-by)
-[`+-apt:in`](@/docs/reference/library/2h.md#apt-in)
-[`++at`](@/docs/reference/library/4b.md#at)
-[`++aura`](@/docs/reference/library/4o.md#aura)
-[`++axis`](@/docs/reference/library/4o.md#axis)
+<a href='https://urbit.org/docs/reference/library/4j.md#ab' data-tippy-content="Primitive parser engine"><code>++ab</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#abs-fl' data-tippy-content="Absolute value"><code>++abs:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#abs-si' data-tippy-content="Absolute value (signed integer)"><code>++abs:si</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#abel' data-tippy-content="Compiler alias"><code>++abel</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#ace' data-tippy-content="Parse space"><code>++ace</code></a>
+<a href='https://urbit.org/docs/reference/library/1a.md#add' data-tippy-content="Add"><code>++add</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#add-ff' data-tippy-content="Add (floating point)"><code>++add:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#add-fl' data-tippy-content="Add (with exact/rounded flag)"><code>++add:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/2j.md#add-ja' data-tippy-content="Prepend to list"><code>+-add:ja</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#add-rd' data-tippy-content="Add (double-precision float)"><code>++add:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#add-rh' data-tippy-content="Add (half-precision float)"><code>++add:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#add-rs' data-tippy-content="Add (single-precision float)"><code>++add:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#add-rq' data-tippy-content="Add (quad-precision float)"><code>++add:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#ag' data-tippy-content="Top-level atom parser engine"><code>++ag</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#alf' data-tippy-content="Parse alphabetic characters"><code>++alf</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#all-by' data-tippy-content="Logical AND (map and wet gate)"><code>+-all:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#all-in' data-tippy-content="Logical AND (set and wet gate)"><code>+-all:in</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#aln' data-tippy-content="Parse alphanumeric characters"><code>++aln</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#alp' data-tippy-content="Parse alphanumeric characters and -"><code>++alp</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#any-by' data-tippy-content="Logical OR (map and wet gate)"><code>+-any:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#any-in' data-tippy-content="Logical OR (set and gate)"><code>+-any:in</code></a>
+<a href='https://urbit.org/docs/reference/library/2f.md#aor' data-tippy-content="Alphabetical order"><code>++aor</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#ape-ag' data-tippy-content="Parse 0 or rule"><code>++ape:ag</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#apt-by' data-tippy-content="Check correctness (map)"><code>+-apt:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#apt-in' data-tippy-content="Check correctness (set)"><code>+-apt:in</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#at' data-tippy-content="(Undocumented)"><code>++at</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#aura' data-tippy-content="'Type' of atom"><code>++aura</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#axis' data-tippy-content="Nock axis"><code>++axis</code></a>
 
 ### b
 
-[`+-bal:to`](@/docs/reference/library/2k.md#bal-to)
-[`++bar`](@/docs/reference/library/4h.md#bar)
-[`++bas`](@/docs/reference/library/4h.md#bas)
-[`++base`](@/docs/reference/library/4o.md#base)
-[`++bass`](@/docs/reference/library/4f.md#bass)
-[`++bay:ag`](@/docs/reference/library/4j.md#bay-ag)
-[`++bean`](@/docs/reference/library/4o.md#bean)
-[`++beer`](@/docs/reference/library/4o.md#beer)
-[`++beet`](@/docs/reference/library/4o.md#beet)
-[`++bend`](@/docs/reference/library/4e.md#bend)
-[`++bet`](@/docs/reference/library/4i.md#bet)
-[`++bex`](@/docs/reference/library/2c.md#bex)
-[`++bif:ff`](@/docs/reference/library/3b.md#bif-ff)
-[`+-bif:by`](@/docs/reference/library/2i.md#bif-by)
-[`+-bif:in`](@/docs/reference/library/2h.md#bif-in)
-[`++biff`](@/docs/reference/library/2a.md#biff)
-[`++bin`](@/docs/reference/library/4i.md#bin)
-[`++bind`](@/docs/reference/library/2a.md#bind)
-[`++bip:ag`](@/docs/reference/library/4j.md#bip-ag)
-[`++bit:ff`](@/docs/reference/library/3b.md#bit-ff)
-[`++bit:rd`](@/docs/reference/library/3b.md#bit-rd)
-[`++bit:rh`](@/docs/reference/library/3b.md#bit-rh)
-[`++bit:rs`](@/docs/reference/library/3b.md#bit-rs)
-[`++bit:rq`](@/docs/reference/library/3b.md#bit-rq)
-[`++bix:ab`](@/docs/reference/library/4j.md#bix-ab)
-[`++bisk:so`](@/docs/reference/library/4l.md#bisk-so)
-[`++bloq`](@/docs/reference/library/1c.md#bloq)
-[`++bond`](@/docs/reference/library/2a.md#bond)
-[`++boss`](@/docs/reference/library/4f.md#boss)
-[`++both`](@/docs/reference/library/2a.md#both)
-[`++buc`](@/docs/reference/library/4h.md#buc)
-[`++but`](@/docs/reference/library/4i.md#but)
+<a href='https://urbit.org/docs/reference/library/2k.md#bal-to'><code>+-bal:to</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#bar'><code>++bar</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#bas'><code>++bas</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#base'><code>++base</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#bass'><code>++bass</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#bay-ag'><code>++bay:ag</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#bean'><code>++bean</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#beer'><code>++beer</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#beet'><code>++beet</code></a>
+<a href='https://urbit.org/docs/reference/library/4e.md#bend'><code>++bend</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#bet'><code>++bet</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#bex'><code>++bex</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#bif-ff'><code>++bif:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#bif-by'><code>+-bif:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#bif-in'><code>+-bif:in</code></a>
+<a href='https://urbit.org/docs/reference/library/2a.md#biff'><code>++biff</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#bin'><code>++bin</code></a>
+<a href='https://urbit.org/docs/reference/library/2a.md#bind'><code>++bind</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#bip-ag'><code>++bip:ag</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#bit-ff'><code>++bit:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#bit-rd'><code>++bit:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#bit-rh'><code>++bit:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#bit-rs'><code>++bit:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#bit-rq'><code>++bit:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#bix-ab'><code>++bix:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4l.md#bisk-so'><code>++bisk:so</code></a>
+<a href='https://urbit.org/docs/reference/library/1c.md#bloq'><code>++bloq</code></a>
+<a href='https://urbit.org/docs/reference/library/2a.md#bond'><code>++bond</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#boss'><code>++boss</code></a>
+<a href='https://urbit.org/docs/reference/library/2a.md#both'><code>++both</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#buc'><code>++buc</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#but'><code>++but</code></a>
 
 ### c
 
-[`++cab`](@/docs/reference/library/4h.md#cab)
-[`++can`](@/docs/reference/library/2c.md#can)
-[`++cap`](@/docs/reference/library/1b.md#cap)
-[`++cass`](@/docs/reference/library/4b.md#cass)
-[`++cat`](@/docs/reference/library/2c.md#cat)
-[`++cen`](@/docs/reference/library/4h.md#cen)
-[`++cet:yo`](@/docs/reference/library/3c.md#cet-yo)
-[`++char`](@/docs/reference/library/2q.md#char)
-[`++chum`](@/docs/reference/library/4o.md#chum)
-[`++cit`](@/docs/reference/library/4i.md#cit)
-[`++clap`](@/docs/reference/library/2a.md#clap)
-[`++cmp:si`](@/docs/reference/library/3a.md#cmp-si)
-[`++co`](@/docs/reference/library/4k.md#co)
-[`++coil`](@/docs/reference/library/4o.md#coil)
-[`++coin`](@/docs/reference/library/3g.md#coin)
-[`++col`](@/docs/reference/library/4h.md#col)
-[`++cold`](@/docs/reference/library/4f.md#cold)
-[`++com`](@/docs/reference/library/4h.md#com)
-[`++comp`](@/docs/reference/library/4e.md#comp)
-[`++con`](@/docs/reference/library/2d.md#con)
-[`++cook`](@/docs/reference/library/4f.md#cook)
-[`++cord`](@/docs/reference/library/2q.md#cord)
-[`++cork`](@/docs/reference/library/2n.md#cork)
-[`++corl`](@/docs/reference/library/2n.md#corl)
-[`++crip`](@/docs/reference/library/4b.md#crip)
-[`++crub:so`](@/docs/reference/library/4l.md#crub-so)
-[`++cue`](@/docs/reference/library/2p.md#cue)
-[`++curr`](@/docs/reference/library/2n.md#curr)
-[`++cury`](@/docs/reference/library/2n.md#cury)
-[`++cuss`](@/docs/reference/library/4b.md#cuss)
-[`++cut`](@/docs/reference/library/2c.md#cut)
+<a href='https://urbit.org/docs/reference/library/4h.md#cab'><code>++cab</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#can'><code>++can</code></a>
+<a href='https://urbit.org/docs/reference/library/1b.md#cap'><code>++cap</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#cass'><code>++cass</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#cat'><code>++cat</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#cen'><code>++cen</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#cet-yo'><code>++cet:yo</code></a>
+<a href='https://urbit.org/docs/reference/library/2q.md#char'><code>++char</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#chum'><code>++chum</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#cit'><code>++cit</code></a>
+<a href='https://urbit.org/docs/reference/library/2a.md#clap'><code>++clap</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#cmp-si'><code>++cmp:si</code></a>
+<a href='https://urbit.org/docs/reference/library/4k.md#co'><code>++co</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#coil'><code>++coil</code></a>
+<a href='https://urbit.org/docs/reference/library/3g.md#coin'><code>++coin</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#col'><code>++col</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#cold'><code>++cold</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#com'><code>++com</code></a>
+<a href='https://urbit.org/docs/reference/library/4e.md#comp'><code>++comp</code></a>
+<a href='https://urbit.org/docs/reference/library/2d.md#con'><code>++con</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#cook'><code>++cook</code></a>
+<a href='https://urbit.org/docs/reference/library/2q.md#cord'><code>++cord</code></a>
+<a href='https://urbit.org/docs/reference/library/2n.md#cork'><code>++cork</code></a>
+<a href='https://urbit.org/docs/reference/library/2n.md#corl'><code>++corl</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#crip'><code>++crip</code></a>
+<a href='https://urbit.org/docs/reference/library/4l.md#crub-so'><code>++crub:so</code></a>
+<a href='https://urbit.org/docs/reference/library/2p.md#cue'><code>++cue</code></a>
+<a href='https://urbit.org/docs/reference/library/2n.md#curr'><code>++curr</code></a>
+<a href='https://urbit.org/docs/reference/library/2n.md#cury'><code>++cury</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#cuss'><code>++cuss</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#cut'><code>++cut</code></a>
 
 ### d
 
-[`++d:ne`](@/docs/reference/library/4j.md#d-ne)
-[`++date`](@/docs/reference/library/2q.md#date)
-[`++day:yo`](@/docs/reference/library/3c.md#day-yo)
-[`++dec`](@/docs/reference/library/1a.md#dec)
-[`+-def:by`](@/docs/reference/library/2i.md#def-by)
-[`+-del:by`](@/docs/reference/library/2i.md#del-by)
-[`+-del:in`](@/docs/reference/library/2h.md#del-in)
-[`+-del:ju`](@/docs/reference/library/2j.md#del-ju)
-[`++dem`](@/docs/reference/library/4i.md#dem)
-[`++dem:ag`](@/docs/reference/library/4j.md#dem-ag)
-[`++den:fl`](@/docs/reference/library/3b.md#den-fl)
-[`+-dep:by`](@/docs/reference/library/2i.md#dep-by)
-[`+-dep:to`](@/docs/reference/library/2k.md#dep-to)
-[`++dif:fe`](@/docs/reference/library/2c.md#dif-fe)
-[`++dif:fo`](@/docs/reference/library/3a.md#dif-fo)
-[`+-dif:in`](@/docs/reference/library/2h.md#dif-in)
-[`++dif:si`](@/docs/reference/library/3a.md#dif-si)
-[`+-dig:by`](@/docs/reference/library/2i.md#dig-by)
-[`+-dig:in`](@/docs/reference/library/2h.md#dig-in)
-[`++dim:ag`](@/docs/reference/library/4j.md#dim-ag)
-[`++dime`](@/docs/reference/library/3g.md#dime)
-[`++din:re`](@/docs/reference/library/4c.md#din-re)
-[`++dis`](@/docs/reference/library/2d.md#dis)
-[`++dit`](@/docs/reference/library/4i.md#dit)
-[`++div`](@/docs/reference/library/1a.md#div)
-[`++div:ff`](@/docs/reference/library/3b.md#div-ff)
-[`++div:fl`](@/docs/reference/library/3b.md#div-fl)
-[`++div:rd`](@/docs/reference/library/3b.md#div-rd)
-[`++div:rh`](@/docs/reference/library/3b.md#div-rh)
-[`++div:rs`](@/docs/reference/library/3b.md#div-rs)
-[`++div:rq`](@/docs/reference/library/3b.md#div-rq)
-[`++dog`](@/docs/reference/library/4i.md#dog)
-[`++doh`](@/docs/reference/library/4i.md#doh)
-[`++doq`](@/docs/reference/library/4h.md#doq)
-[`++dor`](@/docs/reference/library/2f.md#dor)
-[`++dot`](@/docs/reference/library/4h.md#dot)
-[`++drg:ff`](@/docs/reference/library/3b.md#drg-ff)
-[`++drg:fl`](@/docs/reference/library/3b.md#drg-fl)
-[`++drg:rd`](@/docs/reference/library/3b.md#drg-rd)
-[`++drg:rh`](@/docs/reference/library/3b.md#drg-rh)
-[`++drg:rs`](@/docs/reference/library/3b.md#drg-rs)
-[`++drg:rq`](@/docs/reference/library/3b.md#drg-rq)
-[`++drop`](@/docs/reference/library/2a.md#drop)
-[`++dul:si`](@/docs/reference/library/3a.md#dul-si)
-[`++dum:ag`](@/docs/reference/library/4j.md#dum-ag)
-[`++dun`](@/docs/reference/library/4i.md#dun)
-[`++duz`](@/docs/reference/library/4i.md#duz)
-[`++dvr`](@/docs/reference/library/1a.md#dvr)
+<a href='https://urbit.org/docs/reference/library/4j.md#d-ne'><code>++d:ne</code></a>
+<a href='https://urbit.org/docs/reference/library/2q.md#date'><code>++date</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#day-yo'><code>++day:yo</code></a>
+<a href='https://urbit.org/docs/reference/library/1a.md#dec'><code>++dec</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#def-by'><code>+-def:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#del-by'><code>+-del:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#del-in'><code>+-del:in</code></a>
+<a href='https://urbit.org/docs/reference/library/2j.md#del-ju'><code>+-del:ju</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#dem'><code>++dem</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#dem-ag'><code>++dem:ag</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#den-fl'><code>++den:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#dep-by'><code>+-dep:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2k.md#dep-to'><code>+-dep:to</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#dif-fe'><code>++dif:fe</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#dif-fo'><code>++dif:fo</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#dif-in'><code>+-dif:in</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#dif-si'><code>++dif:si</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#dig-by'><code>+-dig:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#dig-in'><code>+-dig:in</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#dim-ag'><code>++dim:ag</code></a>
+<a href='https://urbit.org/docs/reference/library/3g.md#dime'><code>++dime</code></a>
+<a href='https://urbit.org/docs/reference/library/4c.md#din-re'><code>++din:re</code></a>
+<a href='https://urbit.org/docs/reference/library/2d.md#dis'><code>++dis</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#dit'><code>++dit</code></a>
+<a href='https://urbit.org/docs/reference/library/1a.md#div'><code>++div</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#div-ff'><code>++div:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#div-fl'><code>++div:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#div-rd'><code>++div:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#div-rh'><code>++div:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#div-rs'><code>++div:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#div-rq'><code>++div:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#dog'><code>++dog</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#doh'><code>++doh</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#doq'><code>++doq</code></a>
+<a href='https://urbit.org/docs/reference/library/2f.md#dor'><code>++dor</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#dot'><code>++dot</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#drg-ff'><code>++drg:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#drg-fl'><code>++drg:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#drg-rd'><code>++drg:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#drg-rh'><code>++drg:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#drg-rs'><code>++drg:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#drg-rq'><code>++drg:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/2a.md#drop'><code>++drop</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#dul-si'><code>++dul:si</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#dum-ag'><code>++dum:ag</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#dun'><code>++dun</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#duz'><code>++duz</code></a>
+<a href='https://urbit.org/docs/reference/library/1a.md#dvr'><code>++dvr</code></a>
 
 ### e
 
-[`++ead:fl`](@/docs/reference/library/3b.md#ead-fl)
-[`++each`](@/docs/reference/library/1c.md#each)
-[`++easy`](@/docs/reference/library/4f.md#easy)
-[`++edge`](@/docs/reference/library/3g.md#edge)
-[`++egcd`](@/docs/reference/library/3a.md#egcd)
-[`++emn:fl`](@/docs/reference/library/3b.md#emn-fl)
-[`++emu:fl`](@/docs/reference/library/3b.md#emu-fl)
-[`++emx:fl`](@/docs/reference/library/3b.md#emx-fl)
-[`++end`](@/docs/reference/library/2c.md#end)
-[`++equ:ff`](@/docs/reference/library/3b.md#equ-ff)
-[`++equ:fl`](@/docs/reference/library/3b.md#equ-fl)
-[`++equ:rd`](@/docs/reference/library/3b.md#equ-rd)
-[`++equ:rh`](@/docs/reference/library/3b.md#equ-rh)
-[`++equ:rs`](@/docs/reference/library/3b.md#equ-rs)
-[`++equ:rq`](@/docs/reference/library/3b.md#equ-rq)
-[`++era:yo`](@/docs/reference/library/3c.md#era-yo)
-[`++exp:ff`](@/docs/reference/library/3b.md#exp-ff)
-[`++exp:fo`](@/docs/reference/library/3a.md#exp-fo)
-[`++exp:rd`](@/docs/reference/library/3b.md#exp-rd)
-[`++exp:rh`](@/docs/reference/library/3b.md#exp-rh)
-[`++exp:rs`](@/docs/reference/library/3b.md#exp-rs)
-[`++exp:rq`](@/docs/reference/library/3b.md#exp-rq)
+<a href='https://urbit.org/docs/reference/library/3b.md#ead-fl'><code>++ead:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/1c.md#each'><code>++each</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#easy'><code>++easy</code></a>
+<a href='https://urbit.org/docs/reference/library/3g.md#edge'><code>++edge</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#egcd'><code>++egcd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#emn-fl'><code>++emn:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#emu-fl'><code>++emu:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#emx-fl'><code>++emx:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#end'><code>++end</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#equ-ff'><code>++equ:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#equ-fl'><code>++equ:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#equ-rd'><code>++equ:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#equ-rh'><code>++equ:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#equ-rs'><code>++equ:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#equ-rq'><code>++equ:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#era-yo'><code>++era:yo</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#exp-ff'><code>++exp:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#exp-fo'><code>++exp:fo</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#exp-rd'><code>++exp:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#exp-rh'><code>++exp:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#exp-rs'><code>++exp:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#exp-rq'><code>++exp:rq</code></a>
 
 ### f
 
-[`++fail`](@/docs/reference/library/4e.md#fail)
-[`++fall`](@/docs/reference/library/2a.md#fall)
-[`++fand`](@/docs/reference/library/2b.md#fand)
-[`++fas`](@/docs/reference/library/4h.md#fas)
-[`++fe`](@/docs/reference/library/2c.md#fe)
-[`++fed:ag`](@/docs/reference/library/4j.md#fed-ag)
-[`++feen:ob`](@/docs/reference/library/3f.md#feen-ob)
-[`++fend:ob`](@/docs/reference/library/3f.md#fend-ob)
-[`++fice:ob`](@/docs/reference/library/3f.md#fice-ob)
-[`++fil`](@/docs/reference/library/2c.md#fil)
-[`++find`](@/docs/reference/library/2b.md#find)
-[`++fit:re`](@/docs/reference/library/4c.md#fit-re)
-[`++fli:fl`](@/docs/reference/library/3b.md#fli-fl)
-[`++flop`](@/docs/reference/library/2b.md#flop)
-[`++fma:ff`](@/docs/reference/library/3b.md#fma-ff)
-[`++fma:fl`](@/docs/reference/library/3b.md#fma-fl)
-[`++fma:rd`](@/docs/reference/library/3b.md#fma-rd)
-[`++fma:rh`](@/docs/reference/library/3b.md#fma-rh)
-[`++fma:rs`](@/docs/reference/library/3b.md#fma-rs)
-[`++fma:rq`](@/docs/reference/library/3b.md#fma-rq)
-[`++fnv`](@/docs/reference/library/2e.md#fnv)
-[`++fo`](@/docs/reference/library/3a.md#fo)
-[`++foot`](@/docs/reference/library/4o.md#foot)
-[`++fos:rh`](@/docs/reference/library/3b.md#fos-rh)
-[`++fra:fo`](@/docs/reference/library/3a.md#fra-fo)
-[`++fra:si`](@/docs/reference/library/3a.md#fra-si)
-[`++full`](@/docs/reference/library/4f.md#full)
-[`++funk`](@/docs/reference/library/4f.md#funk)
+<a href='https://urbit.org/docs/reference/library/4e.md#fail'><code>++fail</code></a>
+<a href='https://urbit.org/docs/reference/library/2a.md#fall'><code>++fall</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#fand'><code>++fand</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#fas'><code>++fas</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#fe'><code>++fe</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#fed-ag'><code>++fed:ag</code></a>
+<a href='https://urbit.org/docs/reference/library/3f.md#feen-ob'><code>++feen:ob</code></a>
+<a href='https://urbit.org/docs/reference/library/3f.md#fend-ob'><code>++fend:ob</code></a>
+<a href='https://urbit.org/docs/reference/library/3f.md#fice-ob'><code>++fice:ob</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#fil'><code>++fil</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#find'><code>++find</code></a>
+<a href='https://urbit.org/docs/reference/library/4c.md#fit-re'><code>++fit:re</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#fli-fl'><code>++fli:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#flop'><code>++flop</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#fma-ff'><code>++fma:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#fma-fl'><code>++fma:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#fma-rd'><code>++fma:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#fma-rh'><code>++fma:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#fma-rs'><code>++fma:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#fma-rq'><code>++fma:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/2e.md#fnv'><code>++fnv</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#fo'><code>++fo</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#foot'><code>++foot</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#fos-rh'><code>++fos:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#fra-fo'><code>++fra:fo</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#fra-si'><code>++fra:si</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#full'><code>++full</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#funk'><code>++funk</code></a>
 
 ### g
 
-[`++gah`](@/docs/reference/library/4i.md#gah)
-[`++gal`](@/docs/reference/library/4h.md#gal)
-[`++gap`](@/docs/reference/library/4i.md#gap)
-[`++gaq`](@/docs/reference/library/4i.md#gaq)
-[`++gar`](@/docs/reference/library/4h.md#gar)
-[`+-gas:by`](@/docs/reference/library/2i.md#gas-by)
-[`+-gas:in`](@/docs/reference/library/2h.md#gas-in)
-[`+-gas:to`](@/docs/reference/library/2k.md#gas-to)
-[`++gate`](@/docs/reference/library/1c.md#gate)
-[`++gaw`](@/docs/reference/library/4i.md#gaw)
-[`++gay`](@/docs/reference/library/4i.md#gay)
-[`+-get:by`](@/docs/reference/library/2i.md#get-by)
-[`+-get:ja`](@/docs/reference/library/2j.md#get-ja)
-[`+-get:ju`](@/docs/reference/library/2j.md#get-ju)
-[`+-get:to`](@/docs/reference/library/2k.md#get-to)
-[`++glue`](@/docs/reference/library/4e.md#glue)
-[`++gon`](@/docs/reference/library/4i.md#gon)
-[`++gor`](@/docs/reference/library/2f.md#gor)
-[`+-got:by`](@/docs/reference/library/2i.md#got-by)
-[`++grd:ff`](@/docs/reference/library/3b.md#grd-ff)
-[`++grd:fl`](@/docs/reference/library/3b.md#grd-fl)
-[`++grd:rd`](@/docs/reference/library/3b.md#grd-rd)
-[`++grd:rh`](@/docs/reference/library/3b.md#grd-rh)
-[`++grd:rs`](@/docs/reference/library/3b.md#grd-rs)
-[`++grd:rq`](@/docs/reference/library/3b.md#grd-rq)
-[`++gte`](@/docs/reference/library/1a.md#gte)
-[`++gte:ff`](@/docs/reference/library/3b.md#gte-ff)
-[`++gte:fl`](@/docs/reference/library/3b.md#gte-fl)
-[`++gte:rd`](@/docs/reference/library/3b.md#gte-rd)
-[`++gte:rh`](@/docs/reference/library/3b.md#gte-rh)
-[`++gte:rs`](@/docs/reference/library/3b.md#gte-rs)
-[`++gte:rq`](@/docs/reference/library/3b.md#gte-rq)
-[`++gth`](@/docs/reference/library/1a.md#gth)
-[`++gth:ff`](@/docs/reference/library/3b.md#gth-ff)
-[`++gth:fl`](@/docs/reference/library/3b.md#gth-fl)
-[`++gth:rd`](@/docs/reference/library/3b.md#gth-rd)
-[`++gth:rh`](@/docs/reference/library/3b.md#gth-rh)
-[`++gth:rs`](@/docs/reference/library/3b.md#gth-rs)
-[`++gth:rq`](@/docs/reference/library/3b.md#gth-rq)
-[`++gul`](@/docs/reference/library/4i.md#gul)
-[`++gulf`](@/docs/reference/library/2b.md#gulf)
+<a href='https://urbit.org/docs/reference/library/4i.md#gah'><code>++gah</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#gal'><code>++gal</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#gap'><code>++gap</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#gaq'><code>++gaq</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#gar'><code>++gar</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#gas-by'><code>+-gas:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#gas-in'><code>+-gas:in</code></a>
+<a href='https://urbit.org/docs/reference/library/2k.md#gas-to'><code>+-gas:to</code></a>
+<a href='https://urbit.org/docs/reference/library/1c.md#gate'><code>++gate</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#gaw'><code>++gaw</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#gay'><code>++gay</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#get-by'><code>+-get:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2j.md#get-ja'><code>+-get:ja</code></a>
+<a href='https://urbit.org/docs/reference/library/2j.md#get-ju'><code>+-get:ju</code></a>
+<a href='https://urbit.org/docs/reference/library/2k.md#get-to'><code>+-get:to</code></a>
+<a href='https://urbit.org/docs/reference/library/4e.md#glue'><code>++glue</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#gon'><code>++gon</code></a>
+<a href='https://urbit.org/docs/reference/library/2f.md#gor'><code>++gor</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#got-by'><code>+-got:by</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#grd-ff'><code>++grd:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#grd-fl'><code>++grd:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#grd-rd'><code>++grd:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#grd-rh'><code>++grd:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#grd-rs'><code>++grd:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#grd-rq'><code>++grd:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/1a.md#gte'><code>++gte</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#gte-ff'><code>++gte:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#gte-fl'><code>++gte:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#gte-rd'><code>++gte:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#gte-rh'><code>++gte:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#gte-rs'><code>++gte:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#gte-rq'><code>++gte:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/1a.md#gth'><code>++gth</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#gth-ff'><code>++gth:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#gth-fl'><code>++gth:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#gth-rd'><code>++gth:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#gth-rh'><code>++gth:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#gth-rs'><code>++gth:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#gth-rq'><code>++gth:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#gul'><code>++gul</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#gulf'><code>++gulf</code></a>
 
 ### h
 
-[`++hair`](@/docs/reference/library/3g.md#hair)
-[`++hard`](@/docs/reference/library/2n.md#hard)
-[`+-has:by`](@/docs/reference/library/2i.md#has-by)
-[`+-has:in`](@/docs/reference/library/2h.md#has-in)
-[`+-has:ju`](@/docs/reference/library/2j.md#has-ju)
-[`++hax`](@/docs/reference/library/4h.md#hax)
-[`++head`](@/docs/reference/library/2n.md#head)
-[`++here`](@/docs/reference/library/4f.md#here)
-[`++hep`](@/docs/reference/library/4h.md#hep)
-[`++hex`](@/docs/reference/library/4i.md#hex)
-[`++hex:ag`](@/docs/reference/library/4j.md#hex-ag)
-[`++hif:ab`](@/docs/reference/library/4j.md#hif-ab)
-[`++hig`](@/docs/reference/library/4i.md#hig)
-[`++hit`](@/docs/reference/library/4i.md#hit)
-[`++homo`](@/docs/reference/library/2b.md#homo)
-[`++hor`](@/docs/reference/library/2f.md#hor)
-[`++hor:yo`](@/docs/reference/library/3c.md#hor-yo)
-[`++huf:ab`](@/docs/reference/library/4j.md#huf-ab)
-[`++hyf:ab`](@/docs/reference/library/4j.md#hyf-ab)
+<a href='https://urbit.org/docs/reference/library/3g.md#hair'><code>++hair</code></a>
+<a href='https://urbit.org/docs/reference/library/2n.md#hard'><code>++hard</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#has-by'><code>+-has:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#has-in'><code>+-has:in</code></a>
+<a href='https://urbit.org/docs/reference/library/2j.md#has-ju'><code>+-has:ju</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#hax'><code>++hax</code></a>
+<a href='https://urbit.org/docs/reference/library/2n.md#head'><code>++head</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#here'><code>++here</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#hep'><code>++hep</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#hex'><code>++hex</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#hex-ag'><code>++hex:ag</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#hif-ab'><code>++hif:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#hig'><code>++hig</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#hit'><code>++hit</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#homo'><code>++homo</code></a>
+<a href='https://urbit.org/docs/reference/library/2f.md#hor'><code>++hor</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#hor-yo'><code>++hor:yo</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#huf-ab'><code>++huf:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#hyf-ab'><code>++hyf:ab</code></a>
 
 ### i
 
-[`++ibl:fl`](@/docs/reference/library/3b.md#ibl-fl)
-[`++ifix`](@/docs/reference/library/4f.md#ifix)
-[`++ind:po`](@/docs/reference/library/4a.md#ind-po)
-[`++ins:po`](@/docs/reference/library/4a.md#ins-po)
-[`+-int:by`](@/docs/reference/library/2i.md#int-by)
-[`+-int:in`](@/docs/reference/library/2h.md#int-in)
-[`++inv:fe`](@/docs/reference/library/2c.md#inv-fe)
-[`++inv:fl`](@/docs/reference/library/3b.md#inv-fl)
-[`++inv:fo`](@/docs/reference/library/3a.md#inv-fo)
-[`++iny`](@/docs/reference/library/4i.md#iny)
+<a href='https://urbit.org/docs/reference/library/3b.md#ibl-fl'><code>++ibl:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#ifix'><code>++ifix</code></a>
+<a href='https://urbit.org/docs/reference/library/4a.md#ind-po'><code>++ind:po</code></a>
+<a href='https://urbit.org/docs/reference/library/4a.md#ins-po'><code>++ins:po</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#int-by'><code>+-int:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#int-in'><code>+-int:in</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#inv-fe'><code>++inv:fe</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#inv-fl'><code>++inv:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#inv-fo'><code>++inv:fo</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#iny'><code>++iny</code></a>
 
 ### j
 
-[`++ja`](@/docs/reference/library/2j.md#ja)
-[`++jam`](@/docs/reference/library/2p.md#jam)
-[`++jar`](@/docs/reference/library/2o.md#jar)
-[`++jes:yo`](@/docs/reference/library/3c.md#jes-yo)
-[`++jest`](@/docs/reference/library/4f.md#jest)
-[`++ju`](@/docs/reference/library/2j.md#ju)
-[`++jug`](@/docs/reference/library/2o.md#jug)
-[`++just`](@/docs/reference/library/4f.md#just)
+<a href='https://urbit.org/docs/reference/library/2j.md#ja'><code>++ja</code></a>
+<a href='https://urbit.org/docs/reference/library/2p.md#jam'><code>++jam</code></a>
+<a href='https://urbit.org/docs/reference/library/2o.md#jar'><code>++jar</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#jes-yo'><code>++jes:yo</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#jest'><code>++jest</code></a>
+<a href='https://urbit.org/docs/reference/library/2j.md#ju'><code>++ju</code></a>
+<a href='https://urbit.org/docs/reference/library/2o.md#jug'><code>++jug</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#just'><code>++just</code></a>
 
 ### k
 
-[`++kel`](@/docs/reference/library/4h.md#kel)
-[`++ker`](@/docs/reference/library/4h.md#ker)
-[`++ket`](@/docs/reference/library/4h.md#ket)
-[`++knee`](@/docs/reference/library/4f.md#knee)
-[`++knot`](@/docs/reference/library/2q.md#knot)
+<a href='https://urbit.org/docs/reference/library/4h.md#kel'><code>++kel</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#ker'><code>++ker</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#ket'><code>++ket</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#knee'><code>++knee</code></a>
+<a href='https://urbit.org/docs/reference/library/2q.md#knot'><code>++knot</code></a>
 
 ### l
 
-[`++last`](@/docs/reference/library/4d.md#last)
-[`++le:nl`](@/docs/reference/library/2m.md#le-nl)
-[`++lent`](@/docs/reference/library/2b.md#lent)
-[`++levy`](@/docs/reference/library/2b.md#levy)
-[`++lfe:fl`](@/docs/reference/library/3b.md#lfe-fl)
-[`++lfn:fl`](@/docs/reference/library/3b.md#lfn-fl)
-[`++lien`](@/docs/reference/library/2b.md#lien)
-[`++lift`](@/docs/reference/library/2a.md#lift)
-[`++like`](@/docs/reference/library/3g.md#like)
-[`++limb`](@/docs/reference/library/4o.md#limb)
-[`++limo`](@/docs/reference/library/2b.md#limo)
-[`++line`](@/docs/reference/library/4o.md#line)
-[`++lip:ag`](@/docs/reference/library/4j.md#lip-ag)
-[`++list`](@/docs/reference/library/1c.md#list)
-[`++lone`](@/docs/reference/library/1c.md#lone)
-[`++lor`](@/docs/reference/library/2f.md#lor)
-[`++low`](@/docs/reference/library/4i.md#low)
-[`++lsh`](@/docs/reference/library/2c.md#lsh)
-[`++lte`](@/docs/reference/library/1a.md#lte)
-[`++lte:ff`](@/docs/reference/library/3b.md#lte-ff)
-[`++lte:fl`](@/docs/reference/library/3b.md#lte-fl)
-[`++lte:rd`](@/docs/reference/library/3b.md#lte-rd)
-[`++lte:rh`](@/docs/reference/library/3b.md#lte-rh)
-[`++lte:rs`](@/docs/reference/library/3b.md#lte-rs)
-[`++lte:rq`](@/docs/reference/library/3b.md#lte-rq)
-[`++lth`](@/docs/reference/library/1a.md#lth)
-[`++lth:ff`](@/docs/reference/library/3b.md#lth-ff)
-[`++lth:fl`](@/docs/reference/library/3b.md#lth-fl)
-[`++lth:rd`](@/docs/reference/library/3b.md#lth-rd)
-[`++lth:rh`](@/docs/reference/library/3b.md#lth-rh)
-[`++lth:rs`](@/docs/reference/library/3b.md#lth-rs)
-[`++lth:rq`](@/docs/reference/library/3b.md#lth-rq)
-[`++lug:fl`](@/docs/reference/library/3b.md#lug-fl)
-[`++lus`](@/docs/reference/library/4h.md#lus)
-[`++lust`](@/docs/reference/library/4d.md#lust)
-[`++less`](@/docs/reference/library/4e.md#less)
-[`++ly`](@/docs/reference/library/2m.md#ly)
+<a href='https://urbit.org/docs/reference/library/4d.md#last'><code>++last</code></a>
+<a href='https://urbit.org/docs/reference/library/2m.md#le-nl'><code>++le:nl</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#lent'><code>++lent</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#levy'><code>++levy</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#lfe-fl'><code>++lfe:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#lfn-fl'><code>++lfn:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#lien'><code>++lien</code></a>
+<a href='https://urbit.org/docs/reference/library/2a.md#lift'><code>++lift</code></a>
+<a href='https://urbit.org/docs/reference/library/3g.md#like'><code>++like</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#limb'><code>++limb</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#limo'><code>++limo</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#line'><code>++line</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#lip-ag'><code>++lip:ag</code></a>
+<a href='https://urbit.org/docs/reference/library/1c.md#list'><code>++list</code></a>
+<a href='https://urbit.org/docs/reference/library/1c.md#lone'><code>++lone</code></a>
+<a href='https://urbit.org/docs/reference/library/2f.md#lor'><code>++lor</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#low'><code>++low</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#lsh'><code>++lsh</code></a>
+<a href='https://urbit.org/docs/reference/library/1a.md#lte'><code>++lte</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#lte-ff'><code>++lte:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#lte-fl'><code>++lte:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#lte-rd'><code>++lte:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#lte-rh'><code>++lte:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#lte-rs'><code>++lte:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#lte-rq'><code>++lte:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/1a.md#lth'><code>++lth</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#lth-ff'><code>++lth:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#lth-fl'><code>++lth:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#lth-rd'><code>++lth:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#lth-rh'><code>++lth:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#lth-rs'><code>++lth:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#lth-rq'><code>++lth:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#lug-fl'><code>++lug:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#lus'><code>++lus</code></a>
+<a href='https://urbit.org/docs/reference/library/4d.md#lust'><code>++lust</code></a>
+<a href='https://urbit.org/docs/reference/library/4e.md#less'><code>++less</code></a>
+<a href='https://urbit.org/docs/reference/library/2m.md#ly'><code>++ly</code></a>
 
 ### m
 
-[`++ma:rd`](@/docs/reference/library/3b.md#ma-rd)
-[`++ma:rh`](@/docs/reference/library/3b.md#ma-rh)
-[`++ma:rs`](@/docs/reference/library/3b.md#ma-rs)
-[`++ma:rq`](@/docs/reference/library/3b.md#ma-rq)
-[`++mack`](@/docs/reference/library/4n.md#mack)
-[`++malt`](@/docs/reference/library/2l.md#malt)
-[`++map`](@/docs/reference/library/2o.md#map)
-[`+-mar:by`](@/docs/reference/library/2i.md#mar-by)
-[`++mas`](@/docs/reference/library/1b.md#mas)
-[`++mask`](@/docs/reference/library/4f.md#mask)
-[`++mat`](@/docs/reference/library/2p.md#mat)
-[`++mate`](@/docs/reference/library/2a.md#mate)
-[`++max`](@/docs/reference/library/1a.md#max)
-[`++me:ff`](@/docs/reference/library/3b.md#me-ff)
-[`++mean`](@/docs/reference/library/2n.md#mean)
-[`++mes`](@/docs/reference/library/4i.md#mes)
-[`++mesc`](@/docs/reference/library/4b.md#mesc)
-[`++met`](@/docs/reference/library/2c.md#met)
-[`++metl`](@/docs/reference/library/4o.md#metl)
-[`++min`](@/docs/reference/library/1a.md#min)
-[`++mink`](@/docs/reference/library/4n.md#mink)
-[`++mit:yo`](@/docs/reference/library/3c.md#mit-yo)
-[`++mix`](@/docs/reference/library/2d.md#mix)
-[`++mock`](@/docs/reference/library/4n.md#mock)
-[`++mod`](@/docs/reference/library/1a.md#mod)
-[`++moh:yo`](@/docs/reference/library/3c.md#moh-yo)
-[`++molt`](@/docs/reference/library/2l.md#molt)
-[`++mong`](@/docs/reference/library/4n.md#mong)
-[`++mook`](@/docs/reference/library/4n.md#mook)
-[`++more`](@/docs/reference/library/4f.md#more)
-[`++most`](@/docs/reference/library/4f.md#most)
-[`++moy:yo`](@/docs/reference/library/3c.md#moy-yo)
-[`++mu`](@/docs/reference/library/4j.md#mu)
-[`++mug`](@/docs/reference/library/2e.md#mug)
-[`++muk`](@/docs/reference/library/2e.md#muk)
-[`++mul`](@/docs/reference/library/1a.md#mul)
-[`++mul:ff`](@/docs/reference/library/3b.md#mul-ff)
-[`++mul:fl`](@/docs/reference/library/3b.md#mul-fl)
-[`++mul:rd`](@/docs/reference/library/3b.md#mul-rd)
-[`++mul:rh`](@/docs/reference/library/3b.md#mul-rh)
-[`++mul:rs`](@/docs/reference/library/3b.md#mul-rs)
-[`++mul:rq`](@/docs/reference/library/3b.md#mul-rq)
-[`++mule`](@/docs/reference/library/4n.md#mule)
-[`++mute`](@/docs/reference/library/4n.md#mute)
-[`++mum`](@/docs/reference/library/2e.md#mum)
-[`++murn`](@/docs/reference/library/2b.md#murn)
-[`++my`](@/docs/reference/library/2m.md#my)
-[`++my:nl`](@/docs/reference/library/2m.md#my-nl)
+<a href='https://urbit.org/docs/reference/library/3b.md#ma-rd'><code>++ma:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#ma-rh'><code>++ma:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#ma-rs'><code>++ma:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#ma-rq'><code>++ma:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/4n.md#mack'><code>++mack</code></a>
+<a href='https://urbit.org/docs/reference/library/2l.md#malt'><code>++malt</code></a>
+<a href='https://urbit.org/docs/reference/library/2o.md#map'><code>++map</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#mar-by'><code>+-mar:by</code></a>
+<a href='https://urbit.org/docs/reference/library/1b.md#mas'><code>++mas</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#mask'><code>++mask</code></a>
+<a href='https://urbit.org/docs/reference/library/2p.md#mat'><code>++mat</code></a>
+<a href='https://urbit.org/docs/reference/library/2a.md#mate'><code>++mate</code></a>
+<a href='https://urbit.org/docs/reference/library/1a.md#max'><code>++max</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#me-ff'><code>++me:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/2n.md#mean'><code>++mean</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#mes'><code>++mes</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#mesc'><code>++mesc</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#met'><code>++met</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#metl'><code>++metl</code></a>
+<a href='https://urbit.org/docs/reference/library/1a.md#min'><code>++min</code></a>
+<a href='https://urbit.org/docs/reference/library/4n.md#mink'><code>++mink</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#mit-yo'><code>++mit:yo</code></a>
+<a href='https://urbit.org/docs/reference/library/2d.md#mix'><code>++mix</code></a>
+<a href='https://urbit.org/docs/reference/library/4n.md#mock'><code>++mock</code></a>
+<a href='https://urbit.org/docs/reference/library/1a.md#mod'><code>++mod</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#moh-yo'><code>++moh:yo</code></a>
+<a href='https://urbit.org/docs/reference/library/2l.md#molt'><code>++molt</code></a>
+<a href='https://urbit.org/docs/reference/library/4n.md#mong'><code>++mong</code></a>
+<a href='https://urbit.org/docs/reference/library/4n.md#mook'><code>++mook</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#more'><code>++more</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#most'><code>++most</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#moy-yo'><code>++moy:yo</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#mu'><code>++mu</code></a>
+<a href='https://urbit.org/docs/reference/library/2e.md#mug'><code>++mug</code></a>
+<a href='https://urbit.org/docs/reference/library/2e.md#muk'><code>++muk</code></a>
+<a href='https://urbit.org/docs/reference/library/1a.md#mul'><code>++mul</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#mul-ff'><code>++mul:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#mul-fl'><code>++mul:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#mul-rd'><code>++mul:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#mul-rh'><code>++mul:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#mul-rs'><code>++mul:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#mul-rq'><code>++mul:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/4n.md#mule'><code>++mule</code></a>
+<a href='https://urbit.org/docs/reference/library/4n.md#mute'><code>++mute</code></a>
+<a href='https://urbit.org/docs/reference/library/2e.md#mum'><code>++mum</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#murn'><code>++murn</code></a>
+<a href='https://urbit.org/docs/reference/library/2m.md#my'><code>++my</code></a>
+<a href='https://urbit.org/docs/reference/library/2m.md#my-nl'><code>++my:nl</code></a>
 
 ### n
 
-[`++nail`](@/docs/reference/library/3g.md#nail)
-[`+-nap:to`](@/docs/reference/library/2k.md#nap-to)
-[`++ne`](@/docs/reference/library/4j.md#ne)
-[`++ned:fl`](@/docs/reference/library/3b.md#ned-fl)
-[`++need`](@/docs/reference/library/2a.md#need)
-[`++net:fe`](@/docs/reference/library/2c.md#net-fe)
-[`++new:si`](@/docs/reference/library/3a.md#new-si)
-[`++next`](@/docs/reference/library/4f.md#next)
-[`+-nip:to`](@/docs/reference/library/2k.md#nip-to)
-[`++nix`](@/docs/reference/library/4i.md#nix)
-[`++nl`](@/docs/reference/library/2m.md#nl)
-[`++nock`](@/docs/reference/library/4o.md#nock)
-[`++not`](@/docs/reference/library/2d.md#not)
-[`++noun`](@/docs/reference/library/4o.md#noun)
-[`++nuck:so`](@/docs/reference/library/4l.md#nuck-so)
-[`++nud`](@/docs/reference/library/4i.md#nud)
-[`++null`](@/docs/reference/library/4o.md#null)
-[`++nusk:so`](@/docs/reference/library/4l.md#nusk-so)
+<a href='https://urbit.org/docs/reference/library/3g.md#nail'><code>++nail</code></a>
+<a href='https://urbit.org/docs/reference/library/2k.md#nap-to'><code>+-nap:to</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#ne'><code>++ne</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#ned-fl'><code>++ned:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/2a.md#need'><code>++need</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#net-fe'><code>++net:fe</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#new-si'><code>++new:si</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#next'><code>++next</code></a>
+<a href='https://urbit.org/docs/reference/library/2k.md#nip-to'><code>+-nip:to</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#nix'><code>++nix</code></a>
+<a href='https://urbit.org/docs/reference/library/2m.md#nl'><code>++nl</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#nock'><code>++nock</code></a>
+<a href='https://urbit.org/docs/reference/library/2d.md#not'><code>++not</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#noun'><code>++noun</code></a>
+<a href='https://urbit.org/docs/reference/library/4l.md#nuck-so'><code>++nuck:so</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#nud'><code>++nud</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#null'><code>++null</code></a>
+<a href='https://urbit.org/docs/reference/library/4l.md#nusk-so'><code>++nusk:so</code></a>
 
 ### o
 
-[`++ob`](@/docs/reference/library/3f.md#ob)
-[`++og`](@/docs/reference/library/3d.md#og)
-[`++old:si`](@/docs/reference/library/3a.md#old-si)
-[`++oust`](@/docs/reference/library/2b.md#oust)
-[`++out:fe`](@/docs/reference/library/2c.md#out-fe)
+<a href='https://urbit.org/docs/reference/library/3f.md#ob'><code>++ob</code></a>
+<a href='https://urbit.org/docs/reference/library/3d.md#og'><code>++og</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#old-si'><code>++old:si</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#oust'><code>++oust</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#out-fe'><code>++out:fe</code></a>
 
 ### p
 
-[`++pa:ff`](@/docs/reference/library/3b.md#pa-ff)
-[`++pair`](@/docs/reference/library/1c.md#pair)
-[`++pam`](@/docs/reference/library/4h.md#pam)
-[`++pat`](@/docs/reference/library/4h.md#pat)
-[`++path`](@/docs/reference/library/3g.md#path)
-[`++peg`](@/docs/reference/library/1b.md#peg)
-[`++pel`](@/docs/reference/library/4h.md#pel)
-[`++per`](@/docs/reference/library/4h.md#per)
-[`++perd:so`](@/docs/reference/library/4l.md#perd-so)
-[`++pev:ab`](@/docs/reference/library/4j.md#pev-ab)
-[`++pew:ab`](@/docs/reference/library/4j.md#pew-ab)
-[`++pfix`](@/docs/reference/library/4e.md#pfix)
-[`++pint`](@/docs/reference/library/3g.md#pint)
-[`++piv:ab`](@/docs/reference/library/4j.md#piv-ab)
-[`++piw:ab`](@/docs/reference/library/4j.md#piw-ab)
-[`++plug`](@/docs/reference/library/4e.md#plug)
-[`++plus`](@/docs/reference/library/4f.md#plus)
-[`++po`](@/docs/reference/library/4a.md#po)
-[`++pole`](@/docs/reference/library/1c.md#pole)
-[`++port`](@/docs/reference/library/4o.md#port)
-[`++pose`](@/docs/reference/library/4e.md#pose)
-[`++pow`](@/docs/reference/library/2g.md#pow)
-[`++prc:fl`](@/docs/reference/library/3b.md#prc-fl)
-[`++prn`](@/docs/reference/library/4i.md#prn)
-[`++pro:fo`](@/docs/reference/library/3a.md#pro-fo)
-[`++pro:si`](@/docs/reference/library/3a.md#pro-si)
-[`+-put:by`](@/docs/reference/library/2i.md#put-by)
-[`+-put:in`](@/docs/reference/library/2h.md#put-in)
-[`+-put:ju`](@/docs/reference/library/2j.md#put-ju)
-[`+-put:to`](@/docs/reference/library/2k.md#put-to)
+<a href='https://urbit.org/docs/reference/library/3b.md#pa-ff'><code>++pa:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/1c.md#pair'><code>++pair</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#pam'><code>++pam</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#pat'><code>++pat</code></a>
+<a href='https://urbit.org/docs/reference/library/3g.md#path'><code>++path</code></a>
+<a href='https://urbit.org/docs/reference/library/1b.md#peg'><code>++peg</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#pel'><code>++pel</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#per'><code>++per</code></a>
+<a href='https://urbit.org/docs/reference/library/4l.md#perd-so'><code>++perd:so</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#pev-ab'><code>++pev:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#pew-ab'><code>++pew:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4e.md#pfix'><code>++pfix</code></a>
+<a href='https://urbit.org/docs/reference/library/3g.md#pint'><code>++pint</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#piv-ab'><code>++piv:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#piw-ab'><code>++piw:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4e.md#plug'><code>++plug</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#plus'><code>++plus</code></a>
+<a href='https://urbit.org/docs/reference/library/4a.md#po'><code>++po</code></a>
+<a href='https://urbit.org/docs/reference/library/1c.md#pole'><code>++pole</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#port'><code>++port</code></a>
+<a href='https://urbit.org/docs/reference/library/4e.md#pose'><code>++pose</code></a>
+<a href='https://urbit.org/docs/reference/library/2g.md#pow'><code>++pow</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#prc-fl'><code>++prc:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#prn'><code>++prn</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#pro-fo'><code>++pro:fo</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#pro-si'><code>++pro:si</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#put-by'><code>+-put:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#put-in'><code>+-put:in</code></a>
+<a href='https://urbit.org/docs/reference/library/2j.md#put-ju'><code>+-put:ju</code></a>
+<a href='https://urbit.org/docs/reference/library/2k.md#put-to'><code>+-put:to</code></a>
 
 ### q
 
-[`++qad:yo`](@/docs/reference/library/3c.md#qad-yo)
-[`++qeb:ab`](@/docs/reference/library/4j.md#qeb-ab)
-[`++qeu`](@/docs/reference/library/2o.md#qeu)
-[`++qex:ab`](@/docs/reference/library/4j.md#qex-ab)
-[`++qib:ab`](@/docs/reference/library/4j.md#qib-ab)
-[`++qit`](@/docs/reference/library/4i.md#qit)
-[`++qix:ab`](@/docs/reference/library/4j.md#qix-ab)
-[`++quip`](@/docs/reference/library/1c.md#quip)
-[`++qut`](@/docs/reference/library/4i.md#qut)
+<a href='https://urbit.org/docs/reference/library/3c.md#qad-yo'><code>++qad:yo</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#qeb-ab'><code>++qeb:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/2o.md#qeu'><code>++qeu</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#qex-ab'><code>++qex:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#qib-ab'><code>++qib:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#qit'><code>++qit</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#qix-ab'><code>++qix:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/1c.md#quip'><code>++quip</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#qut'><code>++qut</code></a>
 
 ### r
 
-[`++r:at`](@/docs/reference/library/4b.md#r-at)
-[`++rad:og`](@/docs/reference/library/3d.md#rad-og)
-[`++rads:og`](@/docs/reference/library/3d.md#rads-og)
-[`++raku:ob`](@/docs/reference/library/3f.md#raku-ob)
-[`++ram:re`](@/docs/reference/library/4c.md#ram-re)
-[`++rap`](@/docs/reference/library/2c.md#rap)
-[`++rash`](@/docs/reference/library/4g.md#rash)
-[`++rau:fl`](@/docs/reference/library/3b.md#rau-fl)
-[`++raw:og`](@/docs/reference/library/3d.md#raw-og)
-[`++raws:og`](@/docs/reference/library/3d.md#raws-og)
-[`++re`](@/docs/reference/library/4c.md#re)
-[`++rear:co`](@/docs/reference/library/4k.md#rear-co)
-[`++reap`](@/docs/reference/library/2b.md#reap)
-[`++reel`](@/docs/reference/library/2b.md#reel)
-[`++rem:si`](@/docs/reference/library/3a.md#rem-si)
-[`++rend:co`](@/docs/reference/library/4k.md#rend-co)
-[`++rent:co`](@/docs/reference/library/4k.md#rent-co)
-[`++rep`](@/docs/reference/library/2c.md#rep)
-[`+-rep:by`](@/docs/reference/library/2i.md#rep-by)
-[`+-rep:in`](@/docs/reference/library/2h.md#rep-in)
-[`++rf:at`](@/docs/reference/library/4b.md#rf-at)
-[`+-rib:by`](@/docs/reference/library/2i.md#rib-by)
-[`++rig:re`](@/docs/reference/library/4c.md#rig-re)
-[`++rip`](@/docs/reference/library/2c.md#rip)
-[`++rn:at`](@/docs/reference/library/4b.md#rn-at)
-[`++rol:fe`](@/docs/reference/library/2c.md#rol-fe)
-[`++roll`](@/docs/reference/library/2b.md#roll)
-`++rood`
-[`++ror:fe`](@/docs/reference/library/2c.md#ror-fe)
-[`++rou:fl`](@/docs/reference/library/3b.md#rou-fl)
-[`++royl:so`](@/docs/reference/library/4l.md#royl-so)
-[`++royl-cell:so`](@/docs/reference/library/4l.md#royl-cell-so)
-[`++rsh`](@/docs/reference/library/2c.md#rsh)
-[`++rt:at`](@/docs/reference/library/4b.md#rt-at)
-[`++rta:at`](@/docs/reference/library/4b.md#rta-at)
-[`++rtam:at`](@/docs/reference/library/4b.md#rtam-at)
-[`++rub`](@/docs/reference/library/2p.md#rub)
-[`++rub:at`](@/docs/reference/library/4b.md#rub-at)
-[`++rud:at`](@/docs/reference/library/4b.md#rud-at)
-[`++rule`](@/docs/reference/library/3g.md#rule)
-[`++rum:at`](@/docs/reference/library/4b.md#rum-at)
-[`+-run:by`](@/docs/reference/library/2i.md#run-by)
-[`+-run:in`](@/docs/reference/library/2h.md#run-in)
-[`++rund:ob`](@/docs/reference/library/3f.md#rund-ob)
-[`++runt`](@/docs/reference/library/4b.md#runt)
-[`++rup:at`](@/docs/reference/library/4b.md#rup-at)
-[`++rush`](@/docs/reference/library/4g.md#rush)
-[`++rust`](@/docs/reference/library/4g.md#rust)
-[`+-rut:by`](@/docs/reference/library/2i.md#rut-by)
-[`++ruv:at`](@/docs/reference/library/4b.md#ruv-at)
-[`++rux:at`](@/docs/reference/library/4b.md#rux-at)
-[`++rynd:ob`](@/docs/reference/library/3f.md#rynd-ob)
+<a href='https://urbit.org/docs/reference/library/4b.md#r-at'><code>++r:at</code></a>
+<a href='https://urbit.org/docs/reference/library/3d.md#rad-og'><code>++rad:og</code></a>
+<a href='https://urbit.org/docs/reference/library/3d.md#rads-og'><code>++rads:og</code></a>
+<a href='https://urbit.org/docs/reference/library/3f.md#raku-ob'><code>++raku:ob</code></a>
+<a href='https://urbit.org/docs/reference/library/4c.md#ram-re'><code>++ram:re</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#rap'><code>++rap</code></a>
+<a href='https://urbit.org/docs/reference/library/4g.md#rash'><code>++rash</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#rau-fl'><code>++rau:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3d.md#raw-og'><code>++raw:og</code></a>
+<a href='https://urbit.org/docs/reference/library/3d.md#raws-og'><code>++raws:og</code></a>
+<a href='https://urbit.org/docs/reference/library/4c.md#re'><code>++re</code></a>
+<a href='https://urbit.org/docs/reference/library/4k.md#rear-co'><code>++rear:co</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#reap'><code>++reap</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#reel'><code>++reel</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#rem-si'><code>++rem:si</code></a>
+<a href='https://urbit.org/docs/reference/library/4k.md#rend-co'><code>++rend:co</code></a>
+<a href='https://urbit.org/docs/reference/library/4k.md#rent-co'><code>++rent:co</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#rep'><code>++rep</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#rep-by'><code>+-rep:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#rep-in'><code>+-rep:in</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#rf-at'><code>++rf:at</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#rib-by'><code>+-rib:by</code></a>
+<a href='https://urbit.org/docs/reference/library/4c.md#rig-re'><code>++rig:re</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#rip'><code>++rip</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#rn-at'><code>++rn:at</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#rol-fe'><code>++rol:fe</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#roll'><code>++roll</code></a>
+<code>++rood</code>
+<a href='https://urbit.org/docs/reference/library/2c.md#ror-fe'><code>++ror:fe</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#rou-fl'><code>++rou:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/4l.md#royl-so'><code>++royl:so</code></a>
+<a href='https://urbit.org/docs/reference/library/4l.md#royl-cell-so'><code>++royl-cell:so</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#rsh'><code>++rsh</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#rt-at'><code>++rt:at</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#rta-at'><code>++rta:at</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#rtam-at'><code>++rtam:at</code></a>
+<a href='https://urbit.org/docs/reference/library/2p.md#rub'><code>++rub</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#rub-at'><code>++rub:at</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#rud-at'><code>++rud:at</code></a>
+<a href='https://urbit.org/docs/reference/library/3g.md#rule'><code>++rule</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#rum-at'><code>++rum:at</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#run-by'><code>+-run:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#run-in'><code>+-run:in</code></a>
+<a href='https://urbit.org/docs/reference/library/3f.md#rund-ob'><code>++rund:ob</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#runt'><code>++runt</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#rup-at'><code>++rup:at</code></a>
+<a href='https://urbit.org/docs/reference/library/4g.md#rush'><code>++rush</code></a>
+<a href='https://urbit.org/docs/reference/library/4g.md#rust'><code>++rust</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#rut-by'><code>+-rut:by</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#ruv-at'><code>++ruv:at</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#rux-at'><code>++rux:at</code></a>
+<a href='https://urbit.org/docs/reference/library/3f.md#rynd-ob'><code>++rynd:ob</code></a>
 
 ### s
 
-[`++same`](@/docs/reference/library/2n.md#same)
-[`++san:ff`](@/docs/reference/library/3b.md#san-ff)
-[`++san:fl`](@/docs/reference/library/3b.md#san-fl)
-[`++san:rd`](@/docs/reference/library/3b.md#san-rd)
-[`++san:rh`](@/docs/reference/library/3b.md#san-rh)
-[`++san:rs`](@/docs/reference/library/3b.md#san-rs)
-[`++san:rq`](@/docs/reference/library/3b.md#san-rq)
-[`++sand`](@/docs/reference/library/4b.md#sand)
-[`++sane`](@/docs/reference/library/4b.md#sane)
-[`++sb:ff`](@/docs/reference/library/3b.md#sb-ff)
-[`++scag`](@/docs/reference/library/2b.md#scag)
-[`++scan`](@/docs/reference/library/4g.md#scan)
-[`++scot`](@/docs/reference/library/4m.md#scot)
-[`++scow`](@/docs/reference/library/4m.md#scow)
-[`++sea:ff`](@/docs/reference/library/3b.md#sea-ff)
-[`++sea:rd`](@/docs/reference/library/3b.md#sea-rd)
-[`++sea:rh`](@/docs/reference/library/3b.md#sea-rh)
-[`++sea:rs`](@/docs/reference/library/3b.md#sea-rs)
-[`++sea:rq`](@/docs/reference/library/3b.md#sea-rq)
-[`++sear`](@/docs/reference/library/4f.md#sear)
-[`++seb:ab`](@/docs/reference/library/4j.md#seb-ab)
-[`++sed:ab`](@/docs/reference/library/4j.md#sed-ab)
-[`++sel`](@/docs/reference/library/4h.md#sel)
-[`++sem`](@/docs/reference/library/4h.md#sem)
-[`++ser`](@/docs/reference/library/4h.md#ser)
-[`++set`](@/docs/reference/library/2o.md#set)
-[`++sev:ab`](@/docs/reference/library/4j.md#sev-ab)
-[`++sew:ab`](@/docs/reference/library/4j.md#sew-ab)
-[`++sex:ab`](@/docs/reference/library/4j.md#sex-ab)
-[`++sfix`](@/docs/reference/library/4e.md#sfix)
-[`++shad`](@/docs/reference/library/3d.md#shad)
-[`++shaf`](@/docs/reference/library/3d.md#shaf)
-[`++shal`](@/docs/reference/library/3d.md#shal)
-[`++sham`](@/docs/reference/library/3d.md#sham)
-[`++shan`](@/docs/reference/library/3d.md#shan)
-[`++shas`](@/docs/reference/library/3d.md#shas)
-[`++shaw`](@/docs/reference/library/3d.md#shaw)
-[`++shax`](@/docs/reference/library/3d.md#shax)
-[`++shay`](@/docs/reference/library/3d.md#shay)
-[`++shaz`](@/docs/reference/library/3d.md#shaz)
-[`++shep`](@/docs/reference/library/4c.md#shep)
-[`++shf:fl`](@/docs/reference/library/3b.md#shf-fl)
-[`++shim`](@/docs/reference/library/4f.md#shim)
-[`++shop`](@/docs/reference/library/4c.md#shop)
-[`++show`](@/docs/reference/library/4c.md#show)
-[`++si`](@/docs/reference/library/3a.md#si)
-[`++si:nl`](@/docs/reference/library/2m.md#si-nl)
-[`++sib:ab`](@/docs/reference/library/4j.md#sib-ab)
-[`++sid:ab`](@/docs/reference/library/4j.md#sid-ab)
-[`++sig`](@/docs/reference/library/4h.md#sig)
-[`++sig:ff`](@/docs/reference/library/3b.md#sig-ff)
-[`++sig:rd`](@/docs/reference/library/3b.md#sig-rd)
-[`++sig:rh`](@/docs/reference/library/3b.md#sig-rh)
-[`++sig:rs`](@/docs/reference/library/3b.md#sig-rs)
-[`++sig:rq`](@/docs/reference/library/3b.md#sig-rq)
-[`++silt`](@/docs/reference/library/2l.md#silt)
-[`++simu`](@/docs/reference/library/4e.md#simu)
-[`++sit:fe`](@/docs/reference/library/2c.md#sit-fe)
-[`++sit:fo`](@/docs/reference/library/3a.md#sit-fo)
-[`++siv:ab`](@/docs/reference/library/4j.md#siv-ab)
-[`++siw:ab`](@/docs/reference/library/4j.md#siw-ab)
-[`++six:ab`](@/docs/reference/library/4j.md#six-ab)
-[`++skid`](@/docs/reference/library/2b.md#skid)
-[`++skim`](@/docs/reference/library/2b.md#skim)
-[`++skip`](@/docs/reference/library/2b.md#skip)
-[`++slag`](@/docs/reference/library/2b.md#slag)
-[`++slat`](@/docs/reference/library/4m.md#slat)
-[`++slav`](@/docs/reference/library/4m.md#slav)
-[`++slaw`](@/docs/reference/library/4m.md#slaw)
-[`++slay`](@/docs/reference/library/4m.md#slay)
-[`++slog`](@/docs/reference/library/2n.md#slog)
-[`++slug`](@/docs/reference/library/4f.md#slug)
-[`++smyt`](@/docs/reference/library/4m.md#smyt)
-[`++snag`](@/docs/reference/library/2b.md#snag)
-[`++snag:nl`](@/docs/reference/library/2m.md#snag-nl)
-[`++snoc`](@/docs/reference/library/2b.md#snoc)
-[`++so`](@/docs/reference/library/4l.md#so)
-[`++soft`](@/docs/reference/library/2n.md#soft)
-[`++some`](@/docs/reference/library/2a.md#some)
-[`++soq`](@/docs/reference/library/4h.md#soq)
-[`++sort`](@/docs/reference/library/2b.md#sort)
-[`++sov:ab`](@/docs/reference/library/4j.md#sov-ab)
-[`++sow:ab`](@/docs/reference/library/4j.md#sow-ab)
-[`++sox:ab`](@/docs/reference/library/4j.md#sox-ab)
-[`++soz`](@/docs/reference/library/4i.md#soz)
-[`++span`](@/docs/reference/library/4o.md#span)
-[`++spat`](@/docs/reference/library/4m.md#spat)
-[`++spd:fl`](@/docs/reference/library/3b.md#spd-fl)
-[`++spin`](@/docs/reference/library/2b.md#spin)
-[`++spn:fl`](@/docs/reference/library/3b.md#spn-fl)
-[`++spot`](@/docs/reference/library/3g.md#spot)
-[`++spud`](@/docs/reference/library/4m.md#spud)
-[`++spun`](@/docs/reference/library/2b.md#spun)
-[`++sqt`](@/docs/reference/library/2g.md#sqt)
-[`++sqt:ff`](@/docs/reference/library/3b.md#sqt-ff)
-[`++sqt:fl`](@/docs/reference/library/3b.md#sqt-fl)
-[`++sqt:rd`](@/docs/reference/library/3b.md#sqt-rd)
-[`++sqt:rh`](@/docs/reference/library/3b.md#sqt-rh)
-[`++sqt:rs`](@/docs/reference/library/3b.md#sqt-rs)
-[`++sqt:rq`](@/docs/reference/library/3b.md#sqt-rq)
-[`++stab`](@/docs/reference/library/4m.md#stab)
-[`++stag`](@/docs/reference/library/4f.md#stag)
-[`++star`](@/docs/reference/library/4f.md#star)
-[`++stet`](@/docs/reference/library/4f.md#stet)
-[`++stew`](@/docs/reference/library/4f.md#stew)
-[`++stir`](@/docs/reference/library/4f.md#stir)
-[`++stun`](@/docs/reference/library/4f.md#stun)
-[`++sub`](@/docs/reference/library/1a.md#sub)
-[`++sub:ff`](@/docs/reference/library/3b.md#sub-ff)
-[`++sub:fl`](@/docs/reference/library/3b.md#sub-fl)
-[`++sub:rd`](@/docs/reference/library/3b.md#sub-rd)
-[`++sub:rh`](@/docs/reference/library/3b.md#sub-rh)
-[`++sub:rs`](@/docs/reference/library/3b.md#sub-rs)
-[`++sub:rq`](@/docs/reference/library/3b.md#sub-rq)
-[`++sum:fe`](@/docs/reference/library/2c.md#sum-fe)
-[`++sum:fo`](@/docs/reference/library/3a.md#sum-fo)
-[`++sum:si`](@/docs/reference/library/3a.md#sum-si)
-[`++sun:ff`](@/docs/reference/library/3b.md#sun-ff)
-[`++sun:fl`](@/docs/reference/library/3b.md#sun-fl)
-[`++sun:rd`](@/docs/reference/library/3b.md#sun-rd)
-[`++sun:rh`](@/docs/reference/library/3b.md#sun-rh)
-[`++sun:rs`](@/docs/reference/library/3b.md#sun-rs)
-[`++sun:rq`](@/docs/reference/library/3b.md#sun-rq)
-[`++sun:si`](@/docs/reference/library/3a.md#sun-si)
-[`++swag`](@/docs/reference/library/2b.md#swag)
-[`++swp`](@/docs/reference/library/2c.md#swp)
-[`++swr:fl`](@/docs/reference/library/3b.md#swr-fl)
-[`++sy`](@/docs/reference/library/2m.md#sy)
-[`++sym`](@/docs/reference/library/4i.md#sym)
-[`++syn:fl`](@/docs/reference/library/3b.md#syn-fl)
-[`++syn:si`](@/docs/reference/library/3a.md#syn-si)
+<a href='https://urbit.org/docs/reference/library/2n.md#same'><code>++same</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#san-ff'><code>++san:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#san-fl'><code>++san:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#san-rd'><code>++san:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#san-rh'><code>++san:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#san-rs'><code>++san:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#san-rq'><code>++san:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#sand'><code>++sand</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#sane'><code>++sane</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sb-ff'><code>++sb:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#scag'><code>++scag</code></a>
+<a href='https://urbit.org/docs/reference/library/4g.md#scan'><code>++scan</code></a>
+<a href='https://urbit.org/docs/reference/library/4m.md#scot'><code>++scot</code></a>
+<a href='https://urbit.org/docs/reference/library/4m.md#scow'><code>++scow</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sea-ff'><code>++sea:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sea-rd'><code>++sea:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sea-rh'><code>++sea:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sea-rs'><code>++sea:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sea-rq'><code>++sea:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#sear'><code>++sear</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#seb-ab'><code>++seb:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#sed-ab'><code>++sed:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#sel'><code>++sel</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#sem'><code>++sem</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#ser'><code>++ser</code></a>
+<a href='https://urbit.org/docs/reference/library/2o.md#set'><code>++set</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#sev-ab'><code>++sev:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#sew-ab'><code>++sew:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#sex-ab'><code>++sex:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4e.md#sfix'><code>++sfix</code></a>
+<a href='https://urbit.org/docs/reference/library/3d.md#shad'><code>++shad</code></a>
+<a href='https://urbit.org/docs/reference/library/3d.md#shaf'><code>++shaf</code></a>
+<a href='https://urbit.org/docs/reference/library/3d.md#shal'><code>++shal</code></a>
+<a href='https://urbit.org/docs/reference/library/3d.md#sham'><code>++sham</code></a>
+<a href='https://urbit.org/docs/reference/library/3d.md#shan'><code>++shan</code></a>
+<a href='https://urbit.org/docs/reference/library/3d.md#shas'><code>++shas</code></a>
+<a href='https://urbit.org/docs/reference/library/3d.md#shaw'><code>++shaw</code></a>
+<a href='https://urbit.org/docs/reference/library/3d.md#shax'><code>++shax</code></a>
+<a href='https://urbit.org/docs/reference/library/3d.md#shay'><code>++shay</code></a>
+<a href='https://urbit.org/docs/reference/library/3d.md#shaz'><code>++shaz</code></a>
+<a href='https://urbit.org/docs/reference/library/4c.md#shep'><code>++shep</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#shf-fl'><code>++shf:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#shim'><code>++shim</code></a>
+<a href='https://urbit.org/docs/reference/library/4c.md#shop'><code>++shop</code></a>
+<a href='https://urbit.org/docs/reference/library/4c.md#show'><code>++show</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#si'><code>++si</code></a>
+<a href='https://urbit.org/docs/reference/library/2m.md#si-nl'><code>++si:nl</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#sib-ab'><code>++sib:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#sid-ab'><code>++sid:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#sig'><code>++sig</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sig-ff'><code>++sig:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sig-rd'><code>++sig:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sig-rh'><code>++sig:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sig-rs'><code>++sig:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sig-rq'><code>++sig:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/2l.md#silt'><code>++silt</code></a>
+<a href='https://urbit.org/docs/reference/library/4e.md#simu'><code>++simu</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#sit-fe'><code>++sit:fe</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#sit-fo'><code>++sit:fo</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#siv-ab'><code>++siv:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#siw-ab'><code>++siw:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#six-ab'><code>++six:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#skid'><code>++skid</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#skim'><code>++skim</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#skip'><code>++skip</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#slag'><code>++slag</code></a>
+<a href='https://urbit.org/docs/reference/library/4m.md#slat'><code>++slat</code></a>
+<a href='https://urbit.org/docs/reference/library/4m.md#slav'><code>++slav</code></a>
+<a href='https://urbit.org/docs/reference/library/4m.md#slaw'><code>++slaw</code></a>
+<a href='https://urbit.org/docs/reference/library/4m.md#slay'><code>++slay</code></a>
+<a href='https://urbit.org/docs/reference/library/2n.md#slog'><code>++slog</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#slug'><code>++slug</code></a>
+<a href='https://urbit.org/docs/reference/library/4m.md#smyt'><code>++smyt</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#snag'><code>++snag</code></a>
+<a href='https://urbit.org/docs/reference/library/2m.md#snag-nl'><code>++snag:nl</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#snoc'><code>++snoc</code></a>
+<a href='https://urbit.org/docs/reference/library/4l.md#so'><code>++so</code></a>
+<a href='https://urbit.org/docs/reference/library/2n.md#soft'><code>++soft</code></a>
+<a href='https://urbit.org/docs/reference/library/2a.md#some'><code>++some</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#soq'><code>++soq</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#sort'><code>++sort</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#sov-ab'><code>++sov:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#sow-ab'><code>++sow:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#sox-ab'><code>++sox:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#soz'><code>++soz</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#span'><code>++span</code></a>
+<a href='https://urbit.org/docs/reference/library/4m.md#spat'><code>++spat</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#spd-fl'><code>++spd:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#spin'><code>++spin</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#spn-fl'><code>++spn:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3g.md#spot'><code>++spot</code></a>
+<a href='https://urbit.org/docs/reference/library/4m.md#spud'><code>++spud</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#spun'><code>++spun</code></a>
+<a href='https://urbit.org/docs/reference/library/2g.md#sqt'><code>++sqt</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sqt-ff'><code>++sqt:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sqt-fl'><code>++sqt:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sqt-rd'><code>++sqt:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sqt-rh'><code>++sqt:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sqt-rs'><code>++sqt:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sqt-rq'><code>++sqt:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/4m.md#stab'><code>++stab</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#stag'><code>++stag</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#star'><code>++star</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#stet'><code>++stet</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#stew'><code>++stew</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#stir'><code>++stir</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#stun'><code>++stun</code></a>
+<a href='https://urbit.org/docs/reference/library/1a.md#sub'><code>++sub</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sub-ff'><code>++sub:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sub-fl'><code>++sub:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sub-rd'><code>++sub:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sub-rh'><code>++sub:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sub-rs'><code>++sub:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sub-rq'><code>++sub:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#sum-fe'><code>++sum:fe</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#sum-fo'><code>++sum:fo</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#sum-si'><code>++sum:si</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sun-ff'><code>++sun:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sun-fl'><code>++sun:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sun-rd'><code>++sun:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sun-rh'><code>++sun:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sun-rs'><code>++sun:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sun-rq'><code>++sun:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#sun-si'><code>++sun:si</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#swag'><code>++swag</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#swp'><code>++swp</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#swr-fl'><code>++swr:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/2m.md#sy'><code>++sy</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#sym'><code>++sym</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#syn-fl'><code>++syn:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#syn-si'><code>++syn:si</code></a>
 
 ### t
 
-[`++tail`](@/docs/reference/library/2n.md#tail)
-[`+-tap:to`](@/docs/reference/library/2k.md#tap-to)
-[`++tar`](@/docs/reference/library/4h.md#tar)
-[`++tang`](@/docs/reference/library/2q.md#tang)
-[`++tank`](@/docs/reference/library/2q.md#tank)
-[`+-tap:by`](@/docs/reference/library/2i.md#tap-by)
-[`+-tap:in`](@/docs/reference/library/2h.md#tap-in)
-[`++tape`](@/docs/reference/library/2q.md#tape)
-[`++tarp`](@/docs/reference/library/2q.md#tarp)
-[`++tash:so`](@/docs/reference/library/4l.md#tash-so)
-[`++tec`](@/docs/reference/library/4h.md#tec)
-[`++ted:ab`](@/docs/reference/library/4j.md#ted-ab)
-[`++teff`](@/docs/reference/library/4b.md#teff)
-[`++teil:ob`](@/docs/reference/library/3f.md#teil-ob)
-[`++term`](@/docs/reference/library/2q.md#term)
-[`++test`](@/docs/reference/library/2n.md#test)
-[`++tid:ab`](@/docs/reference/library/4j.md#tid-ab)
-[`++tiki`](@/docs/reference/library/4o.md#tiki)
-[`++til:ab`](@/docs/reference/library/4j.md#til-ab)
-[`++tip:ab`](@/docs/reference/library/4j.md#tip-ab)
-[`++tiq:ab`](@/docs/reference/library/4j.md#tiq-ab)
-[`++tis`](@/docs/reference/library/4h.md#tis)
-[`++to`](@/docs/reference/library/2k.md#to)
-[`++tod:po`](@/docs/reference/library/4a.md#tod-po)
-[`++toga`](@/docs/reference/library/4o.md#toga)
-[`++toi:ff`](@/docs/reference/library/3b.md#toi-ff)
-[`++toi:fl`](@/docs/reference/library/3b.md#toi-fl)
-[`++toi:rd`](@/docs/reference/library/3b.md#toi-rd)
-[`++toi:rh`](@/docs/reference/library/3b.md#toi-rh)
-[`++toi:rs`](@/docs/reference/library/3b.md#toi-rs)
-[`++toi:rq`](@/docs/reference/library/3b.md#toi-rq)
-[`++toj:fl`](@/docs/reference/library/3b.md#toj-fl)
-[`++tone`](@/docs/reference/library/3g.md#tone)
-[`++toon`](@/docs/reference/library/3g.md#toon)
-[`+-top:to`](@/docs/reference/library/2k.md#top-to)
-[`++tos:po`](@/docs/reference/library/4a.md#tos-po)
-[`++tos:rh`](@/docs/reference/library/3b.md#tos-rh)
-[`++trap`](@/docs/reference/library/1c.md#trap)
-[`++tree`](@/docs/reference/library/1c.md#tree)
-[`++trel`](@/docs/reference/library/1c.md#trel)
-[`++trim`](@/docs/reference/library/4b.md#trim)
-[`++trip`](@/docs/reference/library/4b.md#trip)
-[`++tuba`](@/docs/reference/library/4b.md#tuba)
-[`++tufa`](@/docs/reference/library/4b.md#tufa)
-[`++tuna`](@/docs/reference/library/4o.md#tuna)
-[`++tuft`](@/docs/reference/library/4b.md#tuft)
-[`++turf`](@/docs/reference/library/4b.md#turf)
-[`++turn`](@/docs/reference/library/2b.md#turn)
-[`++tusk`](@/docs/reference/library/4o.md#tusk)
-[`++twid:so`](@/docs/reference/library/4l.md#twid-so)
-[`++tyke`](@/docs/reference/library/4o.md#tyke)
-[`++typo`](@/docs/reference/library/4o.md#typo)
-[`++tyre`](@/docs/reference/library/4o.md#tyre)
+<a href='https://urbit.org/docs/reference/library/2n.md#tail'><code>++tail</code></a>
+<a href='https://urbit.org/docs/reference/library/2k.md#tap-to'><code>+-tap:to</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#tar'><code>++tar</code></a>
+<a href='https://urbit.org/docs/reference/library/2q.md#tang'><code>++tang</code></a>
+<a href='https://urbit.org/docs/reference/library/2q.md#tank'><code>++tank</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#tap-by'><code>+-tap:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#tap-in'><code>+-tap:in</code></a>
+<a href='https://urbit.org/docs/reference/library/2q.md#tape'><code>++tape</code></a>
+<a href='https://urbit.org/docs/reference/library/2q.md#tarp'><code>++tarp</code></a>
+<a href='https://urbit.org/docs/reference/library/4l.md#tash-so'><code>++tash:so</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#tec'><code>++tec</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#ted-ab'><code>++ted:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#teff'><code>++teff</code></a>
+<a href='https://urbit.org/docs/reference/library/3f.md#teil-ob'><code>++teil:ob</code></a>
+<a href='https://urbit.org/docs/reference/library/2q.md#term'><code>++term</code></a>
+<a href='https://urbit.org/docs/reference/library/2n.md#test'><code>++test</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#tid-ab'><code>++tid:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#tiki'><code>++tiki</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#til-ab'><code>++til:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#tip-ab'><code>++tip:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#tiq-ab'><code>++tiq:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#tis'><code>++tis</code></a>
+<a href='https://urbit.org/docs/reference/library/2k.md#to'><code>++to</code></a>
+<a href='https://urbit.org/docs/reference/library/4a.md#tod-po'><code>++tod:po</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#toga'><code>++toga</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#toi-ff'><code>++toi:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#toi-fl'><code>++toi:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#toi-rd'><code>++toi:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#toi-rh'><code>++toi:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#toi-rs'><code>++toi:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#toi-rq'><code>++toi:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#toj-fl'><code>++toj:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3g.md#tone'><code>++tone</code></a>
+<a href='https://urbit.org/docs/reference/library/3g.md#toon'><code>++toon</code></a>
+<a href='https://urbit.org/docs/reference/library/2k.md#top-to'><code>+-top:to</code></a>
+<a href='https://urbit.org/docs/reference/library/4a.md#tos-po'><code>++tos:po</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#tos-rh'><code>++tos:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/1c.md#trap'><code>++trap</code></a>
+<a href='https://urbit.org/docs/reference/library/1c.md#tree'><code>++tree</code></a>
+<a href='https://urbit.org/docs/reference/library/1c.md#trel'><code>++trel</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#trim'><code>++trim</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#trip'><code>++trip</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#tuba'><code>++tuba</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#tufa'><code>++tufa</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#tuna'><code>++tuna</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#tuft'><code>++tuft</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#turf'><code>++turf</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#turn'><code>++turn</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#tusk'><code>++tusk</code></a>
+<a href='https://urbit.org/docs/reference/library/4l.md#twid-so'><code>++twid:so</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#tyke'><code>++tyke</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#typo'><code>++typo</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#tyre'><code>++tyre</code></a>
 
 ### u
 
-[`++un`](@/docs/reference/library/3f.md#un)
-[`+-uni:by`](@/docs/reference/library/2i.md#uni-by)
-[`++uni:fl`](@/docs/reference/library/3b.md#uni-fl)
-[`+-uni:in`](@/docs/reference/library/2h.md#uni-in)
-[`++unit`](@/docs/reference/library/1c.md#unit)
-[`+-urn:by`](@/docs/reference/library/2i.md#urn-by)
-[`++urs:ab`](@/docs/reference/library/4j.md#urs-ab)
-[`++urt:ab`](@/docs/reference/library/4j.md#urt-ab)
+<a href='https://urbit.org/docs/reference/library/3f.md#un'><code>++un</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#uni-by'><code>+-uni:by</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#uni-fl'><code>++uni:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#uni-in'><code>+-uni:in</code></a>
+<a href='https://urbit.org/docs/reference/library/1c.md#unit'><code>++unit</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#urn-by'><code>+-urn:by</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#urs-ab'><code>++urs:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#urt-ab'><code>++urt:ab</code></a>
 
 ### v
 
-[`++v:ne`](@/docs/reference/library/4j.md#v-ne)
-`++vang`
-[`++vase`](@/docs/reference/library/4o.md#vase)
-`++vast`
-[`++ven`](@/docs/reference/library/4i.md#ven)
-[`++vise`](@/docs/reference/library/4o.md#vise)
-[`++vit`](@/docs/reference/library/4i.md#vit)
-[`++viz:ag`](@/docs/reference/library/4j.md#viz-ag)
-[`++vor`](@/docs/reference/library/2f.md#vor)
-[`++voy:ab`](@/docs/reference/library/4j.md#voy-ab)
-[`++vul`](@/docs/reference/library/4i.md#vul)
-[`++vum:ag`](@/docs/reference/library/4j.md#vum-ag)
+<a href='https://urbit.org/docs/reference/library/4j.md#v-ne'><code>++v:ne</code></a>
+<code>++vang</code>
+<a href='https://urbit.org/docs/reference/library/4o.md#vase'><code>++vase</code></a>
+<code>++vast</code>
+<a href='https://urbit.org/docs/reference/library/4i.md#ven'><code>++ven</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#vise'><code>++vise</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#vit'><code>++vit</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#viz-ag'><code>++viz:ag</code></a>
+<a href='https://urbit.org/docs/reference/library/2f.md#vor'><code>++vor</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#voy-ab'><code>++voy:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#vul'><code>++vul</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#vum-ag'><code>++vum:ag</code></a>
 
 ### w
 
-[`++w:ne`](@/docs/reference/library/4j.md#w-ne)
-[`++wack`](@/docs/reference/library/4b.md#wack)
-[`++wain`](@/docs/reference/library/2q.md#wain)
-[`++wall`](@/docs/reference/library/2q.md#wall)
-[`++weld`](@/docs/reference/library/2b.md#weld)
-[`++weld:nl`](@/docs/reference/library/2m.md#weld-nl)
-[`++welp`](@/docs/reference/library/2b.md#welp)
-[`++wick`](@/docs/reference/library/4b.md#wick)
-[`++wig:re`](@/docs/reference/library/4c.md#wig-re)
-[`++win:re`](@/docs/reference/library/4c.md#win-re)
-[`++wing`](@/docs/reference/library/4o.md#wing)
-[`++wiz:ag`](@/docs/reference/library/4j.md#wiz-ag)
-[`++woad`](@/docs/reference/library/4b.md#woad)
-[`++wood`](@/docs/reference/library/4b.md#wood)
-[`++wonk`](@/docs/reference/library/3g.md#wonk)
-[`++wred:un`](@/docs/reference/library/3f.md#wred-un)
-[`++wren:un`](@/docs/reference/library/3f.md#wren-un)
-[`++wut`](@/docs/reference/library/4h.md#wut)
-[`+-wyt:by`](@/docs/reference/library/2i.md#wyt-by)
-[`+-wyt:in`](@/docs/reference/library/2h.md#wyt-in)
+<a href='https://urbit.org/docs/reference/library/4j.md#w-ne'><code>++w:ne</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#wack'><code>++wack</code></a>
+<a href='https://urbit.org/docs/reference/library/2q.md#wain'><code>++wain</code></a>
+<a href='https://urbit.org/docs/reference/library/2q.md#wall'><code>++wall</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#weld'><code>++weld</code></a>
+<a href='https://urbit.org/docs/reference/library/2m.md#weld-nl'><code>++weld:nl</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#welp'><code>++welp</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#wick'><code>++wick</code></a>
+<a href='https://urbit.org/docs/reference/library/4c.md#wig-re'><code>++wig:re</code></a>
+<a href='https://urbit.org/docs/reference/library/4c.md#win-re'><code>++win:re</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#wing'><code>++wing</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#wiz-ag'><code>++wiz:ag</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#woad'><code>++woad</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#wood'><code>++wood</code></a>
+<a href='https://urbit.org/docs/reference/library/3g.md#wonk'><code>++wonk</code></a>
+<a href='https://urbit.org/docs/reference/library/3f.md#wred-un'><code>++wred:un</code></a>
+<a href='https://urbit.org/docs/reference/library/3f.md#wren-un'><code>++wren:un</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#wut'><code>++wut</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#wyt-by'><code>+-wyt:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#wyt-in'><code>+-wyt:in</code></a>
 
 ### x
 
-[`++x:ne`](@/docs/reference/library/4j.md#x-ne)
-[`++xeb`](@/docs/reference/library/2c.md#xeb)
-[`++xpd:fl`](@/docs/reference/library/3b.md#xpd-fl)
+<a href='https://urbit.org/docs/reference/library/4j.md#x-ne'><code>++x:ne</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#xeb'><code>++xeb</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#xpd-fl'><code>++xpd:fl</code></a>
 
 ### y
 
-[`++yall`](@/docs/reference/library/3c.md#yall)
-[`++yawn`](@/docs/reference/library/3c.md#yawn)
-[`++year`](@/docs/reference/library/3c.md#year)
-[`++yell`](@/docs/reference/library/3c.md#yell)
-[`++yelp`](@/docs/reference/library/3c.md#yelp)
-[`++yer:yo`](@/docs/reference/library/3c.md#yer-yo)
-[`++yo`](@/docs/reference/library/3c.md#yo)
-[`++yore`](@/docs/reference/library/3c.md#yore)
-[`++yule`](@/docs/reference/library/3c.md#yule)
+<a href='https://urbit.org/docs/reference/library/3c.md#yall'><code>++yall</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#yawn'><code>++yawn</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#year'><code>++year</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#yell'><code>++yell</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#yelp'><code>++yelp</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#yer-yo'><code>++yer:yo</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#yo'><code>++yo</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#yore'><code>++yore</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#yule'><code>++yule</code></a>
 
 ### z
 
-[`++zaft:un`](@/docs/reference/library/3f.md#zaft-un)
-[`++zag:mu`](@/docs/reference/library/4j.md#zag-mu)
-[`++zap`](@/docs/reference/library/4h.md#zap)
-[`++zart:un`](@/docs/reference/library/3f.md#zart-un)
-[`++zer:fl`](@/docs/reference/library/3b.md#zer-fl)
-[`++zig:mu`](@/docs/reference/library/4j.md#zig-mu)
-[`++zing`](@/docs/reference/library/2b.md#zing)
-[`++zug:mu`](@/docs/reference/library/4j.md#zug-mu)
-[`++zust:so`](@/docs/reference/library/4l.md#zust-so)
-[`++zyft:un`](@/docs/reference/library/3f.md#zyft-un)
-[`++zyrt:un`](@/docs/reference/library/3f.md#zyrt-un)
+<a href='https://urbit.org/docs/reference/library/3f.md#zaft-un'><code>++zaft:un</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#zag-mu'><code>++zag:mu</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#zap'><code>++zap</code></a>
+<a href='https://urbit.org/docs/reference/library/3f.md#zart-un'><code>++zart:un</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#zer-fl'><code>++zer:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#zig-mu'><code>++zig:mu</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#zing'><code>++zing</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#zug-mu'><code>++zug:mu</code></a>
+<a href='https://urbit.org/docs/reference/library/4l.md#zust-so'><code>++zust:so</code></a>
+<a href='https://urbit.org/docs/reference/library/3f.md#zyft-un'><code>++zyft:un</code></a>
+<a href='https://urbit.org/docs/reference/library/3f.md#zyrt-un'><code>++zyrt:un</code></a>
 
 ## By Section
 
 ### 1a: basic arithmetic
 
-[`++add`](@/docs/reference/library/1a.md#add)
-[`++dec`](@/docs/reference/library/1a.md#dec)
-[`++div`](@/docs/reference/library/1a.md#div)
-[`++dvr`](@/docs/reference/library/1a.md#dvr)
-[`++gte`](@/docs/reference/library/1a.md#gte)
-[`++gth`](@/docs/reference/library/1a.md#gth)
-[`++lte`](@/docs/reference/library/1a.md#lte)
-[`++lth`](@/docs/reference/library/1a.md#lth)
-[`++max`](@/docs/reference/library/1a.md#max)
-[`++min`](@/docs/reference/library/1a.md#min)
-[`++mod`](@/docs/reference/library/1a.md#mod)
-[`++mul`](@/docs/reference/library/1a.md#mul)
-[`++sub`](@/docs/reference/library/1a.md#sub)
+<a href='https://urbit.org/docs/reference/library/1a.md#add' data-tippy-content="Add"><code>++add</code></a>
+<a href='https://urbit.org/docs/reference/library/1a.md#dec'><code>++dec</code></a>
+<a href='https://urbit.org/docs/reference/library/1a.md#div'><code>++div</code></a>
+<a href='https://urbit.org/docs/reference/library/1a.md#dvr'><code>++dvr</code></a>
+<a href='https://urbit.org/docs/reference/library/1a.md#gte'><code>++gte</code></a>
+<a href='https://urbit.org/docs/reference/library/1a.md#gth'><code>++gth</code></a>
+<a href='https://urbit.org/docs/reference/library/1a.md#lte'><code>++lte</code></a>
+<a href='https://urbit.org/docs/reference/library/1a.md#lth'><code>++lth</code></a>
+<a href='https://urbit.org/docs/reference/library/1a.md#max'><code>++max</code></a>
+<a href='https://urbit.org/docs/reference/library/1a.md#min'><code>++min</code></a>
+<a href='https://urbit.org/docs/reference/library/1a.md#mod'><code>++mod</code></a>
+<a href='https://urbit.org/docs/reference/library/1a.md#mul'><code>++mul</code></a>
+<a href='https://urbit.org/docs/reference/library/1a.md#sub'><code>++sub</code></a>
 
 ### 1b: tree addressing
 
-[`++cap`](@/docs/reference/library/1b.md#cap)
-[`++mas`](@/docs/reference/library/1b.md#mas)
-[`++peg`](@/docs/reference/library/1b.md#peg)
+<a href='https://urbit.org/docs/reference/library/1b.md#cap'><code>++cap</code></a>
+<a href='https://urbit.org/docs/reference/library/1b.md#mas'><code>++mas</code></a>
+<a href='https://urbit.org/docs/reference/library/1b.md#peg'><code>++peg</code></a>
 
 ### 1c: molds and mold builders
 
-[`++bloq`](@/docs/reference/library/1c.md#bloq)
-[`++each`](@/docs/reference/library/1c.md#each)
-[`++gate`](@/docs/reference/library/1c.md#gate)
-[`++list`](@/docs/reference/library/1c.md#list)
-[`++lone`](@/docs/reference/library/1c.md#lone)
-[`++pair`](@/docs/reference/library/1c.md#pair)
-[`++pole`](@/docs/reference/library/1c.md#pole)
-[`++quip`](@/docs/reference/library/1c.md#quip)
-[`++trap`](@/docs/reference/library/1c.md#trap)
-[`++tree`](@/docs/reference/library/1c.md#tree)
-[`++trel`](@/docs/reference/library/1c.md#trel)
-[`++unit`](@/docs/reference/library/1c.md#unit)
+<a href='https://urbit.org/docs/reference/library/1c.md#bloq'><code>++bloq</code></a>
+<a href='https://urbit.org/docs/reference/library/1c.md#each'><code>++each</code></a>
+<a href='https://urbit.org/docs/reference/library/1c.md#gate'><code>++gate</code></a>
+<a href='https://urbit.org/docs/reference/library/1c.md#list'><code>++list</code></a>
+<a href='https://urbit.org/docs/reference/library/1c.md#lone'><code>++lone</code></a>
+<a href='https://urbit.org/docs/reference/library/1c.md#pair'><code>++pair</code></a>
+<a href='https://urbit.org/docs/reference/library/1c.md#pole'><code>++pole</code></a>
+<a href='https://urbit.org/docs/reference/library/1c.md#quip'><code>++quip</code></a>
+<a href='https://urbit.org/docs/reference/library/1c.md#trap'><code>++trap</code></a>
+<a href='https://urbit.org/docs/reference/library/1c.md#tree'><code>++tree</code></a>
+<a href='https://urbit.org/docs/reference/library/1c.md#trel'><code>++trel</code></a>
+<a href='https://urbit.org/docs/reference/library/1c.md#unit'><code>++unit</code></a>
 
 ### 2a: unit logic
 
-[`++biff`](@/docs/reference/library/2a.md#biff)
-[`++bind`](@/docs/reference/library/2a.md#bind)
-[`++bond`](@/docs/reference/library/2a.md#bond)
-[`++both`](@/docs/reference/library/2a.md#both)
-[`++clap`](@/docs/reference/library/2a.md#clap)
-[`++drop`](@/docs/reference/library/2a.md#drop)
-[`++fall`](@/docs/reference/library/2a.md#fall)
-[`++lift`](@/docs/reference/library/2a.md#lift)
-[`++mate`](@/docs/reference/library/2a.md#mate)
-[`++need`](@/docs/reference/library/2a.md#need)
-[`++some`](@/docs/reference/library/2a.md#some)
+<a href='https://urbit.org/docs/reference/library/2a.md#biff'><code>++biff</code></a>
+<a href='https://urbit.org/docs/reference/library/2a.md#bind'><code>++bind</code></a>
+<a href='https://urbit.org/docs/reference/library/2a.md#bond'><code>++bond</code></a>
+<a href='https://urbit.org/docs/reference/library/2a.md#both'><code>++both</code></a>
+<a href='https://urbit.org/docs/reference/library/2a.md#clap'><code>++clap</code></a>
+<a href='https://urbit.org/docs/reference/library/2a.md#drop'><code>++drop</code></a>
+<a href='https://urbit.org/docs/reference/library/2a.md#fall'><code>++fall</code></a>
+<a href='https://urbit.org/docs/reference/library/2a.md#lift'><code>++lift</code></a>
+<a href='https://urbit.org/docs/reference/library/2a.md#mate'><code>++mate</code></a>
+<a href='https://urbit.org/docs/reference/library/2a.md#need'><code>++need</code></a>
+<a href='https://urbit.org/docs/reference/library/2a.md#some'><code>++some</code></a>
 
 ### 2b: list logic
 
-[`++fand`](@/docs/reference/library/2b.md#fand)
-[`++find`](@/docs/reference/library/2b.md#find)
-[`++flop`](@/docs/reference/library/2b.md#flop)
-[`++gulf`](@/docs/reference/library/2b.md#gulf)
-[`++homo`](@/docs/reference/library/2b.md#homo)
-[`++lent`](@/docs/reference/library/2b.md#lent)
-[`++levy`](@/docs/reference/library/2b.md#levy)
-[`++lien`](@/docs/reference/library/2b.md#lien)
-[`++limo`](@/docs/reference/library/2b.md#limo)
-[`++murn`](@/docs/reference/library/2b.md#murn)
-[`++oust`](@/docs/reference/library/2b.md#oust)
-[`++reap`](@/docs/reference/library/2b.md#reap)
-[`++reel`](@/docs/reference/library/2b.md#reel)
-[`++roll`](@/docs/reference/library/2b.md#roll)
-[`++scag`](@/docs/reference/library/2b.md#scag)
-[`++skid`](@/docs/reference/library/2b.md#skid)
-[`++skim`](@/docs/reference/library/2b.md#skim)
-[`++skip`](@/docs/reference/library/2b.md#skip)
-[`++slag`](@/docs/reference/library/2b.md#slag)
-[`++snag`](@/docs/reference/library/2b.md#snag)
-[`++snoc`](@/docs/reference/library/2b.md#snoc)
-[`++sort`](@/docs/reference/library/2b.md#sort)
-[`++spin`](@/docs/reference/library/2b.md#spin)
-[`++spun`](@/docs/reference/library/2b.md#spun)
-[`++swag`](@/docs/reference/library/2b.md#swag)
-[`++turn`](@/docs/reference/library/2b.md#turn)
-[`++weld`](@/docs/reference/library/2b.md#weld)
-[`++welp`](@/docs/reference/library/2b.md#welp)
-[`++zing`](@/docs/reference/library/2b.md#zing)
+<a href='https://urbit.org/docs/reference/library/2b.md#fand'><code>++fand</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#find'><code>++find</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#flop'><code>++flop</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#gulf'><code>++gulf</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#homo'><code>++homo</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#lent'><code>++lent</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#levy'><code>++levy</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#lien'><code>++lien</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#limo'><code>++limo</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#murn'><code>++murn</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#oust'><code>++oust</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#reap'><code>++reap</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#reel'><code>++reel</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#roll'><code>++roll</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#scag'><code>++scag</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#skid'><code>++skid</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#skim'><code>++skim</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#skip'><code>++skip</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#slag'><code>++slag</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#snag'><code>++snag</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#snoc'><code>++snoc</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#sort'><code>++sort</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#spin'><code>++spin</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#spun'><code>++spun</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#swag'><code>++swag</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#turn'><code>++turn</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#weld'><code>++weld</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#welp'><code>++welp</code></a>
+<a href='https://urbit.org/docs/reference/library/2b.md#zing'><code>++zing</code></a>
 
 ### 2c: bit arithmetic
 
-[`++fe`](@/docs/reference/library/2c.md#fe)
-[`++dif:fe`](@/docs/reference/library/2c.md#dif-fe)
-[`++inv:fe`](@/docs/reference/library/2c.md#inv-fe)
-[`++net:fe`](@/docs/reference/library/2c.md#net-fe)
-[`++out:fe`](@/docs/reference/library/2c.md#out-fe)
-[`++rol:fe`](@/docs/reference/library/2c.md#rol-fe)
-[`++ror:fe`](@/docs/reference/library/2c.md#ror-fe)
-[`++sit:fe`](@/docs/reference/library/2c.md#sit-fe)
-[`++sum:fe`](@/docs/reference/library/2c.md#sum-fe)
+<a href='https://urbit.org/docs/reference/library/2c.md#fe'><code>++fe</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#dif-fe'><code>++dif:fe</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#inv-fe'><code>++inv:fe</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#net-fe'><code>++net:fe</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#out-fe'><code>++out:fe</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#rol-fe'><code>++rol:fe</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#ror-fe'><code>++ror:fe</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#sit-fe'><code>++sit:fe</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#sum-fe'><code>++sum:fe</code></a>
 
-[`++bex`](@/docs/reference/library/2c.md#bex)
-[`++can`](@/docs/reference/library/2c.md#can)
-[`++cat`](@/docs/reference/library/2c.md#cat)
-[`++cut`](@/docs/reference/library/2c.md#cut)
-[`++end`](@/docs/reference/library/2c.md#end)
-[`++fil`](@/docs/reference/library/2c.md#fil)
-[`++lsh`](@/docs/reference/library/2c.md#lsh)
-[`++met`](@/docs/reference/library/2c.md#met)
-[`++rap`](@/docs/reference/library/2c.md#rap)
-[`++rep`](@/docs/reference/library/2c.md#rep)
-[`++rip`](@/docs/reference/library/2c.md#rip)
-[`++rsh`](@/docs/reference/library/2c.md#rsh)
-[`++swp`](@/docs/reference/library/2c.md#swp)
-[`++xeb`](@/docs/reference/library/2c.md#xeb)
+<a href='https://urbit.org/docs/reference/library/2c.md#bex'><code>++bex</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#can'><code>++can</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#cat'><code>++cat</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#cut'><code>++cut</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#end'><code>++end</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#fil'><code>++fil</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#lsh'><code>++lsh</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#met'><code>++met</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#rap'><code>++rap</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#rep'><code>++rep</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#rip'><code>++rip</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#rsh'><code>++rsh</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#swp'><code>++swp</code></a>
+<a href='https://urbit.org/docs/reference/library/2c.md#xeb'><code>++xeb</code></a>
 
 ### 2d: bit logic
 
-[`++con`](@/docs/reference/library/2d.md#con)
-[`++dis`](@/docs/reference/library/2d.md#dis)
-[`++mix`](@/docs/reference/library/2d.md#mix)
-[`++not`](@/docs/reference/library/2d.md#not)
+<a href='https://urbit.org/docs/reference/library/2d.md#con'><code>++con</code></a>
+<a href='https://urbit.org/docs/reference/library/2d.md#dis'><code>++dis</code></a>
+<a href='https://urbit.org/docs/reference/library/2d.md#mix'><code>++mix</code></a>
+<a href='https://urbit.org/docs/reference/library/2d.md#not'><code>++not</code></a>
 
 ### 2e: insecure hashing
 
-[`++fnv`](@/docs/reference/library/2e.md#fnv)
-[`++mug`](@/docs/reference/library/2e.md#mug)
-[`++muk`](@/docs/reference/library/2e.md#muk)
-[`++mum`](@/docs/reference/library/2e.md#mum)
+<a href='https://urbit.org/docs/reference/library/2e.md#fnv'><code>++fnv</code></a>
+<a href='https://urbit.org/docs/reference/library/2e.md#mug'><code>++mug</code></a>
+<a href='https://urbit.org/docs/reference/library/2e.md#muk'><code>++muk</code></a>
+<a href='https://urbit.org/docs/reference/library/2e.md#mum'><code>++mum</code></a>
 
 ### 2f: noun ordering
 
-[`++aor`](@/docs/reference/library/2f.md#aor)
-[`++dor`](@/docs/reference/library/2f.md#dor)
-[`++gor`](@/docs/reference/library/2f.md#gor)
-[`++hor`](@/docs/reference/library/2f.md#hor)
-[`++lor`](@/docs/reference/library/2f.md#lor)
-[`++vor`](@/docs/reference/library/2f.md#vor)
+<a href='https://urbit.org/docs/reference/library/2f.md#aor' data-tippy-content="Alphabetical order"><code>++aor</code></a>
+<a href='https://urbit.org/docs/reference/library/2f.md#dor'><code>++dor</code></a>
+<a href='https://urbit.org/docs/reference/library/2f.md#gor'><code>++gor</code></a>
+<a href='https://urbit.org/docs/reference/library/2f.md#hor'><code>++hor</code></a>
+<a href='https://urbit.org/docs/reference/library/2f.md#lor'><code>++lor</code></a>
+<a href='https://urbit.org/docs/reference/library/2f.md#vor'><code>++vor</code></a>
 
 ### 2g: unsigned powers
 
-[`++pow`](@/docs/reference/library/2g.md#pow)
-[`++sqt`](@/docs/reference/library/2g.md#sqt)
+<a href='https://urbit.org/docs/reference/library/2g.md#pow'><code>++pow</code></a>
+<a href='https://urbit.org/docs/reference/library/2g.md#sqt'><code>++sqt</code></a>
 
 ### 2h: set logic
 
-[`++in`](@/docs/reference/library/2h.md#in)
-[`+-all:in`](@/docs/reference/library/2h.md#all-in)
-[`+-any:in`](@/docs/reference/library/2h.md#any-in)
-[`+-apt:in`](@/docs/reference/library/2h.md#apt-in)
-[`+-bif:in`](@/docs/reference/library/2h.md#bif-in)
-[`+-del:in`](@/docs/reference/library/2h.md#del-in)
-[`+-dif:in`](@/docs/reference/library/2h.md#dif-in)
-[`+-dig:in`](@/docs/reference/library/2h.md#dig-in)
-[`+-gas:in`](@/docs/reference/library/2h.md#gas-in)
-[`+-has:in`](@/docs/reference/library/2h.md#has-in)
-[`+-int:in`](@/docs/reference/library/2h.md#int-in)
-[`+-put:in`](@/docs/reference/library/2h.md#put-in)
-[`+-rep:in`](@/docs/reference/library/2h.md#rep-in)
-[`+-run:in`](@/docs/reference/library/2h.md#run-in)
-[`+-tap:in`](@/docs/reference/library/2h.md#tap-in)
-[`+-uni:in`](@/docs/reference/library/2h.md#uni-in)
-[`+-wyt:in`](@/docs/reference/library/2h.md#wyt-in)
+<a href='https://urbit.org/docs/reference/library/2h.md#in'><code>++in</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#all-in' data-tippy-content="Logical AND (set and wet gate)"><code>+-all:in</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#any-in' data-tippy-content="Logical OR (set and gate)"><code>+-any:in</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#apt-in' data-tippy-content="Check correctness (set)"><code>+-apt:in</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#bif-in'><code>+-bif:in</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#del-in'><code>+-del:in</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#dif-in'><code>+-dif:in</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#dig-in'><code>+-dig:in</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#gas-in'><code>+-gas:in</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#has-in'><code>+-has:in</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#int-in'><code>+-int:in</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#put-in'><code>+-put:in</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#rep-in'><code>+-rep:in</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#run-in'><code>+-run:in</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#tap-in'><code>+-tap:in</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#uni-in'><code>+-uni:in</code></a>
+<a href='https://urbit.org/docs/reference/library/2h.md#wyt-in'><code>+-wyt:in</code></a>
 
 ### 2i: map logic
 
-[`++by`](@/docs/reference/library/2i.md#by)
-[`+-all:by`](@/docs/reference/library/2i.md#all-by)
-[`+-any:by`](@/docs/reference/library/2i.md#any-by)
-[`+-apt:by`](@/docs/reference/library/2i.md#apt-by)
-[`+-bif:by`](@/docs/reference/library/2i.md#bif-by)
-[`+-def:by`](@/docs/reference/library/2i.md#def-by)
-[`+-del:by`](@/docs/reference/library/2i.md#del-by)
-[`+-dep:by`](@/docs/reference/library/2i.md#dep-by)
-[`+-dig:by`](@/docs/reference/library/2i.md#dig-by)
-[`+-gas:by`](@/docs/reference/library/2i.md#gas-by)
-[`+-get:by`](@/docs/reference/library/2i.md#get-by)
-[`+-got:by`](@/docs/reference/library/2i.md#got-by)
-[`+-has:by`](@/docs/reference/library/2i.md#has-by)
-[`+-int:by`](@/docs/reference/library/2i.md#int-by)
-[`+-mar:by`](@/docs/reference/library/2i.md#mar-by)
-[`+-put:by`](@/docs/reference/library/2i.md#put-by)
-[`+-rep:by`](@/docs/reference/library/2i.md#rep-by)
-[`+-rib:by`](@/docs/reference/library/2i.md#rib-by)
-[`+-run:by`](@/docs/reference/library/2i.md#run-by)
-[`+-rut:by`](@/docs/reference/library/2i.md#rut-by)
-[`+-tap:by`](@/docs/reference/library/2i.md#tap-by)
-[`+-uni:by`](@/docs/reference/library/2i.md#uni-by)
-[`+-urn:by`](@/docs/reference/library/2i.md#urn-by)
-[`+-wyt:by`](@/docs/reference/library/2i.md#wyt-by)
+<a href='https://urbit.org/docs/reference/library/2i.md#by'><code>++by</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#all-by' data-tippy-content="Logical AND (map and wet gate)"><code>+-all:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#any-by' data-tippy-content="Logical OR (map and wet gate)"><code>+-any:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#apt-by' data-tippy-content="Check correctness (map)"><code>+-apt:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#bif-by'><code>+-bif:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#def-by'><code>+-def:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#del-by'><code>+-del:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#dep-by'><code>+-dep:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#dig-by'><code>+-dig:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#gas-by'><code>+-gas:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#get-by'><code>+-get:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#got-by'><code>+-got:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#has-by'><code>+-has:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#int-by'><code>+-int:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#mar-by'><code>+-mar:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#put-by'><code>+-put:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#rep-by'><code>+-rep:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#rib-by'><code>+-rib:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#run-by'><code>+-run:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#rut-by'><code>+-rut:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#tap-by'><code>+-tap:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#uni-by'><code>+-uni:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#urn-by'><code>+-urn:by</code></a>
+<a href='https://urbit.org/docs/reference/library/2i.md#wyt-by'><code>+-wyt:by</code></a>
 
 ### 2j: jar and jug logic
 
-[`++ja`](@/docs/reference/library/2j.md#ja)
-[`+-add:ja`](@/docs/reference/library/2j.md#add-ja)
-[`+-get:ja`](@/docs/reference/library/2j.md#get-ja)
+<a href='https://urbit.org/docs/reference/library/2j.md#ja'><code>++ja</code></a>
+<a href='https://urbit.org/docs/reference/library/2j.md#add-ja' data-tippy-content="Prepend to list"><code>+-add:ja</code></a>
+<a href='https://urbit.org/docs/reference/library/2j.md#get-ja'><code>+-get:ja</code></a>
 
-[`++ju`](@/docs/reference/library/2j.md#ju)
-[`+-del:ju`](@/docs/reference/library/2j.md#del-ju)
-[`+-get:ju`](@/docs/reference/library/2j.md#get-ju)
-[`+-has:ju`](@/docs/reference/library/2j.md#has-ju)
-[`+-put:ju`](@/docs/reference/library/2j.md#put-ju)
+<a href='https://urbit.org/docs/reference/library/2j.md#ju'><code>++ju</code></a>
+<a href='https://urbit.org/docs/reference/library/2j.md#del-ju'><code>+-del:ju</code></a>
+<a href='https://urbit.org/docs/reference/library/2j.md#get-ju'><code>+-get:ju</code></a>
+<a href='https://urbit.org/docs/reference/library/2j.md#has-ju'><code>+-has:ju</code></a>
+<a href='https://urbit.org/docs/reference/library/2j.md#put-ju'><code>+-put:ju</code></a>
 
 ### 2k: queue logic
 
-[`++to`](@/docs/reference/library/2k.md#to)
-[`+-bal:to`](@/docs/reference/library/2k.md#bal-to)
-[`+-dep:to`](@/docs/reference/library/2k.md#dep-to)
-[`+-gas:to`](@/docs/reference/library/2k.md#gas-to)
-[`+-get:to`](@/docs/reference/library/2k.md#get-to)
-[`+-nap:to`](@/docs/reference/library/2k.md#nap-to)
-[`+-nip:to`](@/docs/reference/library/2k.md#nip-to)
-[`+-put:to`](@/docs/reference/library/2k.md#put-to)
-[`+-tap:to`](@/docs/reference/library/2k.md#tap-to)
-[`+-top:to`](@/docs/reference/library/2k.md#top-to)
+<a href='https://urbit.org/docs/reference/library/2k.md#to'><code>++to</code></a>
+<a href='https://urbit.org/docs/reference/library/2k.md#bal-to'><code>+-bal:to</code></a>
+<a href='https://urbit.org/docs/reference/library/2k.md#dep-to'><code>+-dep:to</code></a>
+<a href='https://urbit.org/docs/reference/library/2k.md#gas-to'><code>+-gas:to</code></a>
+<a href='https://urbit.org/docs/reference/library/2k.md#get-to'><code>+-get:to</code></a>
+<a href='https://urbit.org/docs/reference/library/2k.md#nap-to'><code>+-nap:to</code></a>
+<a href='https://urbit.org/docs/reference/library/2k.md#nip-to'><code>+-nip:to</code></a>
+<a href='https://urbit.org/docs/reference/library/2k.md#put-to'><code>+-put:to</code></a>
+<a href='https://urbit.org/docs/reference/library/2k.md#tap-to'><code>+-tap:to</code></a>
+<a href='https://urbit.org/docs/reference/library/2k.md#top-to'><code>+-top:to</code></a>
 
 ### 2l: container from container
 
-[`++malt`](@/docs/reference/library/2l.md#malt)
-[`++molt`](@/docs/reference/library/2l.md#molt)
-[`++silt`](@/docs/reference/library/2l.md#silt)
+<a href='https://urbit.org/docs/reference/library/2l.md#malt'><code>++malt</code></a>
+<a href='https://urbit.org/docs/reference/library/2l.md#molt'><code>++molt</code></a>
+<a href='https://urbit.org/docs/reference/library/2l.md#silt'><code>++silt</code></a>
 
 ### 2m: container from noun
 
-[`++nl`](@/docs/reference/library/2m.md#nl)
-[`++le:nl`](@/docs/reference/library/2m.md#le-nl)
-[`++my:nl`](@/docs/reference/library/2m.md#my-nl)
-[`++si:nl`](@/docs/reference/library/2m.md#si-nl)
-[`++snag:nl`](@/docs/reference/library/2m.md#snag-nl)
-[`++weld:nl`](@/docs/reference/library/2m.md#weld-nl)
+<a href='https://urbit.org/docs/reference/library/2m.md#nl'><code>++nl</code></a>
+<a href='https://urbit.org/docs/reference/library/2m.md#le-nl'><code>++le:nl</code></a>
+<a href='https://urbit.org/docs/reference/library/2m.md#my-nl'><code>++my:nl</code></a>
+<a href='https://urbit.org/docs/reference/library/2m.md#si-nl'><code>++si:nl</code></a>
+<a href='https://urbit.org/docs/reference/library/2m.md#snag-nl'><code>++snag:nl</code></a>
+<a href='https://urbit.org/docs/reference/library/2m.md#weld-nl'><code>++weld:nl</code></a>
 
-[`++ly`](@/docs/reference/library/2m.md#ly)
-[`++my`](@/docs/reference/library/2m.md#my)
-[`++sy`](@/docs/reference/library/2m.md#sy)
+<a href='https://urbit.org/docs/reference/library/2m.md#ly'><code>++ly</code></a>
+<a href='https://urbit.org/docs/reference/library/2m.md#my'><code>++my</code></a>
+<a href='https://urbit.org/docs/reference/library/2m.md#sy'><code>++sy</code></a>
 
 ### 2n: functional hacks
 
-[`++cork`](@/docs/reference/library/2n.md#cork)
-[`++corl`](@/docs/reference/library/2n.md#corl)
-[`++curr`](@/docs/reference/library/2n.md#curr)
-[`++cury`](@/docs/reference/library/2n.md#cury)
-[`++hard`](@/docs/reference/library/2n.md#hard)
-[`++head`](@/docs/reference/library/2n.md#head)
-[`++mean`](@/docs/reference/library/2n.md#mean)
-[`++same`](@/docs/reference/library/2n.md#same)
-[`++slog`](@/docs/reference/library/2n.md#slog)
-[`++soft`](@/docs/reference/library/2n.md#soft)
-[`++tail`](@/docs/reference/library/2n.md#tail)
-[`++test`](@/docs/reference/library/2n.md#test)
+<a href='https://urbit.org/docs/reference/library/2n.md#cork'><code>++cork</code></a>
+<a href='https://urbit.org/docs/reference/library/2n.md#corl'><code>++corl</code></a>
+<a href='https://urbit.org/docs/reference/library/2n.md#curr'><code>++curr</code></a>
+<a href='https://urbit.org/docs/reference/library/2n.md#cury'><code>++cury</code></a>
+<a href='https://urbit.org/docs/reference/library/2n.md#hard'><code>++hard</code></a>
+<a href='https://urbit.org/docs/reference/library/2n.md#head'><code>++head</code></a>
+<a href='https://urbit.org/docs/reference/library/2n.md#mean'><code>++mean</code></a>
+<a href='https://urbit.org/docs/reference/library/2n.md#same'><code>++same</code></a>
+<a href='https://urbit.org/docs/reference/library/2n.md#slog'><code>++slog</code></a>
+<a href='https://urbit.org/docs/reference/library/2n.md#soft'><code>++soft</code></a>
+<a href='https://urbit.org/docs/reference/library/2n.md#tail'><code>++tail</code></a>
+<a href='https://urbit.org/docs/reference/library/2n.md#test'><code>++test</code></a>
 
 ### 2o: normalizing containers
 
-[`++jar`](@/docs/reference/library/2o.md#jar)
-[`++jug`](@/docs/reference/library/2o.md#jug)
-[`++map`](@/docs/reference/library/2o.md#map)
-[`++qeu`](@/docs/reference/library/2o.md#qeu)
-[`++set`](@/docs/reference/library/2o.md#set)
+<a href='https://urbit.org/docs/reference/library/2o.md#jar'><code>++jar</code></a>
+<a href='https://urbit.org/docs/reference/library/2o.md#jug'><code>++jug</code></a>
+<a href='https://urbit.org/docs/reference/library/2o.md#map'><code>++map</code></a>
+<a href='https://urbit.org/docs/reference/library/2o.md#qeu'><code>++qeu</code></a>
+<a href='https://urbit.org/docs/reference/library/2o.md#set'><code>++set</code></a>
 
 ### 2p: serialization
 
-[`++cue`](@/docs/reference/library/2p.md#cue)
-[`++jam`](@/docs/reference/library/2p.md#jam)
-[`++mat`](@/docs/reference/library/2p.md#mat)
-[`++rub`](@/docs/reference/library/2p.md#rub)
+<a href='https://urbit.org/docs/reference/library/2p.md#cue'><code>++cue</code></a>
+<a href='https://urbit.org/docs/reference/library/2p.md#jam'><code>++jam</code></a>
+<a href='https://urbit.org/docs/reference/library/2p.md#mat'><code>++mat</code></a>
+<a href='https://urbit.org/docs/reference/library/2p.md#rub'><code>++rub</code></a>
 
 ### 2q: molds and mold builders
 
-[`++char`](@/docs/reference/library/2q.md#char)
-[`++cord`](@/docs/reference/library/2q.md#cord)
-[`++date`](@/docs/reference/library/2q.md#date)
-[`++knot`](@/docs/reference/library/2q.md#knot)
-[`++tang`](@/docs/reference/library/2q.md#tang)
-[`++tank`](@/docs/reference/library/2q.md#tank)
-[`++tape`](@/docs/reference/library/2q.md#tape)
-[`++tarp`](@/docs/reference/library/2q.md#tarp)
-[`++term`](@/docs/reference/library/2q.md#term)
-[`++wain`](@/docs/reference/library/2q.md#wain)
-[`++wall`](@/docs/reference/library/2q.md#wall)
+<a href='https://urbit.org/docs/reference/library/2q.md#char'><code>++char</code></a>
+<a href='https://urbit.org/docs/reference/library/2q.md#cord'><code>++cord</code></a>
+<a href='https://urbit.org/docs/reference/library/2q.md#date'><code>++date</code></a>
+<a href='https://urbit.org/docs/reference/library/2q.md#knot'><code>++knot</code></a>
+<a href='https://urbit.org/docs/reference/library/2q.md#tang'><code>++tang</code></a>
+<a href='https://urbit.org/docs/reference/library/2q.md#tank'><code>++tank</code></a>
+<a href='https://urbit.org/docs/reference/library/2q.md#tape'><code>++tape</code></a>
+<a href='https://urbit.org/docs/reference/library/2q.md#tarp'><code>++tarp</code></a>
+<a href='https://urbit.org/docs/reference/library/2q.md#term'><code>++term</code></a>
+<a href='https://urbit.org/docs/reference/library/2q.md#wain'><code>++wain</code></a>
+<a href='https://urbit.org/docs/reference/library/2q.md#wall'><code>++wall</code></a>
 
 ### 3a: modular and signed ints
 
-[`++fo`](@/docs/reference/library/3a.md#fo)
-[`++dif:fo`](@/docs/reference/library/3a.md#dif-fo)
-[`++exp:fo`](@/docs/reference/library/3a.md#exp-fo)
-[`++fra:fo`](@/docs/reference/library/3a.md#fra-fo)
-[`++inv:fo`](@/docs/reference/library/3a.md#inv-fo)
-[`++pro:fo`](@/docs/reference/library/3a.md#pro-fo)
-[`++sit:fo`](@/docs/reference/library/3a.md#sit-fo)
-[`++sum:fo`](@/docs/reference/library/3a.md#sum-fo)
+<a href='https://urbit.org/docs/reference/library/3a.md#fo'><code>++fo</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#dif-fo'><code>++dif:fo</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#exp-fo'><code>++exp:fo</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#fra-fo'><code>++fra:fo</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#inv-fo'><code>++inv:fo</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#pro-fo'><code>++pro:fo</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#sit-fo'><code>++sit:fo</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#sum-fo'><code>++sum:fo</code></a>
 
-[`++si`](@/docs/reference/library/3a.md#si)
-[`++abs:si`](@/docs/reference/library/3a.md#abs-si)
-[`++cmp:si`](@/docs/reference/library/3a.md#cmp-si)
-[`++dif:si`](@/docs/reference/library/3a.md#dif-si)
-[`++dul:si`](@/docs/reference/library/3a.md#dul-si)
-[`++fra:si`](@/docs/reference/library/3a.md#fra-si)
-[`++new:si`](@/docs/reference/library/3a.md#new-si)
-[`++old:si`](@/docs/reference/library/3a.md#old-si)
-[`++pro:si`](@/docs/reference/library/3a.md#pro-si)
-[`++rem:si`](@/docs/reference/library/3a.md#rem-si)
-[`++sum:si`](@/docs/reference/library/3a.md#sum-si)
-[`++sun:si`](@/docs/reference/library/3a.md#sun-si)
-[`++syn:si`](@/docs/reference/library/3a.md#syn-si)
+<a href='https://urbit.org/docs/reference/library/3a.md#si'><code>++si</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#abs-si' data-tippy-content="Absolute value (signed integer)"><code>++abs:si</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#cmp-si'><code>++cmp:si</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#dif-si'><code>++dif:si</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#dul-si'><code>++dul:si</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#fra-si'><code>++fra:si</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#new-si'><code>++new:si</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#old-si'><code>++old:si</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#pro-si'><code>++pro:si</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#rem-si'><code>++rem:si</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#sum-si'><code>++sum:si</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#sun-si'><code>++sun:si</code></a>
+<a href='https://urbit.org/docs/reference/library/3a.md#syn-si'><code>++syn:si</code></a>
 
-[`++egcd`](@/docs/reference/library/3a.md#egcd)
+<a href='https://urbit.org/docs/reference/library/3a.md#egcd'><code>++egcd</code></a>
 
 ### 3b: floating point
 
-[`++dn`](@/docs/reference/library/3b.md#dn)
-[`++fn`](@/docs/reference/library/3b.md#fn)
-[`++rn`](@/docs/reference/library/3b.md#rn)
+<a href='https://urbit.org/docs/reference/library/3b.md#dn'><code>++dn</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#fn'><code>++fn</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#rn'><code>++rn</code></a>
 
-[`++ff`](@/docs/reference/library/3b.md#ff)
-[`++add:ff`](@/docs/reference/library/3b.md#add-ff)
-[`++bif:ff`](@/docs/reference/library/3b.md#bif-ff)
-[`++bit:ff`](@/docs/reference/library/3b.md#bit-ff)
-[`++div:ff`](@/docs/reference/library/3b.md#div-ff)
-[`++drg:ff`](@/docs/reference/library/3b.md#drg-ff)
-[`++equ:ff`](@/docs/reference/library/3b.md#equ-ff)
-[`++exp:ff`](@/docs/reference/library/3b.md#exp-ff)
-[`++fma:ff`](@/docs/reference/library/3b.md#fma-ff)
-[`++grd:ff`](@/docs/reference/library/3b.md#grd-ff)
-[`++gte:ff`](@/docs/reference/library/3b.md#gte-ff)
-[`++gth:ff`](@/docs/reference/library/3b.md#gth-ff)
-[`++lte:ff`](@/docs/reference/library/3b.md#lte-ff)
-[`++lth:ff`](@/docs/reference/library/3b.md#lth-ff)
-[`++me:ff`](@/docs/reference/library/3b.md#me-ff)
-[`++mul:ff`](@/docs/reference/library/3b.md#mul-ff)
-[`++pa:ff`](@/docs/reference/library/3b.md#pa-ff)
-[`++san:ff`](@/docs/reference/library/3b.md#san-ff)
-[`++sb:ff`](@/docs/reference/library/3b.md#sb-ff)
-[`++sea:ff`](@/docs/reference/library/3b.md#sea-ff)
-[`++sig:ff`](@/docs/reference/library/3b.md#sig-ff)
-[`++sqt:ff`](@/docs/reference/library/3b.md#sqt-ff)
-[`++sub:ff`](@/docs/reference/library/3b.md#sub-ff)
-[`++sun:ff`](@/docs/reference/library/3b.md#sun-ff)
-[`++toi:ff`](@/docs/reference/library/3b.md#toi-ff)
+<a href='https://urbit.org/docs/reference/library/3b.md#ff'><code>++ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#add-ff' data-tippy-content="Add (floating point)"><code>++add:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#bif-ff'><code>++bif:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#bit-ff'><code>++bit:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#div-ff'><code>++div:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#drg-ff'><code>++drg:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#equ-ff'><code>++equ:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#exp-ff'><code>++exp:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#fma-ff'><code>++fma:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#grd-ff'><code>++grd:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#gte-ff'><code>++gte:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#gth-ff'><code>++gth:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#lte-ff'><code>++lte:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#lth-ff'><code>++lth:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#me-ff'><code>++me:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#mul-ff'><code>++mul:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#pa-ff'><code>++pa:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#san-ff'><code>++san:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sb-ff'><code>++sb:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sea-ff'><code>++sea:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sig-ff'><code>++sig:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sqt-ff'><code>++sqt:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sub-ff'><code>++sub:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sun-ff'><code>++sun:ff</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#toi-ff'><code>++toi:ff</code></a>
 
-[`++fl`](@/docs/reference/library/3b.md#fl)
-[`++abs:fl`](@/docs/reference/library/3b.md#abs-fl)
-[`++add:fl`](@/docs/reference/library/3b.md#add-fl)
-[`++den:fl`](@/docs/reference/library/3b.md#den-fl)
-[`++div:fl`](@/docs/reference/library/3b.md#div-fl)
-[`++drg:fl`](@/docs/reference/library/3b.md#drg-fl)
-[`++ead:fl`](@/docs/reference/library/3b.md#ead-fl)
-[`++emn:fl`](@/docs/reference/library/3b.md#emn-fl)
-[`++emu:fl`](@/docs/reference/library/3b.md#emu-fl)
-[`++emx:fl`](@/docs/reference/library/3b.md#emx-fl)
-[`++equ:fl`](@/docs/reference/library/3b.md#equ-fl)
-[`++fli:fl`](@/docs/reference/library/3b.md#fli-fl)
-[`++fma:fl`](@/docs/reference/library/3b.md#fma-fl)
-[`++grd:fl`](@/docs/reference/library/3b.md#grd-fl)
-[`++gte:fl`](@/docs/reference/library/3b.md#gte-fl)
-[`++gth:fl`](@/docs/reference/library/3b.md#gth-fl)
-[`++ibl:fl`](@/docs/reference/library/3b.md#ibl-fl)
-[`++inv:fl`](@/docs/reference/library/3b.md#inv-fl)
-[`++lfe:fl`](@/docs/reference/library/3b.md#lfe-fl)
-[`++lfn:fl`](@/docs/reference/library/3b.md#lfn-fl)
-[`++lte:fl`](@/docs/reference/library/3b.md#lte-fl)
-[`++lth:fl`](@/docs/reference/library/3b.md#lth-fl)
-[`++lug:fl`](@/docs/reference/library/3b.md#lug-fl)
-[`++mul:fl`](@/docs/reference/library/3b.md#mul-fl)
-[`++ned:fl`](@/docs/reference/library/3b.md#ned-fl)
-[`++prc:fl`](@/docs/reference/library/3b.md#prc-fl)
-[`++rau:fl`](@/docs/reference/library/3b.md#rau-fl)
-[`++rou:fl`](@/docs/reference/library/3b.md#rou-fl)
-[`++san:fl`](@/docs/reference/library/3b.md#san-fl)
-[`++shf:fl`](@/docs/reference/library/3b.md#shf-fl)
-[`++spd:fl`](@/docs/reference/library/3b.md#spd-fl)
-[`++spn:fl`](@/docs/reference/library/3b.md#spn-fl)
-[`++sqt:fl`](@/docs/reference/library/3b.md#sqt-fl)
-[`++sub:fl`](@/docs/reference/library/3b.md#sub-fl)
-[`++sun:fl`](@/docs/reference/library/3b.md#sun-fl)
-[`++swr:fl`](@/docs/reference/library/3b.md#swr-fl)
-[`++syn:fl`](@/docs/reference/library/3b.md#syn-fl)
-[`++toi:fl`](@/docs/reference/library/3b.md#toi-fl)
-[`++toj:fl`](@/docs/reference/library/3b.md#toj-fl)
-[`++uni:fl`](@/docs/reference/library/3b.md#uni-fl)
-[`++xpd:fl`](@/docs/reference/library/3b.md#xpd-fl)
-[`++zer:fl`](@/docs/reference/library/3b.md#zer-fl)
+<a href='https://urbit.org/docs/reference/library/3b.md#fl'><code>++fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#abs-fl' data-tippy-content="Absolute value"><code>++abs:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#add-fl' data-tippy-content="Add (with exact/rounded flag)"><code>++add:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#den-fl'><code>++den:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#div-fl'><code>++div:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#drg-fl'><code>++drg:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#ead-fl'><code>++ead:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#emn-fl'><code>++emn:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#emu-fl'><code>++emu:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#emx-fl'><code>++emx:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#equ-fl'><code>++equ:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#fli-fl'><code>++fli:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#fma-fl'><code>++fma:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#grd-fl'><code>++grd:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#gte-fl'><code>++gte:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#gth-fl'><code>++gth:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#ibl-fl'><code>++ibl:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#inv-fl'><code>++inv:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#lfe-fl'><code>++lfe:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#lfn-fl'><code>++lfn:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#lte-fl'><code>++lte:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#lth-fl'><code>++lth:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#lug-fl'><code>++lug:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#mul-fl'><code>++mul:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#ned-fl'><code>++ned:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#prc-fl'><code>++prc:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#rau-fl'><code>++rau:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#rou-fl'><code>++rou:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#san-fl'><code>++san:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#shf-fl'><code>++shf:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#spd-fl'><code>++spd:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#spn-fl'><code>++spn:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sqt-fl'><code>++sqt:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sub-fl'><code>++sub:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sun-fl'><code>++sun:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#swr-fl'><code>++swr:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#syn-fl'><code>++syn:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#toi-fl'><code>++toi:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#toj-fl'><code>++toj:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#uni-fl'><code>++uni:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#xpd-fl'><code>++xpd:fl</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#zer-fl'><code>++zer:fl</code></a>
 
-[`++rd`](@/docs/reference/library/3b.md#rd)
-[`++add:rd`](@/docs/reference/library/3b.md#add-rd)
-[`++bit:rd`](@/docs/reference/library/3b.md#bit-rd)
-[`++div:rd`](@/docs/reference/library/3b.md#div-rd)
-[`++drg:rd`](@/docs/reference/library/3b.md#drg-rd)
-[`++equ:rd`](@/docs/reference/library/3b.md#equ-rd)
-[`++exp:rd`](@/docs/reference/library/3b.md#exp-rd)
-[`++fma:rd`](@/docs/reference/library/3b.md#fma-rd)
-[`++grd:rd`](@/docs/reference/library/3b.md#grd-rd)
-[`++gte:rd`](@/docs/reference/library/3b.md#gte-rd)
-[`++gth:rd`](@/docs/reference/library/3b.md#gth-rd)
-[`++lte:rd`](@/docs/reference/library/3b.md#lte-rd)
-[`++lth:rd`](@/docs/reference/library/3b.md#lth-rd)
-[`++ma:rd`](@/docs/reference/library/3b.md#ma-rd)
-[`++mul:rd`](@/docs/reference/library/3b.md#mul-rd)
-[`++san:rd`](@/docs/reference/library/3b.md#san-rd)
-[`++sea:rd`](@/docs/reference/library/3b.md#sea-rd)
-[`++sig:rd`](@/docs/reference/library/3b.md#sig-rd)
-[`++sqt:rd`](@/docs/reference/library/3b.md#sqt-rd)
-[`++sub:rd`](@/docs/reference/library/3b.md#sub-rd)
-[`++sun:rd`](@/docs/reference/library/3b.md#sun-rd)
-[`++toi:rd`](@/docs/reference/library/3b.md#toi-rd)
+<a href='https://urbit.org/docs/reference/library/3b.md#rd'><code>++rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#add-rd' data-tippy-content="Add (double-precision float)"><code>++add:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#bit-rd'><code>++bit:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#div-rd'><code>++div:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#drg-rd'><code>++drg:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#equ-rd'><code>++equ:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#exp-rd'><code>++exp:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#fma-rd'><code>++fma:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#grd-rd'><code>++grd:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#gte-rd'><code>++gte:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#gth-rd'><code>++gth:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#lte-rd'><code>++lte:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#lth-rd'><code>++lth:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#ma-rd'><code>++ma:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#mul-rd'><code>++mul:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#san-rd'><code>++san:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sea-rd'><code>++sea:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sig-rd'><code>++sig:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sqt-rd'><code>++sqt:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sub-rd'><code>++sub:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sun-rd'><code>++sun:rd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#toi-rd'><code>++toi:rd</code></a>
 
-[`++rh`](@/docs/reference/library/3b.md#rh)
-[`++add:rh`](@/docs/reference/library/3b.md#add-rh)
-[`++bit:rh`](@/docs/reference/library/3b.md#bit-rh)
-[`++div:rh`](@/docs/reference/library/3b.md#div-rh)
-[`++drg:rh`](@/docs/reference/library/3b.md#drg-rh)
-[`++equ:rh`](@/docs/reference/library/3b.md#equ-rh)
-[`++exp:rh`](@/docs/reference/library/3b.md#exp-rh)
-[`++fma:rh`](@/docs/reference/library/3b.md#fma-rh)
-[`++fos:rh`](@/docs/reference/library/3b.md#fos-rh)
-[`++grd:rh`](@/docs/reference/library/3b.md#grd-rh)
-[`++gte:rh`](@/docs/reference/library/3b.md#gte-rh)
-[`++gth:rh`](@/docs/reference/library/3b.md#gth-rh)
-[`++lte:rh`](@/docs/reference/library/3b.md#lte-rh)
-[`++lth:rh`](@/docs/reference/library/3b.md#lth-rh)
-[`++ma:rh`](@/docs/reference/library/3b.md#ma-rh)
-[`++mul:rh`](@/docs/reference/library/3b.md#mul-rh)
-[`++san:rh`](@/docs/reference/library/3b.md#san-rh)
-[`++sea:rh`](@/docs/reference/library/3b.md#sea-rh)
-[`++sig:rh`](@/docs/reference/library/3b.md#sig-rh)
-[`++sqt:rh`](@/docs/reference/library/3b.md#sqt-rh)
-[`++sub:rh`](@/docs/reference/library/3b.md#sub-rh)
-[`++sun:rh`](@/docs/reference/library/3b.md#sun-rh)
-[`++toi:rh`](@/docs/reference/library/3b.md#toi-rh)
-[`++tos:rh`](@/docs/reference/library/3b.md#tos-rh)
+<a href='https://urbit.org/docs/reference/library/3b.md#rh'><code>++rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#add-rh' data-tippy-content="Add (half-precision float)"><code>++add:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#bit-rh'><code>++bit:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#div-rh'><code>++div:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#drg-rh'><code>++drg:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#equ-rh'><code>++equ:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#exp-rh'><code>++exp:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#fma-rh'><code>++fma:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#fos-rh'><code>++fos:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#grd-rh'><code>++grd:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#gte-rh'><code>++gte:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#gth-rh'><code>++gth:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#lte-rh'><code>++lte:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#lth-rh'><code>++lth:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#ma-rh'><code>++ma:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#mul-rh'><code>++mul:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#san-rh'><code>++san:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sea-rh'><code>++sea:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sig-rh'><code>++sig:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sqt-rh'><code>++sqt:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sub-rh'><code>++sub:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sun-rh'><code>++sun:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#toi-rh'><code>++toi:rh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#tos-rh'><code>++tos:rh</code></a>
 
-[`++rs`](@/docs/reference/library/3b.md#rs)
-[`++add:rs`](@/docs/reference/library/3b.md#add-rs)
-[`++bit:rs`](@/docs/reference/library/3b.md#bit-rs)
-[`++div:rs`](@/docs/reference/library/3b.md#div-rs)
-[`++drg:rs`](@/docs/reference/library/3b.md#drg-rs)
-[`++equ:rs`](@/docs/reference/library/3b.md#equ-rs)
-[`++exp:rs`](@/docs/reference/library/3b.md#exp-rs)
-[`++fma:rs`](@/docs/reference/library/3b.md#fma-rs)
-[`++grd:rs`](@/docs/reference/library/3b.md#grd-rs)
-[`++gte:rs`](@/docs/reference/library/3b.md#gte-rs)
-[`++gth:rs`](@/docs/reference/library/3b.md#gth-rs)
-[`++lte:rs`](@/docs/reference/library/3b.md#lte-rs)
-[`++lth:rs`](@/docs/reference/library/3b.md#lth-rs)
-[`++ma:rs`](@/docs/reference/library/3b.md#ma-rs)
-[`++mul:rs`](@/docs/reference/library/3b.md#mul-rs)
-[`++san:rs`](@/docs/reference/library/3b.md#san-rs)
-[`++sea:rs`](@/docs/reference/library/3b.md#sea-rs)
-[`++sig:rs`](@/docs/reference/library/3b.md#sig-rs)
-[`++sqt:rs`](@/docs/reference/library/3b.md#sqt-rs)
-[`++sub:rs`](@/docs/reference/library/3b.md#sub-rs)
-[`++sun:rs`](@/docs/reference/library/3b.md#sun-rs)
-[`++toi:rs`](@/docs/reference/library/3b.md#toi-rs)
+<a href='https://urbit.org/docs/reference/library/3b.md#rs'><code>++rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#add-rs' data-tippy-content="Add (single-precision float)"><code>++add:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#bit-rs'><code>++bit:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#div-rs'><code>++div:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#drg-rs'><code>++drg:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#equ-rs'><code>++equ:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#exp-rs'><code>++exp:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#fma-rs'><code>++fma:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#grd-rs'><code>++grd:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#gte-rs'><code>++gte:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#gth-rs'><code>++gth:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#lte-rs'><code>++lte:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#lth-rs'><code>++lth:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#ma-rs'><code>++ma:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#mul-rs'><code>++mul:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#san-rs'><code>++san:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sea-rs'><code>++sea:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sig-rs'><code>++sig:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sqt-rs'><code>++sqt:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sub-rs'><code>++sub:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sun-rs'><code>++sun:rs</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#toi-rs'><code>++toi:rs</code></a>
 
-[`++rq`](@/docs/reference/library/3b.md#rq)
-[`++add:rq`](@/docs/reference/library/3b.md#add-rq)
-[`++bit:rq`](@/docs/reference/library/3b.md#bit-rq)
-[`++div:rq`](@/docs/reference/library/3b.md#div-rq)
-[`++drg:rq`](@/docs/reference/library/3b.md#drg-rq)
-[`++equ:rq`](@/docs/reference/library/3b.md#equ-rq)
-[`++exp:rq`](@/docs/reference/library/3b.md#exp-rq)
-[`++fma:rq`](@/docs/reference/library/3b.md#fma-rq)
-[`++grd:rq`](@/docs/reference/library/3b.md#grd-rq)
-[`++gte:rq`](@/docs/reference/library/3b.md#gte-rq)
-[`++gth:rq`](@/docs/reference/library/3b.md#gth-rq)
-[`++lte:rq`](@/docs/reference/library/3b.md#lte-rq)
-[`++lth:rq`](@/docs/reference/library/3b.md#lth-rq)
-[`++ma:rq`](@/docs/reference/library/3b.md#ma-rq)
-[`++mul:rq`](@/docs/reference/library/3b.md#mul-rq)
-[`++san:rq`](@/docs/reference/library/3b.md#san-rq)
-[`++sea:rq`](@/docs/reference/library/3b.md#sea-rq)
-[`++sig:rq`](@/docs/reference/library/3b.md#sig-rq)
-[`++sqt:rq`](@/docs/reference/library/3b.md#sqt-rq)
-[`++sub:rq`](@/docs/reference/library/3b.md#sub-rq)
-[`++sun:rq`](@/docs/reference/library/3b.md#sun-rq)
-[`++toi:rq`](@/docs/reference/library/3b.md#toi-rq)
+<a href='https://urbit.org/docs/reference/library/3b.md#rq'><code>++rq</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#add-rq' data-tippy-content="Add (quad-precision float)"><code>++add:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#bit-rq'><code>++bit:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#div-rq'><code>++div:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#drg-rq'><code>++drg:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#equ-rq'><code>++equ:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#exp-rq'><code>++exp:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#fma-rq'><code>++fma:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#grd-rq'><code>++grd:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#gte-rq'><code>++gte:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#gth-rq'><code>++gth:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#lte-rq'><code>++lte:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#lth-rq'><code>++lth:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#ma-rq'><code>++ma:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#mul-rq'><code>++mul:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#san-rq'><code>++san:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sea-rq'><code>++sea:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sig-rq'><code>++sig:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sqt-rq'><code>++sqt:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sub-rq'><code>++sub:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#sun-rq'><code>++sun:rq</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#toi-rq'><code>++toi:rq</code></a>
 
-[`++rlyd`](@/docs/reference/library/3b.md#rlyd)
-[`++rlyh`](@/docs/reference/library/3b.md#rlyh)
-[`++rlyq`](@/docs/reference/library/3b.md#rlyq)
-[`++rlys`](@/docs/reference/library/3b.md#rlys)
-[`++ryld`](@/docs/reference/library/3b.md#ryld)
-[`++rylh`](@/docs/reference/library/3b.md#rylh)
-[`++rylq`](@/docs/reference/library/3b.md#rylq)
-[`++ryls`](@/docs/reference/library/3b.md#ryls)
+<a href='https://urbit.org/docs/reference/library/3b.md#rlyd'><code>++rlyd</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#rlyh'><code>++rlyh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#rlyq'><code>++rlyq</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#rlys'><code>++rlys</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#ryld'><code>++ryld</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#rylh'><code>++rylh</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#rylq'><code>++rylq</code></a>
+<a href='https://urbit.org/docs/reference/library/3b.md#ryls'><code>++ryls</code></a>
 
 ### 3c: urbit time
 
-[`++yo`](@/docs/reference/library/3c.md#yo)
-[`++cet:yo`](@/docs/reference/library/3c.md#cet-yo)
-[`++day:yo`](@/docs/reference/library/3c.md#day-yo)
-[`++era:yo`](@/docs/reference/library/3c.md#era-yo)
-[`++hor:yo`](@/docs/reference/library/3c.md#hor-yo)
-[`++jes:yo`](@/docs/reference/library/3c.md#jes-yo)
-[`++mit:yo`](@/docs/reference/library/3c.md#mit-yo)
-[`++moh:yo`](@/docs/reference/library/3c.md#moh-yo)
-[`++moy:yo`](@/docs/reference/library/3c.md#moy-yo)
-[`++qad:yo`](@/docs/reference/library/3c.md#qad-yo)
-[`++yer:yo`](@/docs/reference/library/3c.md#yer-yo)
+<a href='https://urbit.org/docs/reference/library/3c.md#yo'><code>++yo</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#cet-yo'><code>++cet:yo</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#day-yo'><code>++day:yo</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#era-yo'><code>++era:yo</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#hor-yo'><code>++hor:yo</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#jes-yo'><code>++jes:yo</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#mit-yo'><code>++mit:yo</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#moh-yo'><code>++moh:yo</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#moy-yo'><code>++moy:yo</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#qad-yo'><code>++qad:yo</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#yer-yo'><code>++yer:yo</code></a>
 
-[`++yall`](@/docs/reference/library/3c.md#yall)
-[`++yawn`](@/docs/reference/library/3c.md#yawn)
-[`++year`](@/docs/reference/library/3c.md#year)
-[`++yell`](@/docs/reference/library/3c.md#yell)
-[`++yelp`](@/docs/reference/library/3c.md#yelp)
-[`++yore`](@/docs/reference/library/3c.md#yore)
-[`++yule`](@/docs/reference/library/3c.md#yule)
+<a href='https://urbit.org/docs/reference/library/3c.md#yall'><code>++yall</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#yawn'><code>++yawn</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#year'><code>++year</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#yell'><code>++yell</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#yelp'><code>++yelp</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#yore'><code>++yore</code></a>
+<a href='https://urbit.org/docs/reference/library/3c.md#yule'><code>++yule</code></a>
 
 ### 3d: SHA hash family
 
-[`++og`](@/docs/reference/library/3d.md#og)
-[`++rad:og`](@/docs/reference/library/3d.md#rad-og)
-[`++rads:og`](@/docs/reference/library/3d.md#rads-og)
-[`++raw:og`](@/docs/reference/library/3d.md#raw-og)
-[`++raws:og`](@/docs/reference/library/3d.md#raws-og)
+<a href='https://urbit.org/docs/reference/library/3d.md#og'><code>++og</code></a>
+<a href='https://urbit.org/docs/reference/library/3d.md#rad-og'><code>++rad:og</code></a>
+<a href='https://urbit.org/docs/reference/library/3d.md#rads-og'><code>++rads:og</code></a>
+<a href='https://urbit.org/docs/reference/library/3d.md#raw-og'><code>++raw:og</code></a>
+<a href='https://urbit.org/docs/reference/library/3d.md#raws-og'><code>++raws:og</code></a>
 
-[`++shad`](@/docs/reference/library/3d.md#shad)
-[`++shaf`](@/docs/reference/library/3d.md#shaf)
-[`++shal`](@/docs/reference/library/3d.md#shal)
-[`++sham`](@/docs/reference/library/3d.md#sham)
-[`++shan`](@/docs/reference/library/3d.md#shan)
-[`++shas`](@/docs/reference/library/3d.md#shas)
-[`++shaw`](@/docs/reference/library/3d.md#shaw)
-[`++shax`](@/docs/reference/library/3d.md#shax)
-[`++shay`](@/docs/reference/library/3d.md#shay)
-[`++shaz`](@/docs/reference/library/3d.md#shaz)
+<a href='https://urbit.org/docs/reference/library/3d.md#shad'><code>++shad</code></a>
+<a href='https://urbit.org/docs/reference/library/3d.md#shaf'><code>++shaf</code></a>
+<a href='https://urbit.org/docs/reference/library/3d.md#shal'><code>++shal</code></a>
+<a href='https://urbit.org/docs/reference/library/3d.md#sham'><code>++sham</code></a>
+<a href='https://urbit.org/docs/reference/library/3d.md#shan'><code>++shan</code></a>
+<a href='https://urbit.org/docs/reference/library/3d.md#shas'><code>++shas</code></a>
+<a href='https://urbit.org/docs/reference/library/3d.md#shaw'><code>++shaw</code></a>
+<a href='https://urbit.org/docs/reference/library/3d.md#shax'><code>++shax</code></a>
+<a href='https://urbit.org/docs/reference/library/3d.md#shay'><code>++shay</code></a>
+<a href='https://urbit.org/docs/reference/library/3d.md#shaz'><code>++shaz</code></a>
 
 ### 3e: AES encryption
 
-[_(removed)_](@/docs/reference/library/3e.md)
+<a href='https://urbit.org/docs/reference/library/3e.md'>_(removed)_</a>
 
 ### 3f: scrambling
 
-[`++ob`](@/docs/reference/library/3f.md#ob)
-[`++feen:ob`](@/docs/reference/library/3f.md#feen-ob)
-[`++fend:ob`](@/docs/reference/library/3f.md#fend-ob)
-[`++fice:ob`](@/docs/reference/library/3f.md#fice-ob)
-[`++raku:ob`](@/docs/reference/library/3f.md#raku-ob)
-[`++rund:ob`](@/docs/reference/library/3f.md#rund-ob)
-[`++rynd:ob`](@/docs/reference/library/3f.md#rynd-ob)
-[`++teil:ob`](@/docs/reference/library/3f.md#teil-ob)
+<a href='https://urbit.org/docs/reference/library/3f.md#ob'><code>++ob</code></a>
+<a href='https://urbit.org/docs/reference/library/3f.md#feen-ob'><code>++feen:ob</code></a>
+<a href='https://urbit.org/docs/reference/library/3f.md#fend-ob'><code>++fend:ob</code></a>
+<a href='https://urbit.org/docs/reference/library/3f.md#fice-ob'><code>++fice:ob</code></a>
+<a href='https://urbit.org/docs/reference/library/3f.md#raku-ob'><code>++raku:ob</code></a>
+<a href='https://urbit.org/docs/reference/library/3f.md#rund-ob'><code>++rund:ob</code></a>
+<a href='https://urbit.org/docs/reference/library/3f.md#rynd-ob'><code>++rynd:ob</code></a>
+<a href='https://urbit.org/docs/reference/library/3f.md#teil-ob'><code>++teil:ob</code></a>
 
-[`++un`](@/docs/reference/library/3f.md#un)
-[`++wred:un`](@/docs/reference/library/3f.md#wred-un)
-[`++wren:un`](@/docs/reference/library/3f.md#wren-un)
-[`++xafo:un`](@/docs/reference/library/3f.md#xafo-un)
-[`++xaro:un`](@/docs/reference/library/3f.md#xaro-un)
-[`++zaft:un`](@/docs/reference/library/3f.md#zaft-un)
-[`++zart:un`](@/docs/reference/library/3f.md#zart-un)
-[`++zyft:un`](@/docs/reference/library/3f.md#zyft-un)
-[`++zyrt:un`](@/docs/reference/library/3f.md#zyrt-un)
+<a href='https://urbit.org/docs/reference/library/3f.md#un'><code>++un</code></a>
+<a href='https://urbit.org/docs/reference/library/3f.md#wred-un'><code>++wred:un</code></a>
+<a href='https://urbit.org/docs/reference/library/3f.md#wren-un'><code>++wren:un</code></a>
+<a href='https://urbit.org/docs/reference/library/3f.md#xafo-un'><code>++xafo:un</code></a>
+<a href='https://urbit.org/docs/reference/library/3f.md#xaro-un'><code>++xaro:un</code></a>
+<a href='https://urbit.org/docs/reference/library/3f.md#zaft-un'><code>++zaft:un</code></a>
+<a href='https://urbit.org/docs/reference/library/3f.md#zart-un'><code>++zart:un</code></a>
+<a href='https://urbit.org/docs/reference/library/3f.md#zyft-un'><code>++zyft:un</code></a>
+<a href='https://urbit.org/docs/reference/library/3f.md#zyrt-un'><code>++zyrt:un</code></a>
 
 ### 3g: molds and mold builders
 
-[`++coin`](@/docs/reference/library/3g.md#coin)
-[`++dime`](@/docs/reference/library/3g.md#dime)
-[`++edge`](@/docs/reference/library/3g.md#edge)
-[`++hair`](@/docs/reference/library/3g.md#hair)
-[`++like`](@/docs/reference/library/3g.md#like)
-[`++nail`](@/docs/reference/library/3g.md#nail)
-[`++path`](@/docs/reference/library/3g.md#path)
-[`++pint`](@/docs/reference/library/3g.md#pint)
-[`++rule`](@/docs/reference/library/3g.md#rule)
-[`++spot`](@/docs/reference/library/3g.md#spot)
-[`++tone`](@/docs/reference/library/3g.md#tone)
-[`++toon`](@/docs/reference/library/3g.md#toon)
-[`++wonk`](@/docs/reference/library/3g.md#wonk)
+<a href='https://urbit.org/docs/reference/library/3g.md#coin'><code>++coin</code></a>
+<a href='https://urbit.org/docs/reference/library/3g.md#dime'><code>++dime</code></a>
+<a href='https://urbit.org/docs/reference/library/3g.md#edge'><code>++edge</code></a>
+<a href='https://urbit.org/docs/reference/library/3g.md#hair'><code>++hair</code></a>
+<a href='https://urbit.org/docs/reference/library/3g.md#like'><code>++like</code></a>
+<a href='https://urbit.org/docs/reference/library/3g.md#nail'><code>++nail</code></a>
+<a href='https://urbit.org/docs/reference/library/3g.md#path'><code>++path</code></a>
+<a href='https://urbit.org/docs/reference/library/3g.md#pint'><code>++pint</code></a>
+<a href='https://urbit.org/docs/reference/library/3g.md#rule'><code>++rule</code></a>
+<a href='https://urbit.org/docs/reference/library/3g.md#spot'><code>++spot</code></a>
+<a href='https://urbit.org/docs/reference/library/3g.md#tone'><code>++tone</code></a>
+<a href='https://urbit.org/docs/reference/library/3g.md#toon'><code>++toon</code></a>
+<a href='https://urbit.org/docs/reference/library/3g.md#wonk'><code>++wonk</code></a>
 
 ### 4a: exotic bases
 
-[`++po`](@/docs/reference/library/4a.md#po)
-[`++ind:po`](@/docs/reference/library/4a.md#ind-po)
-[`++ins:po`](@/docs/reference/library/4a.md#ins-po)
-[`++tod:po`](@/docs/reference/library/4a.md#tod-po)
-[`++tos:po`](@/docs/reference/library/4a.md#tos-po)
+<a href='https://urbit.org/docs/reference/library/4a.md#po'><code>++po</code></a>
+<a href='https://urbit.org/docs/reference/library/4a.md#ind-po'><code>++ind:po</code></a>
+<a href='https://urbit.org/docs/reference/library/4a.md#ins-po'><code>++ins:po</code></a>
+<a href='https://urbit.org/docs/reference/library/4a.md#tod-po'><code>++tod:po</code></a>
+<a href='https://urbit.org/docs/reference/library/4a.md#tos-po'><code>++tos:po</code></a>
 
 ### 4b: text processing
 
-[`++at`](@/docs/reference/library/4b.md#at)
-[`++r:at`](@/docs/reference/library/4b.md#r-at)
-[`++rf:at`](@/docs/reference/library/4b.md#rf-at)
-[`++rn:at`](@/docs/reference/library/4b.md#rn-at)
-[`++rt:at`](@/docs/reference/library/4b.md#rt-at)
-[`++rta:at`](@/docs/reference/library/4b.md#rta-at)
-[`++rtam:at`](@/docs/reference/library/4b.md#rtam-at)
-[`++rub:at`](@/docs/reference/library/4b.md#rub-at)
-[`++rud:at`](@/docs/reference/library/4b.md#rud-at)
-[`++rum:at`](@/docs/reference/library/4b.md#rum-at)
-[`++rup:at`](@/docs/reference/library/4b.md#rup-at)
-[`++ruv:at`](@/docs/reference/library/4b.md#ruv-at)
-[`++rux:at`](@/docs/reference/library/4b.md#rux-at)
+<a href='https://urbit.org/docs/reference/library/4b.md#at' data-tippy-content="(Undocumented)"><code>++at</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#r-at'><code>++r:at</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#rf-at'><code>++rf:at</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#rn-at'><code>++rn:at</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#rt-at'><code>++rt:at</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#rta-at'><code>++rta:at</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#rtam-at'><code>++rtam:at</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#rub-at'><code>++rub:at</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#rud-at'><code>++rud:at</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#rum-at'><code>++rum:at</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#rup-at'><code>++rup:at</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#ruv-at'><code>++ruv:at</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#rux-at'><code>++rux:at</code></a>
 
-[`++cass`](@/docs/reference/library/4b.md#cass)
-[`++crip`](@/docs/reference/library/4b.md#crip)
-[`++cuss`](@/docs/reference/library/4b.md#cuss)
-[`++mesc`](@/docs/reference/library/4b.md#mesc)
-[`++runt`](@/docs/reference/library/4b.md#runt)
-[`++sand`](@/docs/reference/library/4b.md#sand)
-[`++sane`](@/docs/reference/library/4b.md#sane)
-[`++teff`](@/docs/reference/library/4b.md#teff)
-[`++trim`](@/docs/reference/library/4b.md#trim)
-[`++trip`](@/docs/reference/library/4b.md#trip)
-[`++tuba`](@/docs/reference/library/4b.md#tuba)
-[`++tufa`](@/docs/reference/library/4b.md#tufa)
-[`++tuft`](@/docs/reference/library/4b.md#tuft)
-[`++turf`](@/docs/reference/library/4b.md#turf)
-[`++wack`](@/docs/reference/library/4b.md#wack)
-[`++wick`](@/docs/reference/library/4b.md#wick)
-[`++woad`](@/docs/reference/library/4b.md#woad)
-[`++wood`](@/docs/reference/library/4b.md#wood)
+<a href='https://urbit.org/docs/reference/library/4b.md#cass'><code>++cass</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#crip'><code>++crip</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#cuss'><code>++cuss</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#mesc'><code>++mesc</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#runt'><code>++runt</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#sand'><code>++sand</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#sane'><code>++sane</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#teff'><code>++teff</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#trim'><code>++trim</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#trip'><code>++trip</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#tuba'><code>++tuba</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#tufa'><code>++tufa</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#tuft'><code>++tuft</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#turf'><code>++turf</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#wack'><code>++wack</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#wick'><code>++wick</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#woad'><code>++woad</code></a>
+<a href='https://urbit.org/docs/reference/library/4b.md#wood'><code>++wood</code></a>
 
 ### 4c: tank printer
 
-[`++re`](@/docs/reference/library/4c.md#re)
-[`++din:re`](@/docs/reference/library/4c.md#din-re)
-[`++fit:re`](@/docs/reference/library/4c.md#fit-re)
-[`++ram:re`](@/docs/reference/library/4c.md#ram-re)
-[`++rig:re`](@/docs/reference/library/4c.md#rig-re)
-[`++wig:re`](@/docs/reference/library/4c.md#wig-re)
-[`++win:re`](@/docs/reference/library/4c.md#win-re)
+<a href='https://urbit.org/docs/reference/library/4c.md#re'><code>++re</code></a>
+<a href='https://urbit.org/docs/reference/library/4c.md#din-re'><code>++din:re</code></a>
+<a href='https://urbit.org/docs/reference/library/4c.md#fit-re'><code>++fit:re</code></a>
+<a href='https://urbit.org/docs/reference/library/4c.md#ram-re'><code>++ram:re</code></a>
+<a href='https://urbit.org/docs/reference/library/4c.md#rig-re'><code>++rig:re</code></a>
+<a href='https://urbit.org/docs/reference/library/4c.md#wig-re'><code>++wig:re</code></a>
+<a href='https://urbit.org/docs/reference/library/4c.md#win-re'><code>++win:re</code></a>
 
-[`++shep`](@/docs/reference/library/4c.md#shep)
-[`++shop`](@/docs/reference/library/4c.md#shop)
-[`++show`](@/docs/reference/library/4c.md#show)
+<a href='https://urbit.org/docs/reference/library/4c.md#shep'><code>++shep</code></a>
+<a href='https://urbit.org/docs/reference/library/4c.md#shop'><code>++shop</code></a>
+<a href='https://urbit.org/docs/reference/library/4c.md#show'><code>++show</code></a>
 
 ### 4d: parsing (tracing)
 
-[`++last`](@/docs/reference/library/4d.md#last)
-[`++lust`](@/docs/reference/library/4d.md#lust)
+<a href='https://urbit.org/docs/reference/library/4d.md#last'><code>++last</code></a>
+<a href='https://urbit.org/docs/reference/library/4d.md#lust'><code>++lust</code></a>
 
 ### 4e: parsing (combinators)
 
-[`++bend`](@/docs/reference/library/4e.md#bend)
-[`++comp`](@/docs/reference/library/4e.md#comp)
-[`++fail`](@/docs/reference/library/4e.md#fail)
-[`++glue`](@/docs/reference/library/4e.md#glue)
-[`++less`](@/docs/reference/library/4e.md#less)
-[`++pfix`](@/docs/reference/library/4e.md#pfix)
-[`++plug`](@/docs/reference/library/4e.md#plug)
-[`++pose`](@/docs/reference/library/4e.md#pose)
-[`++sfix`](@/docs/reference/library/4e.md#sfix)
-[`++simu`](@/docs/reference/library/4e.md#simu)
+<a href='https://urbit.org/docs/reference/library/4e.md#bend'><code>++bend</code></a>
+<a href='https://urbit.org/docs/reference/library/4e.md#comp'><code>++comp</code></a>
+<a href='https://urbit.org/docs/reference/library/4e.md#fail'><code>++fail</code></a>
+<a href='https://urbit.org/docs/reference/library/4e.md#glue'><code>++glue</code></a>
+<a href='https://urbit.org/docs/reference/library/4e.md#less'><code>++less</code></a>
+<a href='https://urbit.org/docs/reference/library/4e.md#pfix'><code>++pfix</code></a>
+<a href='https://urbit.org/docs/reference/library/4e.md#plug'><code>++plug</code></a>
+<a href='https://urbit.org/docs/reference/library/4e.md#pose'><code>++pose</code></a>
+<a href='https://urbit.org/docs/reference/library/4e.md#sfix'><code>++sfix</code></a>
+<a href='https://urbit.org/docs/reference/library/4e.md#simu'><code>++simu</code></a>
 
 ### 4f: parsing (rule builders)
 
-[`++bass`](@/docs/reference/library/4f.md#bass)
-[`++boss`](@/docs/reference/library/4f.md#boss)
-[`++cold`](@/docs/reference/library/4f.md#cold)
-[`++cook`](@/docs/reference/library/4f.md#cook)
-[`++easy`](@/docs/reference/library/4f.md#easy)
-[`++full`](@/docs/reference/library/4f.md#full)
-[`++funk`](@/docs/reference/library/4f.md#funk)
-[`++here`](@/docs/reference/library/4f.md#here)
-[`++ifix`](@/docs/reference/library/4f.md#ifix)
-[`++jest`](@/docs/reference/library/4f.md#jest)
-[`++just`](@/docs/reference/library/4f.md#just)
-[`++knee`](@/docs/reference/library/4f.md#knee)
-[`++mask`](@/docs/reference/library/4f.md#mask)
-[`++more`](@/docs/reference/library/4f.md#more)
-[`++most`](@/docs/reference/library/4f.md#most)
-[`++next`](@/docs/reference/library/4f.md#next)
-[`++plus`](@/docs/reference/library/4f.md#plus)
-[`++sear`](@/docs/reference/library/4f.md#sear)
-[`++shim`](@/docs/reference/library/4f.md#shim)
-[`++slug`](@/docs/reference/library/4f.md#slug)
-[`++stag`](@/docs/reference/library/4f.md#stag)
-[`++star`](@/docs/reference/library/4f.md#star)
-[`++stet`](@/docs/reference/library/4f.md#stet)
-[`++stew`](@/docs/reference/library/4f.md#stew)
-[`++stir`](@/docs/reference/library/4f.md#stir)
-[`++stun`](@/docs/reference/library/4f.md#stun)
+<a href='https://urbit.org/docs/reference/library/4f.md#bass'><code>++bass</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#boss'><code>++boss</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#cold'><code>++cold</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#cook'><code>++cook</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#easy'><code>++easy</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#full'><code>++full</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#funk'><code>++funk</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#here'><code>++here</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#ifix'><code>++ifix</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#jest'><code>++jest</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#just'><code>++just</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#knee'><code>++knee</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#mask'><code>++mask</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#more'><code>++more</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#most'><code>++most</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#next'><code>++next</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#plus'><code>++plus</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#sear'><code>++sear</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#shim'><code>++shim</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#slug'><code>++slug</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#stag'><code>++stag</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#star'><code>++star</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#stet'><code>++stet</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#stew'><code>++stew</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#stir'><code>++stir</code></a>
+<a href='https://urbit.org/docs/reference/library/4f.md#stun'><code>++stun</code></a>
 
 ### 4g: parsing (outside caller)
 
-[`++rash`](@/docs/reference/library/4g.md#rash)
-[`++rush`](@/docs/reference/library/4g.md#rush)
-[`++rust`](@/docs/reference/library/4g.md#rust)
-[`++scan`](@/docs/reference/library/4g.md#scan)
+<a href='https://urbit.org/docs/reference/library/4g.md#rash'><code>++rash</code></a>
+<a href='https://urbit.org/docs/reference/library/4g.md#rush'><code>++rush</code></a>
+<a href='https://urbit.org/docs/reference/library/4g.md#rust'><code>++rust</code></a>
+<a href='https://urbit.org/docs/reference/library/4g.md#scan'><code>++scan</code></a>
 
 ### 4h: parsing (ascii glyphs)
 
-[`++ace`](@/docs/reference/library/4h.md#ace)
-[`++bar`](@/docs/reference/library/4h.md#bar)
-[`++bas`](@/docs/reference/library/4h.md#bas)
-[`++buc`](@/docs/reference/library/4h.md#buc)
-[`++cab`](@/docs/reference/library/4h.md#cab)
-[`++cen`](@/docs/reference/library/4h.md#cen)
-[`++col`](@/docs/reference/library/4h.md#col)
-[`++com`](@/docs/reference/library/4h.md#com)
-[`++doq`](@/docs/reference/library/4h.md#doq)
-[`++dot`](@/docs/reference/library/4h.md#dot)
-[`++fas`](@/docs/reference/library/4h.md#fas)
-[`++gal`](@/docs/reference/library/4h.md#gal)
-[`++gar`](@/docs/reference/library/4h.md#gar)
-[`++hax`](@/docs/reference/library/4h.md#hax)
-[`++hep`](@/docs/reference/library/4h.md#hep)
-[`++kel`](@/docs/reference/library/4h.md#kel)
-[`++ker`](@/docs/reference/library/4h.md#ker)
-[`++ket`](@/docs/reference/library/4h.md#ket)
-[`++lus`](@/docs/reference/library/4h.md#lus)
-[`++pam`](@/docs/reference/library/4h.md#pam)
-[`++pat`](@/docs/reference/library/4h.md#pat)
-[`++pel`](@/docs/reference/library/4h.md#pel)
-[`++per`](@/docs/reference/library/4h.md#per)
-[`++sel`](@/docs/reference/library/4h.md#sel)
-[`++sem`](@/docs/reference/library/4h.md#sem)
-[`++ser`](@/docs/reference/library/4h.md#ser)
-[`++sig`](@/docs/reference/library/4h.md#sig)
-[`++soq`](@/docs/reference/library/4h.md#soq)
-[`++tar`](@/docs/reference/library/4h.md#tar)
-[`++tec`](@/docs/reference/library/4h.md#tec)
-[`++tis`](@/docs/reference/library/4h.md#tis)
-[`++wut`](@/docs/reference/library/4h.md#wut)
-[`++zap`](@/docs/reference/library/4h.md#zap)
+<a href='https://urbit.org/docs/reference/library/4h.md#ace' data-tippy-content="Parse space"><code>++ace</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#bar'><code>++bar</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#bas'><code>++bas</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#buc'><code>++buc</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#cab'><code>++cab</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#cen'><code>++cen</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#col'><code>++col</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#com'><code>++com</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#doq'><code>++doq</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#dot'><code>++dot</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#fas'><code>++fas</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#gal'><code>++gal</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#gar'><code>++gar</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#hax'><code>++hax</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#hep'><code>++hep</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#kel'><code>++kel</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#ker'><code>++ker</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#ket'><code>++ket</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#lus'><code>++lus</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#pam'><code>++pam</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#pat'><code>++pat</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#pel'><code>++pel</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#per'><code>++per</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#sel'><code>++sel</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#sem'><code>++sem</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#ser'><code>++ser</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#sig'><code>++sig</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#soq'><code>++soq</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#tar'><code>++tar</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#tec'><code>++tec</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#tis'><code>++tis</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#wut'><code>++wut</code></a>
+<a href='https://urbit.org/docs/reference/library/4h.md#zap'><code>++zap</code></a>
 
 ### 4i: parsing (useful idioms)
 
-[`++alf`](@/docs/reference/library/4i.md#alf)
-[`++aln`](@/docs/reference/library/4i.md#aln)
-[`++alp`](@/docs/reference/library/4i.md#alp)
-[`++bet`](@/docs/reference/library/4i.md#bet)
-[`++bin`](@/docs/reference/library/4i.md#bin)
-[`++but`](@/docs/reference/library/4i.md#but)
-[`++cit`](@/docs/reference/library/4i.md#cit)
-[`++dem`](@/docs/reference/library/4i.md#dem)
-[`++dit`](@/docs/reference/library/4i.md#dit)
-[`++dog`](@/docs/reference/library/4i.md#dog)
-[`++doh`](@/docs/reference/library/4i.md#doh)
-[`++dun`](@/docs/reference/library/4i.md#dun)
-[`++duz`](@/docs/reference/library/4i.md#duz)
-[`++gah`](@/docs/reference/library/4i.md#gah)
-[`++gap`](@/docs/reference/library/4i.md#gap)
-[`++gaq`](@/docs/reference/library/4i.md#gaq)
-[`++gaw`](@/docs/reference/library/4i.md#gaw)
-[`++gay`](@/docs/reference/library/4i.md#gay)
-[`++gon`](@/docs/reference/library/4i.md#gon)
-[`++gul`](@/docs/reference/library/4i.md#gul)
-[`++hex`](@/docs/reference/library/4i.md#hex)
-[`++hig`](@/docs/reference/library/4i.md#hig)
-[`++hit`](@/docs/reference/library/4i.md#hit)
-[`++iny`](@/docs/reference/library/4i.md#iny)
-[`++low`](@/docs/reference/library/4i.md#low)
-[`++mes`](@/docs/reference/library/4i.md#mes)
-[`++nix`](@/docs/reference/library/4i.md#nix)
-[`++nud`](@/docs/reference/library/4i.md#nud)
-[`++prn`](@/docs/reference/library/4i.md#prn)
-[`++qit`](@/docs/reference/library/4i.md#qit)
-[`++qut`](@/docs/reference/library/4i.md#qut)
-[`++soz`](@/docs/reference/library/4i.md#soz)
-[`++sym`](@/docs/reference/library/4i.md#sym)
-[`++ven`](@/docs/reference/library/4i.md#ven)
-[`++vit`](@/docs/reference/library/4i.md#vit)
-[`++vul`](@/docs/reference/library/4i.md#vul)
+<a href='https://urbit.org/docs/reference/library/4i.md#alf' data-tippy-content="Parse alphabetic characters"><code>++alf</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#aln' data-tippy-content="Parse alphanumeric characters"><code>++aln</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#alp' data-tippy-content="Parse alphanumeric characters and -"><code>++alp</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#bet'><code>++bet</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#bin'><code>++bin</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#but'><code>++but</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#cit'><code>++cit</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#dem'><code>++dem</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#dit'><code>++dit</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#dog'><code>++dog</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#doh'><code>++doh</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#dun'><code>++dun</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#duz'><code>++duz</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#gah'><code>++gah</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#gap'><code>++gap</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#gaq'><code>++gaq</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#gaw'><code>++gaw</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#gay'><code>++gay</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#gon'><code>++gon</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#gul'><code>++gul</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#hex'><code>++hex</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#hig'><code>++hig</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#hit'><code>++hit</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#iny'><code>++iny</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#low'><code>++low</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#mes'><code>++mes</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#nix'><code>++nix</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#nud'><code>++nud</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#prn'><code>++prn</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#qit'><code>++qit</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#qut'><code>++qut</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#soz'><code>++soz</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#sym'><code>++sym</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#ven'><code>++ven</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#vit'><code>++vit</code></a>
+<a href='https://urbit.org/docs/reference/library/4i.md#vul'><code>++vul</code></a>
 
 ### 4j: parsing (bases and base digits)
 
-[`++ab`](@/docs/reference/library/4j.md#ab)
-[`++bix:ab`](@/docs/reference/library/4j.md#bix-ab)
-[`++hif:ab`](@/docs/reference/library/4j.md#hif-ab)
-[`++huf:ab`](@/docs/reference/library/4j.md#huf-ab)
-[`++hyf:ab`](@/docs/reference/library/4j.md#hyf-ab)
-[`++pev:ab`](@/docs/reference/library/4j.md#pev-ab)
-[`++pew:ab`](@/docs/reference/library/4j.md#pew-ab)
-[`++piv:ab`](@/docs/reference/library/4j.md#piv-ab)
-[`++piw:ab`](@/docs/reference/library/4j.md#piw-ab)
-[`++qeb:ab`](@/docs/reference/library/4j.md#qeb-ab)
-[`++qex:ab`](@/docs/reference/library/4j.md#qex-ab)
-[`++qib:ab`](@/docs/reference/library/4j.md#qib-ab)
-[`++qix:ab`](@/docs/reference/library/4j.md#qix-ab)
-[`++seb:ab`](@/docs/reference/library/4j.md#seb-ab)
-[`++sed:ab`](@/docs/reference/library/4j.md#sed-ab)
-[`++sev:ab`](@/docs/reference/library/4j.md#sev-ab)
-[`++sew:ab`](@/docs/reference/library/4j.md#sew-ab)
-[`++sex:ab`](@/docs/reference/library/4j.md#sex-ab)
-[`++sib:ab`](@/docs/reference/library/4j.md#sib-ab)
-[`++sid:ab`](@/docs/reference/library/4j.md#sid-ab)
-[`++siv:ab`](@/docs/reference/library/4j.md#siv-ab)
-[`++siw:ab`](@/docs/reference/library/4j.md#siw-ab)
-[`++six:ab`](@/docs/reference/library/4j.md#six-ab)
-[`++sov:ab`](@/docs/reference/library/4j.md#sov-ab)
-[`++sow:ab`](@/docs/reference/library/4j.md#sow-ab)
-[`++sox:ab`](@/docs/reference/library/4j.md#sox-ab)
-[`++ted:ab`](@/docs/reference/library/4j.md#ted-ab)
-[`++tid:ab`](@/docs/reference/library/4j.md#tid-ab)
-[`++til:ab`](@/docs/reference/library/4j.md#til-ab)
-[`++tip:ab`](@/docs/reference/library/4j.md#tip-ab)
-[`++tiq:ab`](@/docs/reference/library/4j.md#tiq-ab)
-[`++urs:ab`](@/docs/reference/library/4j.md#urs-ab)
-[`++urt:ab`](@/docs/reference/library/4j.md#urt-ab)
-[`++voy:ab`](@/docs/reference/library/4j.md#voy-ab)
+<a href='https://urbit.org/docs/reference/library/4j.md#ab' data-tippy-content="Primitive parser engine"><code>++ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#bix-ab'><code>++bix:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#hif-ab'><code>++hif:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#huf-ab'><code>++huf:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#hyf-ab'><code>++hyf:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#pev-ab'><code>++pev:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#pew-ab'><code>++pew:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#piv-ab'><code>++piv:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#piw-ab'><code>++piw:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#qeb-ab'><code>++qeb:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#qex-ab'><code>++qex:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#qib-ab'><code>++qib:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#qix-ab'><code>++qix:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#seb-ab'><code>++seb:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#sed-ab'><code>++sed:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#sev-ab'><code>++sev:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#sew-ab'><code>++sew:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#sex-ab'><code>++sex:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#sib-ab'><code>++sib:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#sid-ab'><code>++sid:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#siv-ab'><code>++siv:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#siw-ab'><code>++siw:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#six-ab'><code>++six:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#sov-ab'><code>++sov:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#sow-ab'><code>++sow:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#sox-ab'><code>++sox:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#ted-ab'><code>++ted:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#tid-ab'><code>++tid:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#til-ab'><code>++til:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#tip-ab'><code>++tip:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#tiq-ab'><code>++tiq:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#urs-ab'><code>++urs:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#urt-ab'><code>++urt:ab</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#voy-ab'><code>++voy:ab</code></a>
 
-[`++ag`](@/docs/reference/library/4j.md#ag)
-[`++ape:ag`](@/docs/reference/library/4j.md#ape-ag)
-[`++bay:ag`](@/docs/reference/library/4j.md#bay-ag)
-[`++bip:ag`](@/docs/reference/library/4j.md#bip-ag)
-[`++dem:ag`](@/docs/reference/library/4j.md#dem-ag)
-[`++dim:ag`](@/docs/reference/library/4j.md#dim-ag)
-[`++dum:ag`](@/docs/reference/library/4j.md#dum-ag)
-[`++fed:ag`](@/docs/reference/library/4j.md#fed-ag)
-[`++hex:ag`](@/docs/reference/library/4j.md#hex-ag)
-[`++lip:ag`](@/docs/reference/library/4j.md#lip-ag)
-[`++viz:ag`](@/docs/reference/library/4j.md#viz-ag)
-[`++vum:ag`](@/docs/reference/library/4j.md#vum-ag)
-[`++wiz:ag`](@/docs/reference/library/4j.md#wiz-ag)
+<a href='https://urbit.org/docs/reference/library/4j.md#ag' data-tippy-content="Top-level atom parser engine"><code>++ag</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#ape-ag' data-tippy-content="Parse 0 or rule"><code>++ape:ag</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#bay-ag'><code>++bay:ag</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#bip-ag'><code>++bip:ag</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#dem-ag'><code>++dem:ag</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#dim-ag'><code>++dim:ag</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#dum-ag'><code>++dum:ag</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#fed-ag'><code>++fed:ag</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#hex-ag'><code>++hex:ag</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#lip-ag'><code>++lip:ag</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#viz-ag'><code>++viz:ag</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#vum-ag'><code>++vum:ag</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#wiz-ag'><code>++wiz:ag</code></a>
 
-[`++mu`](@/docs/reference/library/4j.md#mu)
-[`++zag:mu`](@/docs/reference/library/4j.md#zag-mu)
-[`++zig:mu`](@/docs/reference/library/4j.md#zig-mu)
-[`++zug:mu`](@/docs/reference/library/4j.md#zug-mu)
+<a href='https://urbit.org/docs/reference/library/4j.md#mu'><code>++mu</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#zag-mu'><code>++zag:mu</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#zig-mu'><code>++zig:mu</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#zug-mu'><code>++zug:mu</code></a>
 
-[`++ne`](@/docs/reference/library/4j.md#ne)
-[`++d:ne`](@/docs/reference/library/4j.md#d-ne)
-[`++v:ne`](@/docs/reference/library/4j.md#v-ne)
-[`++w:ne`](@/docs/reference/library/4j.md#w-ne)
-[`++x:ne`](@/docs/reference/library/4j.md#x-ne)
+<a href='https://urbit.org/docs/reference/library/4j.md#ne'><code>++ne</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#d-ne'><code>++d:ne</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#v-ne'><code>++v:ne</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#w-ne'><code>++w:ne</code></a>
+<a href='https://urbit.org/docs/reference/library/4j.md#x-ne'><code>++x:ne</code></a>
 
 ### 4k: parsing (atom printing)
 
-[`++co`](@/docs/reference/library/4k.md#co)
-[`++rear:co`](@/docs/reference/library/4k.md#rear-co)
-[`++rend:co`](@/docs/reference/library/4k.md#rend-co)
-[`++rent:co`](@/docs/reference/library/4k.md#rent-co)
+<a href='https://urbit.org/docs/reference/library/4k.md#co'><code>++co</code></a>
+<a href='https://urbit.org/docs/reference/library/4k.md#rear-co'><code>++rear:co</code></a>
+<a href='https://urbit.org/docs/reference/library/4k.md#rend-co'><code>++rend:co</code></a>
+<a href='https://urbit.org/docs/reference/library/4k.md#rent-co'><code>++rent:co</code></a>
 
 ### 4l: parsing (atom parsing)
 
-[`++so`](@/docs/reference/library/4l.md#so)
-[`++bisk:so`](@/docs/reference/library/4l.md#bisk-so)
-[`++crub:so`](@/docs/reference/library/4l.md#crub-so)
-[`++nuck:so`](@/docs/reference/library/4l.md#nuck-so)
-[`++nusk:so`](@/docs/reference/library/4l.md#nusk-so)
-[`++perd:so`](@/docs/reference/library/4l.md#perd-so)
-[`++royl:so`](@/docs/reference/library/4l.md#royl-so)
-[`++royl-cell:so`](@/docs/reference/library/4l.md#royl-cell-so)
-[`++tash:so`](@/docs/reference/library/4l.md#tash-so)
-[`++twid:so`](@/docs/reference/library/4l.md#twid-so)
-[`++zust:so`](@/docs/reference/library/4l.md#zust-so)
+<a href='https://urbit.org/docs/reference/library/4l.md#so'><code>++so</code></a>
+<a href='https://urbit.org/docs/reference/library/4l.md#bisk-so'><code>++bisk:so</code></a>
+<a href='https://urbit.org/docs/reference/library/4l.md#crub-so'><code>++crub:so</code></a>
+<a href='https://urbit.org/docs/reference/library/4l.md#nuck-so'><code>++nuck:so</code></a>
+<a href='https://urbit.org/docs/reference/library/4l.md#nusk-so'><code>++nusk:so</code></a>
+<a href='https://urbit.org/docs/reference/library/4l.md#perd-so'><code>++perd:so</code></a>
+<a href='https://urbit.org/docs/reference/library/4l.md#royl-so'><code>++royl:so</code></a>
+<a href='https://urbit.org/docs/reference/library/4l.md#royl-cell-so'><code>++royl-cell:so</code></a>
+<a href='https://urbit.org/docs/reference/library/4l.md#tash-so'><code>++tash:so</code></a>
+<a href='https://urbit.org/docs/reference/library/4l.md#twid-so'><code>++twid:so</code></a>
+<a href='https://urbit.org/docs/reference/library/4l.md#zust-so'><code>++zust:so</code></a>
 
 ### 4m: parsing (formatting functions)
 
-[`++scot`](@/docs/reference/library/4m.md#scot)
-[`++scow`](@/docs/reference/library/4m.md#scow)
-[`++slat`](@/docs/reference/library/4m.md#slat)
-[`++slav`](@/docs/reference/library/4m.md#slav)
-[`++slaw`](@/docs/reference/library/4m.md#slaw)
-[`++slay`](@/docs/reference/library/4m.md#slay)
-[`++smyt`](@/docs/reference/library/4m.md#smyt)
-[`++spat`](@/docs/reference/library/4m.md#spat)
-[`++spud`](@/docs/reference/library/4m.md#spud)
-[`++stab`](@/docs/reference/library/4m.md#stab)
+<a href='https://urbit.org/docs/reference/library/4m.md#scot'><code>++scot</code></a>
+<a href='https://urbit.org/docs/reference/library/4m.md#scow'><code>++scow</code></a>
+<a href='https://urbit.org/docs/reference/library/4m.md#slat'><code>++slat</code></a>
+<a href='https://urbit.org/docs/reference/library/4m.md#slav'><code>++slav</code></a>
+<a href='https://urbit.org/docs/reference/library/4m.md#slaw'><code>++slaw</code></a>
+<a href='https://urbit.org/docs/reference/library/4m.md#slay'><code>++slay</code></a>
+<a href='https://urbit.org/docs/reference/library/4m.md#smyt'><code>++smyt</code></a>
+<a href='https://urbit.org/docs/reference/library/4m.md#spat'><code>++spat</code></a>
+<a href='https://urbit.org/docs/reference/library/4m.md#spud'><code>++spud</code></a>
+<a href='https://urbit.org/docs/reference/library/4m.md#stab'><code>++stab</code></a>
 
 ### 4n: parsing (virtualization)
 
-[`++mack`](@/docs/reference/library/4n.md#mack)
-[`++mink`](@/docs/reference/library/4n.md#mink)
-[`++mock`](@/docs/reference/library/4n.md#mock)
-[`++mong`](@/docs/reference/library/4n.md#mong)
-[`++mook`](@/docs/reference/library/4n.md#mook)
-[`++mule`](@/docs/reference/library/4n.md#mule)
-[`++mute`](@/docs/reference/library/4n.md#mute)
+<a href='https://urbit.org/docs/reference/library/4n.md#mack'><code>++mack</code></a>
+<a href='https://urbit.org/docs/reference/library/4n.md#mink'><code>++mink</code></a>
+<a href='https://urbit.org/docs/reference/library/4n.md#mock'><code>++mock</code></a>
+<a href='https://urbit.org/docs/reference/library/4n.md#mong'><code>++mong</code></a>
+<a href='https://urbit.org/docs/reference/library/4n.md#mook'><code>++mook</code></a>
+<a href='https://urbit.org/docs/reference/library/4n.md#mule'><code>++mule</code></a>
+<a href='https://urbit.org/docs/reference/library/4n.md#mute'><code>++mute</code></a>
 
 ### 4o: parsing (molds)
 
-[`++abel`](@/docs/reference/library/4o.md#abel)
-[`++aura`](@/docs/reference/library/4o.md#aura)
-[`++axis`](@/docs/reference/library/4o.md#axis)
-[`++base`](@/docs/reference/library/4o.md#base)
-[`++bean`](@/docs/reference/library/4o.md#bean)
-[`++beer`](@/docs/reference/library/4o.md#beer)
-[`++beet`](@/docs/reference/library/4o.md#beet)
-[`++chum`](@/docs/reference/library/4o.md#chum)
-[`++coil`](@/docs/reference/library/4o.md#coil)
-[`++foot`](@/docs/reference/library/4o.md#foot)
-[`++limb`](@/docs/reference/library/4o.md#limb)
-[`++line`](@/docs/reference/library/4o.md#line)
-[`++metl`](@/docs/reference/library/4o.md#metl)
-[`++nock`](@/docs/reference/library/4o.md#nock)
-[`++noun`](@/docs/reference/library/4o.md#noun)
-[`++null`](@/docs/reference/library/4o.md#null)
-[`++port`](@/docs/reference/library/4o.md#port)
-[`++span`](@/docs/reference/library/4o.md#span)
-[`++tiki`](@/docs/reference/library/4o.md#tiki)
-[`++toga`](@/docs/reference/library/4o.md#toga)
-[`++tone`](@/docs/reference/library/4o.md#tone)
-[`++tuna`](@/docs/reference/library/4o.md#tuna)
-[`++tusk`](@/docs/reference/library/4o.md#tusk)
-[`++tyke`](@/docs/reference/library/4o.md#tyke)
-[`++typo`](@/docs/reference/library/4o.md#typo)
-[`++tyre`](@/docs/reference/library/4o.md#tyre)
-[`++vase`](@/docs/reference/library/4o.md#vase)
-[`++vise`](@/docs/reference/library/4o.md#vise)
-[`++wing`](@/docs/reference/library/4o.md#wing)
+<a href='https://urbit.org/docs/reference/library/4o.md#abel' data-tippy-content="Compiler alias"><code>++abel</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#aura' data-tippy-content="'Type' of atom"><code>++aura</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#axis' data-tippy-content="Nock axis"><code>++axis</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#base'><code>++base</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#bean'><code>++bean</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#beer'><code>++beer</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#beet'><code>++beet</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#chum'><code>++chum</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#coil'><code>++coil</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#foot'><code>++foot</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#limb'><code>++limb</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#line'><code>++line</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#metl'><code>++metl</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#nock'><code>++nock</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#noun'><code>++noun</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#null'><code>++null</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#port'><code>++port</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#span'><code>++span</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#tiki'><code>++tiki</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#toga'><code>++toga</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#tone'><code>++tone</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#tuna'><code>++tuna</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#tusk'><code>++tusk</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#tyke'><code>++tyke</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#typo'><code>++typo</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#tyre'><code>++tyre</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#vase'><code>++vase</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#vise'><code>++vise</code></a>
+<a href='https://urbit.org/docs/reference/library/4o.md#wing'><code>++wing</code></a>
 
 ### 5a: compiler utilities
 
-[_(To be documented)_](@/docs/reference/library/5a.md)
+<a href='https://urbit.org/docs/reference/library/5a.md'>_(To be documented)_</a>
 
 ### 5b: macro expansion
 
-[_(To be documented)_](@/docs/reference/library/5b.md)
+<a href='https://urbit.org/docs/reference/library/5b.md'>_(To be documented)_</a>
 
 ### 5c: compiler backend and prettyprinter
 
-[_(To be documented)_](@/docs/reference/library/5c.md)
+<a href='https://urbit.org/docs/reference/library/5c.md'>_(To be documented)_</a>
 
 ### 5d: parser
 
-[_(To be documented)_](@/docs/reference/library/5d.md)
+<a href='https://urbit.org/docs/reference/library/5d.md'>_(To be documented)_</a>
 
 ### 5e: caching compiler
 
-[_(To be documented)_](@/docs/reference/library/5e.md)
+<a href='https://urbit.org/docs/reference/library/5e.md'>_(To be documented)_</a>
 
 ### 5f: molds and mold builders
 
-[`++mane`](@/docs/reference/library/5f.md#mane)
-[`++manx`](@/docs/reference/library/5f.md#manx)
-[`++marl`](@/docs/reference/library/5f.md#marl)
-[`++mars`](@/docs/reference/library/5f.md#mars)
-[`++mart`](@/docs/reference/library/5f.md#mart)
-[`++marx`](@/docs/reference/library/5f.md#marx)
-[`++pass`](@/docs/reference/library/5f.md#pass)
-[`++ring`](@/docs/reference/library/5f.md#ring)
-[`++time`](@/docs/reference/library/5f.md#time)
+<a href='https://urbit.org/docs/reference/library/5f.md#mane'><code>++mane</code></a>
+<a href='https://urbit.org/docs/reference/library/5f.md#manx'><code>++manx</code></a>
+<a href='https://urbit.org/docs/reference/library/5f.md#marl'><code>++marl</code></a>
+<a href='https://urbit.org/docs/reference/library/5f.md#mars'><code>++mars</code></a>
+<a href='https://urbit.org/docs/reference/library/5f.md#mart'><code>++mart</code></a>
+<a href='https://urbit.org/docs/reference/library/5f.md#marx'><code>++marx</code></a>
+<a href='https://urbit.org/docs/reference/library/5f.md#pass'><code>++pass</code></a>
+<a href='https://urbit.org/docs/reference/library/5f.md#ring'><code>++ring</code></a>
+<a href='https://urbit.org/docs/reference/library/5f.md#time'><code>++time</code></a>
 
 ### 5g: profiling support
 
-[_(To be documented)_](@/docs/reference/library/5g.md)
+<a href='https://urbit.org/docs/reference/library/5g.md'>_(To be documented)_</a>


### PR DESCRIPTION
Fixes #601. This PR, in conjunction with [urbit.org#163](https://github.com/urbit/urbit.org/pull/163), provides tooltips and metadata for every arm of the standard library.

- Converts all links in _index.md from inline Markdown to HTML
- Adds tooltip class to those links
- Provides new, brief descriptions for every arm of the library as `title` attributes (yes, I went to each page, and consistently and succinctly described the functionality; if I couldn't, I just used the summary the documentation itself used)

## The good

- This PR's text is de facto metadata for the entire standard library functionality, organised by its term. If you use some regex, you can transform this into JSON trivially and make it into anything you like — up to and including IDE extensions. VSCode could mouse over `flop`, `vum:ag` or `lust` and tell you what they mean, for example.

## The bad

- HTML is harder to read when editing — but hey, it's a single page.
- When stdlib changes in future, it must be considered part of the workflow to **add a title attribute to its link on this page**. There are two listings — alphabetical and per section — so find and replace is a necessity.