### PR TITLE
rewrites section on nested cores

### DIFF
--- a/tutorials/hoon/arms-and-cores.md
+++ b/tutorials/hoon/arms-and-cores.md
@@ -181,7 +181,7 @@ To reinforce your newfound understanding of arms and cores, let's go over the va
 
 ### Address-Based Wings
 
-In the last lesson, you saw how the following expressions return legs based on an address in the subject: `+n`, `.`, `-`, `+`, `+>`, `+<`, `->`, `-<`, `&`, `|` etc.  When these resolve to the part of the subject containing an arm, they **don't** evaluate the arm.  They simply return the indicated noun fragment of the subject, as if it were a leg.
+In the [previous lesson](@../the-subject-and-its-legs.md), you saw how the following expressions return legs based on an address in the subject: `+n`, `.`, `-`, `+`, `+>`, `+<`, `->`, `-<`, `&`, `|` etc.  When these resolve to the part of the subject containing an arm, they **don't** evaluate the arm.  They simply return the indicated noun fragment of the subject, as if it were a leg.
 
 Let's use `-.c` to look at the head of `c`, i.e., the battery of the core:
 
@@ -299,7 +299,7 @@ Hoon doesn't know whether `double` is a face or an arm name until it conducts a 
 24
 ```
 
-### Modifying a Core
+### Modifying a Core's Payload
 
 We can produce a modified version of the core `c` in which `a` and `b` have different values.  A core is just a noun in the subject, so we can modify it in the way we learned to modify legs in the last lesson.  To change `a` to `99`, use `c(a 99)`:
 
@@ -360,6 +360,15 @@ We can make multiple changes to `c` at once:
 > sum:c
 99
 ```
+
+#### Exercise 1.7a
+Using the technique in this section, lets guess on how to make a new core `d` by modifying `c` so that the arm `double` multiplies `-.b` and `+.b`:
+```
+> =d c(double (mul -.b +.b))
+> d
+528
+```
+Why is `d` simply the product of `(mul -.b +.b)` instead of the core `c` with the `double` arm replaced by `++  double  (mul -.b +.b)`?
 
 ### Arms on the Search Path
 
@@ -486,3 +495,8 @@ You can now unbind `c` in the dojo -- this will help to keep your dojo subject t
 > c
 -find.c
 ```
+
+## Exercise solutions
+
+### Exercise 1.7a
+First, 

--- a/tutorials/hoon/arms-and-cores.md
+++ b/tutorials/hoon/arms-and-cores.md
@@ -547,6 +547,17 @@ If you counted the arms in this core by hand, you'll come up with 126 arms. This
 ```
 and we also see the section 1 core and the core containing `hoon-version` in the subject.
 
+We can also confirm that `add` is in the subject of `biff`
+```
+> add:biff
+<1.vwd {{a/@ b/@} <41.mac 1.ane $141>}>
+```
+and that `biff` is not in the subject of `add`.
+```
+> biff:add
+-find.biff
+```
+
 Lastly, let's check the subject of the last arm in `hoon.hoon` (as of November 2019)
 ```
 > ..pi-tell

--- a/tutorials/hoon/arms-and-cores.md
+++ b/tutorials/hoon/arms-and-cores.md
@@ -429,7 +429,6 @@ Let's take a quick look at the battery of one core in the dojo to show that this
     ?:  =(a +(b))  b
     $(b +(b))
   --
-
 ```
 
 This core has one arm `dec` which implements decrement. If we look at the head of the core we'll see the Nock.
@@ -482,6 +481,30 @@ Let's take a quick look at how cores can be combined to build up larger structur
 
 Here you can see the style of wrapping one core in another. This technique is used frequently in Hoon, particularly in the standard library. `dec` is used in the subsequent core. This can be a useful code organization technique. Gates and Traps are both special kinds of cores, as you will see in later lessons.
 
+#### Exercise 1.7b
+
+When you compose two cores, as done above, which of the following describes the resulting subject?
+ + The first core is in the payload of the second core.
+ + The first core is in the battery of the second core.
+ + The resulting core is equivalent to the following core:
+
+```hoon
+|%
+++  dec
+  |=  a=@
+  ?<  =(0 a)
+  =+  b=0
+  |-  ^-  @
+  ?:  =(a +(b))  b
+  $(b +(b))
+++  add
+  |=  [a=@ b=@]
+  ^-  @
+  ?:  =(0 a)  b
+  $(a (dec a), b +(b))
+--
+```
+
 
 ## Summary
 
@@ -499,4 +522,7 @@ You can now unbind `c` in the dojo -- this will help to keep your dojo subject t
 ## Exercise solutions
 
 ### Exercise 1.7a
-First, 
+Asked David
+
+### Exercise 1.7b
+Asked David.

--- a/tutorials/hoon/arms-and-cores.md
+++ b/tutorials/hoon/arms-and-cores.md
@@ -391,6 +391,46 @@ So the meaning of `two.double.c` is, roughly, '`two` in the parent core of `doub
 
 In each of the following examples, the only wings that matter are `c` and whichever arm name is left-most in the expression.  The other arm names in the path simply resolve to their parent core, which is just `c`.
 
