### PR TITLE
removed next up links

### DIFF
--- a/tutorials/hoon/ackermann.md
+++ b/tutorials/hoon/ackermann.md
@@ -27,6 +27,3 @@ Second, if `n` is zero, decrement `m`, set `n` to 1 and recurse.
 Else, decrement `m` and set `n` to be the value of the Ackermann function with `n` and the decrement of `n` as arguments.
 
 This is not a terribly useful function to compute but it has an interesting history in mathematics. When running this function the value grows rapidly even for very small input. The value of computing this where `m` is `4` and `n` is `2` is an integer with 19,729 digits.
-
-
-### [Next Up: Reading -- Arms and Cores](../arms-and-cores)

--- a/tutorials/hoon/arms-and-cores.md
+++ b/tutorials/hoon/arms-and-cores.md
@@ -486,5 +486,3 @@ You can now unbind `c` in the dojo -- this will help to keep your dojo subject t
 > c
 -find.c
 ```
-
-### [Next Up: Walkthrough -- Caesar Cipher](../caesar)

--- a/tutorials/hoon/atoms-auras-and-simple-cell-types.md
+++ b/tutorials/hoon/atoms-auras-and-simple-cell-types.md
@@ -775,5 +775,3 @@ Hoon pretty-prints them the same way, but can we be sure that they are the same 
 
 They are indeed the same.
 
-
-### [Next Up: Reading -- Type Checking and Type Inference](../type-checking-and-type-inference)

--- a/tutorials/hoon/bank-account.md
+++ b/tutorials/hoon/bank-account.md
@@ -78,5 +78,3 @@ Each of these arms produces a gate which takes an `@ud` argument. Each of these 
 `+>` is [wing syntax](/docs/reference/hoon-expressions/limb/limb/). This particularly wing construction looks for the the tail of the tail (the third element) in `$`, the subject of the gate we are in, which is the entire `new-account` door. We change `balance` to be the result of adding `balance` and `amount` and produce the door as the result. `withdraw` functions the same way only doing subtraction instead of addition.
 
 It's important to notice that the sample, `balance`, is stored as part of the door rather than existing outside of it.
-
-### [Next Up: Reading -- Generators](../generators)

--- a/tutorials/hoon/caesar.md
+++ b/tutorials/hoon/caesar.md
@@ -343,5 +343,3 @@ look for the legible result.
 possible unshifted `tapes`.
 
 4. Modify the example generator into a `%say` generator.
-
-### [Next Up: Reading -- Doors](../doors)

--- a/tutorials/hoon/conditionals.md
+++ b/tutorials/hoon/conditionals.md
@@ -71,5 +71,3 @@ We only went into three "wut" runes in our walkthrough, but there are many other
 - `?|` takes an indefinite number of children. It's the logical "or" operator. It checks if at least one of its children is true.
 
 To see an exhaustive list of "wut" runes, check out the [reference documentation on conditionals](/docs/reference/hoon-expressions/rune/wut/).
-
-### [Next Up: Reading -- Lists](../lists)

--- a/tutorials/hoon/doors.md
+++ b/tutorials/hoon/doors.md
@@ -502,5 +502,3 @@ It's better simply to use the `~(arm rs arg)` syntax to replace the value of the
 ## Conclusion
 
 You've now reached the end of Chapter 1 of the Hoon tutorial.  Ideally you should have a fair understanding of the fundamental concepts of subject-oriented programming: limbs, legs, faces, wings, arms, cores, gates, and doors.  If you can master these concepts you should have little or no trouble learning to write substantial Hoon programs.  Continue to [Chapter 2](atoms-auras-and-simple-cell-types) to get started.
-
-### [Next Up: Walkthrough -- Bank Account](../bank-account)

--- a/tutorials/hoon/egg-timer.md
+++ b/tutorials/hoon/egg-timer.md
@@ -117,5 +117,3 @@ Next we have the same cast we used in `++poke-noun` to make sure we are producin
 `~&` is the debugging printf rune. Here we're using it to output a message. We could, however, modify this line of code to do any other computation we would want to happen when `++wait` gets called.
 
 Finally, we need to produce our `effect`. Here the effect is simply `[~ +>.$]`, since we have no `syscall` to make and we are not changing the state of our app. We just use the `door` without changing its sample.
-
-### [Next Up: Reading -- Ford](../ford)

--- a/tutorials/hoon/fibonacci.md
+++ b/tutorials/hoon/fibonacci.md
@@ -59,5 +59,3 @@ In the code above, `?:` checks whether the first child, `=(i n)`, our terminatin
 ```
 
 The final expression in our program calls the `$` arm of the trap we are but makes some changes: we increment `i`, set `p` to be `q` and `q` becomes the sum of `p` and `q`. `r` becomes a cell of `q` and whatever `r` was previously. The list built from this is the one that will get `flop`ped to produce the result at the end of the computation.
