### PR TITLE
update cass and cuss

### DIFF
--- a/reference/library/4b.md
+++ b/reference/library/4b.md
@@ -185,7 +185,8 @@ XX document
 
 To lowercase
 
-Produce the case insensitive (all lowercase) `++cord` of a `++tape`.
+Turn all occurences of uppercase letters in any `++tape` into lowercase
+letters. Returns a `++tape`.
 
 #### Accepts
 
@@ -193,31 +194,28 @@ Produce the case insensitive (all lowercase) `++cord` of a `++tape`.
 
 #### Produces
 
-A `++cord`.
+A `++tape`.
 
 #### Source
 
 ```
     ++  cass                                                ::  lowercase
       |=  vib/tape
-      %+  rap  3
+      ^-  tape
       (turn vib |=(a/@ ?.(&((gte a 'A') (lte a 'Z')) a (add 32 a))))
 ```
 
 #### Examples
 
 ```
-    > (cass "john doe")
-    7.309.170.810.699.673.450
+    > (cass "JOHN DOE")
+    "john doe"
 
-    > `cord`(cass "john doe")
-    'john doe'
+    > (cass "abc ABC 123 !@#")
+    "abc abc 123 !@#"
 
-    > (cass "abc, 123, !@#")
-    2.792.832.775.110.938.439.066.079.945.313
-
-    > `cord`(cass "abc, 123, !@#")
-    'abc, 123, !@#'
+    > (cass "AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsQqRrVvWwXxYyZz")
+    "aabbccddeeffgghhiijjkkllmmnnooppqqrrssqqrrvvwwxxyyzz"
 ```
 
 ---
@@ -259,8 +257,8 @@ A `++cord`.
 
 To uppercase
 
-Turn all occurances of lowercase letters in any `++tape` into uppercase
-letters, as a `++cord`.
+Turn all occurences of lowercase letters in any `++tape` into uppercase
+letters. Returns a `++tape`.
 
 #### Accepts
 
@@ -268,32 +266,28 @@ letters, as a `++cord`.
 
 #### Produces
 
-A `++cord`.
+A `++tape`.
 
 #### Source
 
 ```
     ++  cuss                                                ::  uppercase
-      |=  vib=tape
-      ^-  @t
-      %+  rap  3
-      (turn vib |=(a=@ ?.(&((gte a 'a') (lte a 'z')) a (sub a 32))))
+      |=  vib/tape
+      ^-  tape
+      (turn vib |=(a/@ ?.(&((gte a 'a') (lte a 'z')) a (sub a 32))))
 ```
 
 #### Examples
 
 ```
     > (cuss "john doe")
-    'JOHN DOE'
+    "JOHN DOE"
 
     > (cuss "abc ABC 123 !@#")
-    'ABC ABC 123 !@#'
-
-    > `@ud`(cuss "abc")
-    4.407.873
+    "ABC ABC 123 !@#"
 
     > (cuss "AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsQqRrVvWwXxYyZz")
-    'AABBCCDDEEFFGGHHIIJJKKLLMMNNOOPPQQRRSSQQRRVVWWXXYYZZ'
+    "AABBCCDDEEFFGGHHIIJJKKLLMMNNOOPPQQRRSSQQRRVVWWXXYYZZ"
 ```
 
 ---


### PR DESCRIPTION
The docs incorrectly state that `++cass` and `++cuss` returns `cords`. They return `tapes`. This PR also updates the relevant examples, removing some that actually `nest-fail`, and synchronizes them between the two methods.