### PR TITLE
bridge: match docs to 'Breach Continuity' checkbox

### DIFF
--- a/tutorials/guide-to-breaches.md
+++ b/tutorials/guide-to-breaches.md
@@ -15,8 +15,8 @@ Ships on the Arvo network sometimes need to reset their continuity. A personal b
 Personal breaches often fix connectivity issues, but should only be used as a last resort. To perform a personal breach, follow the steps below.
 
 - Go to [bridge.urbit.org](https://bridge.urbit.org) and log into your identity.
-- Go to the `Admin` section. Then go to `Networking Keys`.
-- Check the `Trigger New Continuity Era` box. Click `Reset Networking Keys`, and then click `Send Transaction`.
+- Go to the `Admin` section. Then go to `Edit Permisions`, then `Networking Keys`.
+- Check the `Breach Continuity` box. Click `Reset Networking Keys`, and then click `Send Transaction`.
 - Click `Download Arvo Keyfile`.
 - Delete or archive your old pier.
 - Create a new pier by booting your ship with your new keyfile.


### PR DESCRIPTION
On Bridge, the checkbox `Trigger New Continuity Era` has been renamed `Breach Continuity`

https://github.com/urbit/bridge/pull/339