-
-### [Next Up: Reading -- Gates](../gates)

--- a/tutorials/hoon/ford.md
+++ b/tutorials/hoon/ford.md
@@ -193,5 +193,3 @@ produces: `0v0`
 Ford is the vane utilized for unit testing, which are the the simplest sort of test one may perform on software that is one step removed from manual testing. Ford itself does not have testing capabilities built in, rather Ford has a more general capability known as _rendering_ which is utilized by the `+test` generator to perform the tests. The walkthrough which follows this lesson goes into more detail.
 
 One typically tests software by feeding it inputs and seeing if the outputs matches what is expected (something that is determined manually by the engineer). Unit tests work with only a single "module" at a time. What exactly is meant by this is shown by example in the following walkthrough, but for now it suffices to say that unit tests are in contrast with larger scale tests variously known as end-to-end tests, system tests, and integration tests.
-
-### [Next up: Unit Testing with Ford](../test-sets.md)

--- a/tutorials/hoon/gates.md
+++ b/tutorials/hoon/gates.md
@@ -269,5 +269,3 @@ Write a gate that takes an atom, `a=@`, and which returns double the value of `a
 > (double 25)
 50
 ```
-
-### [Next Up: Walkthrough -- Recursion](../recursion)

--- a/tutorials/hoon/hoon-syntax.md
+++ b/tutorials/hoon/hoon-syntax.md
@@ -325,5 +325,3 @@ There are a couple useful runes associated with debugging:
 `~&` (sigpam) is used to print its argument every time that argument executes. So, if you wanted to see how many times your program executed `foo`, you would write `foo bar`. Then, when your program runs, it will print `foo` on a new line of output every time the program comes across it by recursion.
 
 But there are more. Check out the aforementioned [troubleshooting](/docs/reference/troubleshooting/) page to see other handy debugging runes and how to use them.
-
-### [Next Up: Walkthrough -- Conditionals](../conditionals)

--- a/tutorials/hoon/iron-polymorphism.md
+++ b/tutorials/hoon/iron-polymorphism.md
@@ -86,6 +86,3 @@ But `fold` does not have to produce a `list`. Let's look at another example:
 Here `fold` will produce a gate that takes an `atom` and applies a gate to a `list` of `atoms`. The difference here is that this call will produce a sum of the elements of the list, rather than the list itself.
 
 The key takeaway from both of these examples is that the gates provided are _iron polymorphic_ with respect to the definition of the type in `fold`. They are iron polymorphic because samples `s` and `e` nest under the types `state` and `elem`. In second case case, that's because when we provided those to `fold`, it was was stated they were `@` and `@`. In the first case, we stated that `state` was `(list @)` and `elem` was `@`. In both cases, the sample of each gate nest inside the types defined when we called the wet gate `fold`.
-
-
-[Next Up: Walkthrough -- Lead Polymorphism](../lead-polymorphism)

--- a/tutorials/hoon/lead-polymorphism.md
+++ b/tutorials/hoon/lead-polymorphism.md
@@ -153,5 +153,3 @@ Finally, the first line of our program will take the first 10 elements of `fib` 
 ```
 
 This example is a bit overkill for simply calculating the Fibonacci series, but it nicely illustrates how you might use iron cores. Instead of `fib`, you could have any `stream` that produces some stream of values and you'd still be able to use the `take`, `to-list`, and `stream-type` arms.
-
-[Next Up: Reading -- Gall](../gall)

--- a/tutorials/hoon/libraries.md
+++ b/tutorials/hoon/libraries.md
@@ -181,5 +181,3 @@ So now that we have this library, how do we actually use it? Let's look at a ver
 If you save our the library as `playing-cards.hoon` in the `lib` directory, you can import the library with the `/+` rune. Our above `say` -- let's call it `cards.hoon` -- imports our library in this way. It should be noted that `/+` is not a Hoon rune, but instead a rune used by Ford, the Urbit build-system. When `cards.hoon` gets built, Ford will pull in the requested library and also build that. It will also create a dependency so that if `playing-cards.hoon` changes, this file will also get rebuilt.
 
 Below `/+  playing-cards`, you have the standard `say` generator boilerplate that allows us to get a bit of entropy from `arvo` when the generator is run. Then we feed the entropy and a `deck` created by `make-deck` into `shuffle-deck` to get back a shuffled `deck`.
-
-### [Next Up: Reading -- Trees, Sets, and Maps](../trees-sets-and-maps)

--- a/tutorials/hoon/list-of-numbers.md
+++ b/tutorials/hoon/list-of-numbers.md
@@ -130,5 +130,3 @@ Our program works by having each iteration of the list creating a cell. In each 
 ```
 
 If you still don't intuit how this is working, don't worry. We'll take a deeper look into recursion later with our [Recursion walkthrough](../recursion).
