### PR TITLE
change order of 1.4 and 1.5, mini exercises for lists

### DIFF
--- a/tutorials/hoon/fibonacci.md
+++ b/tutorials/hoon/fibonacci.md
@@ -1,6 +1,6 @@
 +++
-title = "1.4.1 Walkthrough: Fibonacci Sequence"
-weight = 7
+title = "1.5.1 Walkthrough: Fibonacci Sequence"
+weight = 9
 template = "doc.html"
 aliases = ["/docs/learn/hoon/hoon-tutorial/fibonacci/"]
 +++

--- a/tutorials/hoon/gates.md
+++ b/tutorials/hoon/gates.md
@@ -166,7 +166,7 @@ Let's look at the context of `inc`:
 
 This is exactly the default dojo subject, from before we put `inc` into the subject.  The `|=` expression defines the context as whatever the subject is.  This guarantees that the context has all the information it needs to have for the `$` arm to work correctly.
 
-### Exercise 1.5.1a
+### Exercise 1.4.1a
 
 Write a gate that takes an atom, `a=@`, and which returns double the value of `a`.  Bind this gate to `double` and test it in the dojo.  A solution is given at the end of this lesson.
 
@@ -256,7 +256,7 @@ Before finishing the lesson let's unbind `ten`:
 > =ten
 ```
 
-## Exercise 1.5a Solution
+## Exercise 1.4.1a Solution
 
 Write a gate that takes an atom, `a=@`, and which returns double the value of `a`.  Bind this gate to `double` and test it in the dojo.
 

--- a/tutorials/hoon/gates.md
+++ b/tutorials/hoon/gates.md
@@ -1,6 +1,6 @@
 +++
-title = "1.5 Gates (Hoon Functions)"
-weight = 8
+title = "1.4 Gates (Hoon Functions)"
+weight = 6
 template = "doc.html"
 aliases = ["/docs/learn/hoon/hoon-tutorial/gates/"]
 +++

--- a/tutorials/hoon/lists.md
+++ b/tutorials/hoon/lists.md
@@ -333,6 +333,9 @@ Then determine whether the following dojo expressions are valid, and if so, what
 > (add (lent b) (lent c))
 ```
 
+#### Exercise 1.5g
+Write a gate that takes in a list `a` and returns `%.y` if `a` is a palindrome and `%.n` otherwise. You may make use of the `flop` function.
+
 
 ## Exercise Solutions
 
@@ -449,3 +452,20 @@ This also fails for the same reason, but it is important to note that in some la
 7
 ```
 We see here the correct way to find the sum of the length of two lists of unknown type.
+
+#### 1.5g
+```hoon
+::  palindrome.hoon
+::
+|=  a=(list)
+=(a (flop a))
+```
+
+Run in dojo:
+
+```
+> +palindrome "urbit"
+%.n
+> +palindrome "racecar"
+%.y
+```

--- a/tutorials/hoon/lists.md
+++ b/tutorials/hoon/lists.md
@@ -207,7 +207,7 @@ You can cast `b` to `(list)` to work around this:
 11
 ```
 
-#### `snag` exercise
+#### `snag` Exercise
 
 Without using `snag`, write a gate that returns the `n`th item of a list.  There is a solution at the bottom of this lesson.
 
@@ -240,6 +240,10 @@ The `lent` function takes a list and returns the number of items in it:
 > (lent "Hello!")
 6
 ```
+
+#### `lent` Exercise
+
+Without using `lent`, write a gate that takes a list and returns the number of item in it. There is a solution at the bottom of this lesson.
 
 ### `roll`
 
@@ -352,4 +356,26 @@ Run in dojo:
 
 > +snag [2 ~[11 22 33 44]]
 33
+```
+
+#### `lent`
+
+```hoon
+::  lent.hoon
+::
+|=  a=(list)
+^-  @
+=/  b=@  0
+|-
+?~  a  b
+$(a t.a, b +(b))
+```
+
+Run in dojo:
+
+```
+> +lent ~[1 2 3 4 5]
+5
+> +lent "asdf"
+4
 ```

--- a/tutorials/hoon/lists.md
+++ b/tutorials/hoon/lists.md
@@ -154,6 +154,10 @@ The `weld` function takes two lists and concatenates them:
 "Happy Birthday!"
 ```
 
+#### `weld` Exercise
+
+Without using `weld`, write a gate that takes a `[(list @) (list @)]` who product is the concatenation of these two lists.
+
 ### `snag`
 
 The `snag` function takes an atom `n` and a list, and returns the `n`th item of the list, where `0` is the first item:
@@ -310,6 +314,23 @@ Run in dojo:
 ```
 > +flop ~[11 22 33 44]
 ~[44 33 22 11]
+```
+
+#### `weld`
+```hoon
+::  weld.hoon
+::
+|=  [a=(list @) b=(list @)]
+|-  ^-  (list @)
+?~  a  b
+[i.a $(a t.a)]
+```
+
+Run in dojo:
+
+```
+> +weld [~[1 2 3] ~[3 4 5 6]]
+~[1 2 3 3 4 5 6]
 ```
 
 #### `snag`

--- a/tutorials/hoon/lists.md
+++ b/tutorials/hoon/lists.md
@@ -1,6 +1,6 @@
 +++
-title = "1.4 Lists"
-weight = 6
+title = "1.5 Lists"
+weight = 8
 template = "doc.html"
 aliases = ["/docs/learn/hoon/hoon-tutorial/lists/"]
 +++

--- a/tutorials/hoon/lists.md
+++ b/tutorials/hoon/lists.md
@@ -113,7 +113,7 @@ The `flop` function takes a list and returns it in reverse order:
 "Hello!"
 ```
 
