### PR TITLE
fix 0 test in Ackermann function

### DIFF
--- a/learn/hoon/hoon-tutorial/ackermann.md
+++ b/learn/hoon/hoon-tutorial/ackermann.md
@@ -10,8 +10,8 @@ In this lesson, we will write a gate that computes the [Ackermann function](http
 
  ```
 |=  [m=@ n=@]
-?~  m  +(n)
-?~  n  $(m (dec m), n 1)
+?:  =(m 0)  +(n)
+?:  =(n 0)  $(m (dec m), n 1)
 $(m (dec m), n $(n (dec n)))
 ```
 


### PR DESCRIPTION
According to the [`wut` docs](https://github.com/urbit/docs/blob/master/reference/hoon-expressions/rune/wut.md), "It's bad style to use `?~` to test for any zero atom. Use it only for a true null, `~`." The [Ackermann function example](https://github.com/urbit/docs/blob/master/learn/hoon/hoon-tutorial/ackermann.md) uses `?~` to test for a zero atom, so this PR corrects this to the proper use of `?:`instead.