### PR TITLE
kiss -> task

### DIFF
--- a/learn/arvo/_index.md
+++ b/learn/arvo/_index.md
@@ -101,12 +101,12 @@ As of this writing, we have seven vanes, which each provide the following servic
 
 ### Cards
 
-Cards are the vane-specific portion of a move. Each vane defines a protocol for interacting with other vanes (via Arvo) by defining four types of cards: kisses, gifts, notes, and signs.
+Cards are the vane-specific portion of a move. Each vane defines a protocol for interacting with other vanes (via Arvo) by defining four types of cards: tasks, gifts, notes, and signs.
 
-When one vane is `%pass`ed a card in its `++kiss`, Arvo activates the `++call` gate with the card as its argument. To produce a result, the vane `%give`s one of the cards defined in its `++gift`. If the vane needs to request something of another vane, it `%pass`es it a `++note` card. When that other vane returns a result, Arvo activates the `++take` gate of the initial vane with one of the cards defined in its `++sign`.
+When one vane is `%pass`ed a card in its `++task` (defined in zuse), Arvo activates the `++call` gate with the card as its argument. To produce a result, the vane `%give`s one of the cards defined in its `++gift`. If the vane needs to request something of another vane, it `%pass`es it a `++note` card. When that other vane returns a result, Arvo activates the `++take` gate of the initial vane with one of the cards defined in its `++sign`.
 
-In other words, there are only four ways of seeing a move: (1) as a request seen by the caller, which is a ++note. (2) that same request as seen by the callee, a `++kiss`. (3) the response to that first request as seen by the callee, a `++gift`. (4) the response to the first request as seen by the caller, a `++sign`.
+In other words, there are only four ways of seeing a move: (1) as a request seen by the caller, which is a ++note. (2) that same request as seen by the callee, a `++task`. (3) the response to that first request as seen by the callee, a `++gift`. (4) the response to the first request as seen by the caller, a `++sign`.
 
-When a `++kiss` card is passed to a vane, Arvo calls its `++call` gate, passing it both the card and its duct. This gate must be defined in every vane. It produces two things in the following order: a list of moves and a possibly modified copy of its context. The moves are used to interact with other vanes, while the new context allows the vane to save its state. The next time Arvo activates the vane it will have this context as its subject.
+When a `++task` card is passed to a vane, Arvo calls its `++call` gate, passing it both the card and its duct. This gate must be defined in every vane. It produces two things in the following order: a list of moves and a possibly modified copy of its context. The moves are used to interact with other vanes, while the new context allows the vane to save its state. The next time Arvo activates the vane it will have this context as its subject.
 
-This overview has detailed how to pass a card to a particular vane. To see the cards each vane can be `%pass`ed as a `++kiss` or return as a `++gift` (as well as the semantics tied to them), each vane's public interface is explained in detail in its respective overview.
+This overview has detailed how to pass a card to a particular vane. To see the cards each vane can be `%pass`ed as a `++task` or return as a `++gift` (as well as the semantics tied to them), each vane's public interface is explained in detail in its respective overview.

--- a/learn/arvo/ames.md
+++ b/learn/arvo/ames.md
@@ -681,10 +681,10 @@ The packet, after its creation, embarks on a journey across physical
 time and space into the great unknown. Hurtling through fiber-optic
 cables at hundreds of thousands of kilometers per second, it finally
 arrives at our neighbor's network adapter. The adapter tells unix, unix
-tells libuv, libuv tells vere, and vere sends a `%hear` kiss to ames.
+tells libuv, libuv tells vere, and vere sends a `%hear` task to ames.
 And now we reenter the kernel.
 
-The `%hear` kiss goes straight to `++knob`, just as did the `%wont` kiss
+The `%hear` task goes straight to `++knob`, just as did the `%wont` task
 earlier.
 
 ```
@@ -693,12 +693,12 @@ earlier.
 ```
 
 Here, though, we call `++gnaw:am` to process the packet. The arguments
-to `++gnaw` are the same as those to the `%hear` kiss: the lane on which
+to `++gnaw` are the same as those to the `%hear` task: the lane on which
 the packet was received and the packet itself. The other argument is
 just `%good`, which is a `++cape:ames` saying that we expect the packet to
 succeed. If a formal error occurs, then since we have a transactional
 event system, the `%hear` event will never be considered to have