+### The `..arm` Syntax
+
+Let's say you have a wing that resolves to a leg of the subject.  In this wing is an arm name, e.g., `a.b.arm`.  As you learned in lesson 1.4, this should be read as '`a` in `b` in the parent core of `arm`'.  Speaking more directly: the wing resolution path goes through the parent core of the arm, not the arm itself.
+
+Recall that using `.` by itself returns the whole subject.  With that in mind, take a moment to answer the following question on your own.  In general, what should the expression `..arm` produce?
+
+Do you have an answer?  If not, consider going back and trying to figure it out before moving on.
+
+You may read `..arm` as '`.` of the parent core of `arm`'.  This amounts to just the parent core of `arm`.  Let's try this out with the arms of `c`:
+
+```
+> ..inc:c
+< 4.han
+  { {our/@p now/@da eny/@uvJ}
+    <19.anu 24.tmo 6.ipz 38.ard 119.spd 241.plj 51.zox 93.pqh 74.dbd 1.qct $141>
+  }
+>
+
+> c
+< 4.han
+  { {our/@p now/@da eny/@uvJ}
+    <19.anu 24.tmo 6.ipz 38.ard 119.spd 241.plj 51.zox 93.pqh 74.dbd 1.qct $141>
+  }
+>
+```
+
+Yes, they match.  `..inc` of `c` is just the parent core of `inc`, `c` itself.  But why would we ever use `..inc` to refer to `c`?  It's much simpler to use `c`.
+
+Sometimes the `..arm` syntax is quite useful.  Often there is a core in the subject without a face bound to it; i.e., the core might be nameless.  In that case you can use an arm name in that core to refer to the whole core.
+
+For an example of this, consider the `add` arm of the Hoon standard library.  This arm is in a nameless core.  To see the parent core of `add`, try `..add`:
+
+```
+> ..add
+<74.dbd 1.qct $141>
+```
+
+Here you see a core with a battery of 74 arms (!), and whose payload is another core with one arm.
+
+
 ### Evaluating an Arm Against a Modified Core
 
 Assume `this.is.a.wing` is a wing that resolves to an arm.  You can use the `this.is.a.wing(face new-value)` syntax to compute the arm against a modified version of the parent core of `this.is.a.wing`.

--- a/tutorials/hoon/arms-and-cores.md
+++ b/tutorials/hoon/arms-and-cores.md
@@ -457,7 +457,7 @@ This core has one arm `dec` which implements decrement. If we look at the head o
  
 Again, being able to read Nock is not essential to understanding Hoon.
 
-Let's take a quick look at how cores can be combined to build up larger structures.
+Let's take a quick look at how cores can be combined with `=>` to build up larger structures.
 
 ```hoon
 =>

--- a/tutorials/hoon/doors.md
+++ b/tutorials/hoon/doors.md
@@ -81,45 +81,6 @@ Let's try out these arms, using them for function calls:
 
 Notice that each arm in core `c` is able to call the other arms of `c` -- `add-two` uses the `inc` arm to increment a number twice.  As a reminder, each arm is evaluated with is parent core as the subject.  In the case of `add-two` the parent core is `c`, which has `inc` in it.
 
-### The `..arm` Syntax
-
-Let's say you have a wing that resolves to a leg of the subject.  In this wing is an arm name, e.g., `a.b.arm`.  As you learned in lesson 1.4, this should be read as '`a` in `b` in the parent core of `arm`'.  Speaking more directly: the wing resolution path goes through the parent core of the arm, not the arm itself.
-
-Recall that using `.` by itself returns the whole subject.  With that in mind, take a moment to answer the following question on your own.  In general, what should the expression `..arm` produce?
-
-Do you have an answer?  If not, consider going back and trying to figure it out before moving on.
-
-You may read `..arm` as '`.` of the parent core of `arm`'.  This amounts to just the parent core of `arm`.  Let's try this out with the arms of `c`:
-
-```
-> ..inc:c
-< 4.han
-  { {our/@p now/@da eny/@uvJ}
-    <19.anu 24.tmo 6.ipz 38.ard 119.spd 241.plj 51.zox 93.pqh 74.dbd 1.qct $141>
-  }
->
-
-> c
-< 4.han
-  { {our/@p now/@da eny/@uvJ}
-    <19.anu 24.tmo 6.ipz 38.ard 119.spd 241.plj 51.zox 93.pqh 74.dbd 1.qct $141>
-  }
->
-```
-
-Yes, they match.  `..inc` of `c` is just the parent core of `inc`, `c` itself.  But why would we ever use `..inc` to refer to `c`?  It's much simpler to use `c`.
-
-Sometimes the `..arm` syntax is quite useful.  Often there is a core in the subject without a face bound to it; i.e., the core might be nameless.  In that case you can use an arm name in that core to refer to the whole core.
-
-For an example of this, consider the `add` arm of the Hoon standard library.  This arm is in a nameless core.  To see the parent core of `add`, try `..add`:
-
-```
-> ..add
-<74.dbd 1.qct $141>
-```
-
-Here you see a core with a battery of 74 arms (!), and whose payload is another core with one arm.
-
 ### Mutating a Gate
 
 Let's say you want to modify the default sample of the gate for `double`.  We can infer the default sample by calling `double` with no argument:


### PR DESCRIPTION
The section on nesting cores was a bit misleading and didn't elaborate much on why you would do it. I've rewritten it to be more explicit about how core nesting works in the standard library and how it affects visibility of arms.

I did have a couple of exercises that I wrote a few days ago that I removed. I couldn't figure out why the first one behaved as it did and neither did @baudtack, so it seemed too technical to be included. The second one was rolled into the rewritten section.