-#### `flop` Exercise
+#### `flop` Exercise 1.5a
 
 Without using `flop`, write a gate that takes a `(list @)` and returns it in reverse order.  There is a solution at the bottom of this lesson.
 
@@ -144,7 +144,7 @@ The function passed to `sort` must produce a `flag`, i.e., `?`.
 
 ### `weld`
 
-The `weld` function takes two lists and concatenates them:
+The `weld` function takes two lists of the same type and concatenates them:
 
 ```
 > (weld ~[1 2 3] ~[4 5 6])
@@ -154,9 +154,9 @@ The `weld` function takes two lists and concatenates them:
 "Happy Birthday!"
 ```
 
-#### `weld` Exercise
+#### `weld` Exercise 1.5b
 
-Without using `weld`, write a gate that takes a `[(list @) (list @)]` who product is the concatenation of these two lists.
+Without using `weld`, write a gate that takes a `[(list @) (list @)]` who product is the concatenation of these two lists. There is a solution at the bottom of this lesson.
 
 ### `snag`
 
@@ -207,7 +207,7 @@ You can cast `b` to `(list)` to work around this:
 11
 ```
 
-#### `snag` Exercise
+#### `snag` Exercise 1.5c
 
 Without using `snag`, write a gate that returns the `n`th item of a list.  There is a solution at the bottom of this lesson.
 
@@ -241,7 +241,7 @@ The `lent` function takes a list and returns the number of items in it:
 6
 ```
 
-#### `lent` Exercise
+#### `lent` Exercise 1.5d
 
 Without using `lent`, write a gate that takes a list and returns the number of item in it. There is a solution at the bottom of this lesson.
 
@@ -299,9 +299,44 @@ c
 
 The Hoon standard library and compiler are written in Hoon.  At this point, you know enough Hoon to be able to explore the standard library portions of `hoon.hoon` and find more functions relevant to lists.  [Look around in section `2b` (and elsewhere)](/docs/reference/library/2b/)
 
+## Additional Exercises
+
+#### Exercise 1.5e
+Without entering these expressions into the dojo, what are the products of the following expressions?
+```
+> (lent ~[1 2 3 4 5])
+```
+```
+> (lent ~[~[1 2] ~[1 2 3] ~[2 3 4]])
+```
+```
+> (lent ~[1 2 (weld ~[1 2 3] ~[4 5 6])])
+```
+
+#### Exercise 1.5f
+First, bind these faces.
+```
+> =b ~['moon' 'planet' 'star' 'galaxy']
+> =c ~[1 2 3]
+```
+Then determine whether the following dojo expressions are valid, and if so, what they evaluate to.
+```
+> (weld b b)
+```
+```
+> (weld b c)
+```
+```
+> (lent (weld b c))
+```
+```
+> (add (lent b) (lent c))
+```
+
+
 ## Exercise Solutions
 
-#### `flop`
+#### `flop` 1.5a
 
 ```hoon
 ::  flop.hoon
@@ -320,7 +355,7 @@ Run in dojo:
 ~[44 33 22 11]
 ```
 
-#### `weld`
+#### `weld` 1.5b
 ```hoon
 ::  weld.hoon
 ::
@@ -337,7 +372,7 @@ Run in dojo:
 ~[1 2 3 3 4 5 6]
 ```
 
-#### `snag`
+#### `snag` 1.5c
 
 ```hoon
 ::  snag.hoon
@@ -358,7 +393,7 @@ Run in dojo:
 33
 ```
 
-#### `lent`
+#### `lent` 1.5d
 
 ```hoon
 ::  lent.hoon
@@ -379,3 +414,38 @@ Run in dojo:
 > +lent "asdf"
 4
 ```
+
+#### 1.5e
+
+Run in dojo:
+
+```
+> (lent ~[1 2 3 4 5])
+5
+> (lent ~[~[1 2] ~[1 2 3] ~[2 3 4]])
+3
+> (lent ~[1 2 (weld ~[1 2 3] ~[4 5 6])])
+3
+```
+
+#### 1.5f
+
+Run in dojo:
+
+```
+> (weld b b)
+<|moon planet star galaxy moon planet star galaxy|>
+```
+```
+> (weld b c)
+```
+This will not run because `weld` expects the elements of both lists to be of the same type.
+```
+> (lent (weld b c))
+```
+This also fails for the same reason, but it is important to note that in some languages that are more lazily evaluated, such an expression would still work since it would only look at the length of `b` and `c` and not worry about what the elements were. In that case, it would return `7`.
+```
+> (add (lent b) (lent c))
+7
+```
+We see here the correct way to find the sum of the length of two lists of unknown type.

--- a/tutorials/hoon/recursion.md
+++ b/tutorials/hoon/recursion.md
@@ -1,6 +1,6 @@
 +++
-title = "1.5.1 Walkthrough: Recursion"
-weight = 9
+title = "1.4.1 Walkthrough: Recursion"
+weight = 7
 template = "doc.html"
 aliases = ["/docs/learn/hoon/hoon-tutorial/recursion/"]
 +++


### PR DESCRIPTION
The content of 1.4 (lists) depended on 1.5 (gates and recursion) but not vice versa, so I switched their order.

I've also added in mini exercises to the lesson on lists.