-actually happened, and unix will send a `%hole` kiss so that we may send
+actually happened, and unix will send a `%hole` task so that we may send
 a negative acknowledgment.
 
 ```
@@ -929,7 +929,7 @@ Forwarding is the simplest case, since we've seen all the arms before,
 except perhaps `++emit` and `++emir`, which simply take a boon or list
 of boons respectively and queue them up to be handled when the core
 resolves. If we're told to forward a packet to ourselves, then we emit a
-`%mead` boon which simply sends another `%hear` kiss to ourselves with
+`%mead` boon which simply sends another `%hear` task to ourselves with
 the data. Otherwise, we try to find a route to the recipient, as before.
 
 ```
@@ -1278,9 +1278,9 @@ The weary traveler is seeking out its familial roots, finding the app
 from whom sprung forth the original message way back in paragraph three.
 When it arrives at the network adapter of its ancestors, the adapter
 tells unix, unix tells libuv, libuv tells vere, and vere sends a `%hear`
-kiss to ames. Once more into the kernel.
+task to ames. Once more into the kernel.
 
-The `%hear` kiss is handled in `++knob` as before, leading to `++gnaw`,
+The `%hear` task is handled in `++knob` as before, leading to `++gnaw`,
 going over to `++chew`, `++apse`, `++chow`, and eventualy to `++dine`.
 We've seen most of the cases in `++dine`, but we haven't yet looked at
 the handling of this `%buck` meal.

--- a/learn/arvo/eyre.md
+++ b/learn/arvo/eyre.md
@@ -50,10 +50,10 @@ browser to server to browser and back.
 ### Initial request
 
 An http request for `http://sampel-sipnym.urbit.org/cli` will be [redirected](dns)
-to the `%eyre` on ~sampel-sipnym, and come in as a `%this` kiss.
+to the `%eyre` on ~sampel-sipnym, and come in as a `%this` task.
 
 From arvo, requests enter `++call`, which after some type reification are passed
-along to `++apex:ye`. In the case of a `%this` kiss, its components are
+along to `++apex:ye`. In the case of a `%this` task, its components are
 parsed(see `++zest:epur`, `++eat-headers`) and handed off to `++handle`, wrapped
 in `++emule` to produce a `++fail` page in case of error. `++apex:handle` will
 `++process` the request to a `pest` or a `++done` core, and in the former case
@@ -295,7 +295,7 @@ This document outlines the following:
 
 2. [the values stored on the client](#client), both statically in cookies and dynamically as the `window.urb` object, which facilitate this transaction.
 
-3. [`kiss`](#kiss), the requests `%eyre` will accept.
+3. [`task`](#task), the requests `%eyre` will accept.
 
 4. [`gift`](#gift), the responses it will give to those requests.
 

--- a/learn/arvo/gall.md
+++ b/learn/arvo/gall.md
@@ -755,7 +755,7 @@ code quoted above includes a bunch of otherwise unnecessary faces for
 the purpose of illustration. Compare: `[%hiss p=(unit user) q=mark
 r=cage]` from `zuse`.
 
-> You can grep zuse.hoon and arvo.hoon for most of these definitions. However, beware the ambiguity surrounding "hiss": there's ++hiss in section 3bI of `zuse` ("Arvo structures"), and there's `%hiss` the move that is sent to %eyre to make our HTTP request happen. Here we're talking about the latter. See `++kiss-eyre` in `zuse`.
+> You can grep zuse.hoon and arvo.hoon for most of these definitions. However, beware the ambiguity surrounding "hiss": there's ++hiss in section 3bI of `zuse` ("Arvo structures"), and there's `%hiss` the move that is sent to %eyre to make our HTTP request happen. Here we're talking about the latter. See `++task:able:eyre` in `zuse`.
 
 > Recall that `++unit` means "maybe".  Formally, "`(unit a)` is either null or a pair of null and a value in `a`". Also recall that to pull a value out of a unit (`u.unit`), you must first verify that the unit is not null (for example with `?~`). See `++need`.
 


### PR DESCRIPTION
Removes references to `kiss` and replacing them with `task` where appropriate - protects readers from trying to figure out what the hell a `kiss` is (which was replaced with `task` a while back).