### PR TITLE
recieved -> received in tutorials/hoon/landscape-tile.md

### DIFF
--- a/tutorials/hoon/landscape-tile.md
+++ b/tutorials/hoon/landscape-tile.md
@@ -285,7 +285,7 @@ When we get a response from `%helm` to our `poke`, we'll receive a `coup`, which
 ``` hoon
 ++  coup-helm-hi
   |=  [pax=path cop=(unit tang)]
-  ~&  ["Coup recieved" pax]
+  ~&  ["Coup received" pax]
   :_  this
   ?~  cop
     (send-status-diff "successfully found {<pax>}")


### PR DESCRIPTION
The line in question appears twice in the file; once in the program listing, and again in an excerpt.  One has already been fixed in an earlier PR; this fixes the other.