### PR TITLE
Add article links to community tutorials page.

### DIFF
--- a/concepts/community-tutorials.md
+++ b/concepts/community-tutorials.md
@@ -9,5 +9,7 @@ Here are some tutorials written by members of the Urbit community. Some are a li
 - [Generators](https://github.com/joemfb/mardev/tree/master/docs/gen) by `~master-morzod`
 - [Urbit by Doing](https://github.com/Fang-/Urbit-By-Doing) by `~palfun-foslup`
 - [Learning Hoon](https://github.com/knubie/learning-hoon) by `@knubie`
+- [A Nock Interpreter](https://jtobin.io/nock) by `~nidsut-tomdun`
+- [Basic Hoonery](https://jtobin.io/basic-hoonery) by `~nidsut-tomdun`
 
 If you want to add something to the list, [shoot us an email](mailto:support@urbit.org) or make a pull request in the [docs repository](https://github.com/urbit/docs).


### PR DESCRIPTION
These are two blog posts on Nock and Hoon that I wrote some time ago; others have mentioned they found them useful, so they're probably worth linking here.