### PR TITLE
fixed syntax update errors in library 2a section

### DIFF
--- a/reference/library/2a.md
+++ b/reference/library/2a.md
@@ -24,7 +24,7 @@ A unit.
 
 ```
     ++  biff
-      |*  [a](unit) b]$-(* (unit))]
+      |*  [a=(unit) b=$-(* (unit))]
       ?~  a  ~
       (b u.a)
 ```
@@ -32,10 +32,10 @@ A unit.
 #### Examples
 
 ```
-    > (biff (some 5) |=(a]@ (some (add a 2))))
+    > (biff (some 5) |=(a=@ (some (add a 2))))
     [~ u=7]
 
-    > (biff ~ |=(a]@ (some (add a 2))))
+    > (biff ~ |=(a=@ (some (add a 2))))
     ~
 ```
 
@@ -75,7 +75,7 @@ A unit.
     > (bind ((unit @) [~ 97]) ,@t)
     [~ u='a']
 
-    > =a |=(a]@ (add a 1))
+    > =a |=(a=@ (add a 1))
     > (bind ((unit @) [~ 2]) a)
     [~ u=3]
 ```
@@ -185,7 +185,7 @@ A unit.
 
 ```
     ++  clap                                                ::  combine
-      |*  [a](unit) b=(unit) c=_|=(^ +<-)]
+      |*  [a=(unit) b=(unit) c=_|=(^ +<-)]
       ?~  a  b
       ?~  b  a
       [~ u=(c u.a u.b)]
@@ -389,7 +389,7 @@ Either the unwrapped value of `a` (`u.a`), or crash.
 
 ```
     ++  need                                                ::  demand
-      |*  a](unit)
+      |*  a=(unit)
       ?~  a  ~|(%need !!)
       u.a
 ```


### PR DESCRIPTION
`/` was changed to `]` instead of `=`