### PR TITLE
Egg timer code nit & corrections

### DIFF
--- a/tutorials/hoon/egg-timer.md
+++ b/tutorials/hoon/egg-timer.md
@@ -21,7 +21,7 @@ The Arvo operating system is divided up into modules called vanes. Gall is the v
   [ost %wait /egg-timer (add now t)]
 ++  wake
   |=  [=wire error=(unit tang)]
-  ^+  [*(list card) +>.$]
+  ^+  [*(list move) +>.$]
   ~&  "Timer went off!"
   [~ +>.$]
 --
@@ -59,7 +59,7 @@ The `door` we've made has two arms `poke-noun` and `wake`. Gall is capable of di
 ```hoon
 ++  poke-noun
   |=  t=@dr
-  ^+  [*(list card) +>.$]
+  ^+  [*(list move) +>.$]
   :_  +>.$  :_  ~
   [ost %wait /egg-timer (add now t)]
 ```
@@ -70,7 +70,7 @@ In the above code, we create a gate that takes a single `@dr` argument. `@dr` is
 - `~m20`  20 minutes
 - `~d42`  42 days
 
-As a matter of good type hygiene, we explicitly cast the output of this gate with `^+` to ensure we are producing the correct thing for Gall to handle. `^+` is the rune for casting by example. Our example is a cell: `list` of `card`, which we `bunt` with `*`, is the head; `+>.$`, the enclosing core which is our `door`, is the tail.
+As a matter of good type hygiene, we explicitly cast the output of this gate with `^+` to ensure we are producing the correct thing for Gall to handle. `^+` is the rune for casting by example. Our example is a cell: `list` of `move`, which we `bunt` with `*`, is the head; `+>.$`, the enclosing core which is our `door`, is the tail.
 
 Next we're going to use the `:_` rune which is just the inverted form a `:-` the cell construction rune. We use it twice so the actual data will end up looking something like:
 
@@ -96,12 +96,12 @@ The final part of this `move` is:
 
 `now` is the current time of type `@da`, and `t` was declared as `@dr`. Because they are both atoms, we can add `now` and `t` these two to get an atom that is `t` units of time into the future from `now`. That produced atom can be interpreted as a `@da`.
 
-That's all for our `poke-noun` arm. But what about when the timer goes off? Behn will create a `gift`, a similar construct to how we created an `card`, only this time it will end up being dispatched back to us via Gall in the `++wake` arm. Any app that wants to use a timer trigger needs to have an arm called `++wake`.
+That's all for our `poke-noun` arm. But what about when the timer goes off? Behn will create a `gift`, a similar construct to how we created a `card`, only this time it will end up being dispatched back to us via Gall in the `++wake` arm. Any app that wants to use a timer trigger needs to have an arm called `++wake`.
 
 ```hoon
 ++  wake
   |=  [=wire error=(unit tang)]
-  ^+  [*(list card) +>.$]
+  ^+  [*(list move) +>.$]
   ~&  "Timer went off!"
   [~ +>.$]
 ```
@@ -116,4 +116,4 @@ Next we have the same cast we used in `++poke-noun` to make sure we are producin
 
 `~&` is the debugging printf rune. Here we're using it to output a message. We could, however, modify this line of code to do any other computation we would want to happen when `++wait` gets called.
 
-Finally, we need to produce our `card`. Here the effect is simply `[~ +>.$]`, since we have no `move` to make and we are not changing the state of our app. We just use the `door` without changing its sample.
+Finally, we need to produce our `move`. Here the effect is simply `[~ +>.$]`, since we have no `move` to make and we are not changing the state of our app. We just use the `door` without changing its sample.

--- a/tutorials/hoon/egg-timer.md
+++ b/tutorials/hoon/egg-timer.md
@@ -31,8 +31,8 @@ The first thing to notice is that we are creating a `core` (`|%`) and a `door` (
 
 ```hoon
 |%
-+$  card  (pair bone move)
-+$  move  [%wait path @da]
++$  move  (pair bone card)
++$  card  [%wait path @da]
 --
 ```
 

--- a/tutorials/hoon/egg-timer.md
+++ b/tutorials/hoon/egg-timer.md
@@ -10,7 +10,7 @@ The Arvo operating system is divided up into modules called vanes. Gall is the v
 
 ```hoon
 |%
-+$  move   (pair bone card)
++$  move  (pair bone card)
 +$  card  [%wait path @da]
 --
 |_  [bowl:gall ~]
@@ -31,7 +31,7 @@ The first thing to notice is that we are creating a `core` (`|%`) and a `door` (
 
 ```hoon
 |%
-+$  card   (pair bone move)
++$  card  (pair bone move)
 +$  move  [%wait path @da]
 --
 ```


### PR DESCRIPTION
This triggered me. Also we were using `card` in place of `move` a bunch? Pretty sure the code wouldn't compile.

I have a couple other style changes I'd make, but they're a bit more aggressive, so just listing them here instead:
- `(pair bone card)` -> `[bone card]` because you never ever care about accessing these and `+pair` isn't exactly modern hoon.
- `+>.$` -> `+*  this  .` etc.
- `:_  ~  move` ->  `[move]~`, double-`:_`s are pretty hard to follow imo, and `[item]~` lists are pretty common in these contexts. (Alternatively, `[move ~]`.)