-
-### [Next Up: Reading -- Nouns](../nouns)

--- a/tutorials/hoon/lists.md
+++ b/tutorials/hoon/lists.md
@@ -332,5 +332,3 @@ Run in dojo:
 > +snag [2 ~[11 22 33 44]]
 33
 ```
-
-### [Next Up: Walkthrough -- Fibonacci Sequence](../fibonacci)

--- a/tutorials/hoon/nouns.md
+++ b/tutorials/hoon/nouns.md
@@ -479,5 +479,3 @@ That's it for our basic introduction to nouns.  Hit `ctrl-d` to exit your ship, 
 + +14
 + +15
 + +31
-
-### [Next Up: Reading -- Hoon Syntax](../hoon-syntax)

--- a/tutorials/hoon/recursion.md
+++ b/tutorials/hoon/recursion.md
@@ -193,4 +193,3 @@ Disks are stacked on a pole by decreasing order of size. Move all of the
 disks from one pole to another with a third pole as a spare, moving one
 disc at a time, without putting a larger disk on top of a smaller disk.
 
-### [Next Up: Reading -- The Subject and its Legs](../the-subject-and-its-legs/)

--- a/tutorials/hoon/setup.md
+++ b/tutorials/hoon/setup.md
@@ -105,5 +105,3 @@ Emacs is free and open-source and runs on all major operating systems. It is ava
 
 Vim is free and open-source and runs on all major operating systems. It is available [here](https://www.vim.org/). Hoon support is available with [hoon.vim](https://github.com/urbit/hoon.vim) and is maintained by Tlon.
 
-
-### [Next Up: Walkthrough -- List of Numbers](../list-of-numbers)

--- a/tutorials/hoon/structures-and-complex-types.md
+++ b/tutorials/hoon/structures-and-complex-types.md
@@ -354,4 +354,3 @@ Now the `~` value is included as a possible value for `user`.
 
 That's all we have to say about types in this chapter.  More on types in [Chapter 2](@/docs/tutorials/hoon/type-polymorphism.md).
 
-### [Next Up: Walkthrough -- Libraries](../libraries)

--- a/tutorials/hoon/the-subject-and-its-legs.md
+++ b/tutorials/hoon/the-subject-and-its-legs.md
@@ -654,4 +654,3 @@ You can also use more complex wings and modify their values as well:
 
 At this point you should have at least a rough idea of what the subject is, and a fair understanding of how to get legs of the subject using wings.  But legs are only one kind of limb -- we'll talk about arms in the next lesson.
 
-### [Next Up: Walkthrough -- Ackermann Function](../ackermann)

--- a/tutorials/hoon/trees-sets-and-maps.md
+++ b/tutorials/hoon/trees-sets-and-maps.md
@@ -319,5 +319,3 @@ You can use `run` of `by` to apply a gate to each value in a map, producing a ma
 ```
 
 There are other map functions in the Hoon standard library that didn't cover here.
-
-### [Next Up: <placeholder>]

--- a/tutorials/hoon/type-checking-and-type-inference.md
+++ b/tutorials/hoon/type-checking-and-type-inference.md
@@ -641,4 +641,3 @@ More subtly, the `=+`, `=/`, and `=|` runes modify the subject by pinning values
 
 In general, anything that modifies the subject modifies the type of the subject.  Type inference can work in subtle ways for various expressions.  However, we have covered enough that it should be relatively clear how to anticipate how type inference works for the vast majority of ordinary use cases.
 
-### [Next Up: Reading -- Structures and Complex Types](../structures-and-complex-types)


### PR DESCRIPTION
as per Matilde's email that these links can now be generated automatically, I have removed the Next Up links at the end of each Hoon tutorial page