### PR TITLE
Gall cleanup

### DIFF
--- a/tutorials/hoon/async-monad.md
+++ b/tutorials/hoon/async-monad.md
@@ -4,7 +4,7 @@ weight = 37
 template = "doc.html"
 +++
 
-Gall apps can be difficult to understand and simple ones often don't need the full complexity available when writing standard Gall apps. To that end, the `tapp` library implements the "async monad" which is more accurately described as a transitional IO monad. If you're not familiar with monads, don't worry as that understanding will not be necessary to use the `tapp` library.
+Gall apps can be difficult to understand and simple ones often don't need the full complexity available when writing standard Gall apps. To that end, the `tapp` library implements the "async monad" which is more accurately described as a transactional IO monad. If you're not familiar with monads, don't worry as that understanding will not be necessary to use the `tapp` library.
 
 The following code is from `app/example-tapp-fetch.hoon` Much of this file should already be pretty readable, particularly given the comments in it, so we'll focus here on specific parts of the file rather than a full walkthrough. This app is intended to get the top comment of the top ten stories on Hacker News.
 
@@ -184,7 +184,7 @@ The first part of this gate inspects the `in-poke-data` structure, specifically 
 
 The most important part to see here is the `;<` rune. If you're familiar with monadic bind, this is what this rune is. If you're not, don't worry! While we wont be discussing the implementation details of this rune, it's quite simple to use. 
 
-`;<` has four children: `A`, `B`, `C` and `D`.
+`;<` has four children we will sequentially label `A`, `B`, `C` and `D`.
 
 `A` is a mold that describes the type produced by `C`. 
 
@@ -192,9 +192,9 @@ The most important part to see here is the `;<` rune. If you're familiar with mo
 
 `C` is some code we want to run and `D` is code to run after the `C` has completed successfully. If `C` fails, then the entire `;<` call will fail. This will allow us to chain a series of calls which may take a long time to complete, such as http requests, together and proceed when they actually complete.
 
-`D` must produce the type defined by `B`, `tapp-async` or `(async ,state)`. In the final leg of the `;<` series in this app you'll see the calls to `pure:m` which is used to wrap `top-comments` in an `async`.
+`D` must produce the type defined by `B`, `tapp-async` or `(async, state)`. In the final leg of the `;<` series in this app you'll see the calls to `pure:m` which is used to wrap `top-comments` in an `async`.
 
-In a number of cases `D` here is going to be another `;<` rune. This is how you can chain these together to perform a lot of asynchronous actions that need to all complete.
+Frequently the final child `D` is going to be another `;<` rune. This is how you can chain these together to perform a lot of asynchronous actions that need to all complete.
 
 ```hoon
   ::

--- a/tutorials/hoon/async-monad.md
+++ b/tutorials/hoon/async-monad.md
@@ -4,6 +4,10 @@ weight = 37
 template = "doc.html"
 +++
 
+Note: as of 2019.12.02, this material is out of date. While this is being updated, please see the [Gall overview](@/docs/tutorials/arvo/gall.md) in the Arvo section to get oriented with Gall. Some material presented here may still be useful.
+
+## Async Monad
+
 Gall apps can be difficult to understand and simple ones often don't need the full complexity available when writing standard Gall apps. To that end, the `tapp` library implements the "async monad" which is more accurately described as a transactional IO monad. If you're not familiar with monads, don't worry as that understanding will not be necessary to use the `tapp` library.
 
 The following code is from `app/example-tapp-fetch.hoon` Much of this file should already be pretty readable, particularly given the comments in it, so we'll focus here on specific parts of the file rather than a full walkthrough. This app is intended to get the top comment of the top ten stories on Hacker News.

--- a/tutorials/hoon/egg-timer.md
+++ b/tutorials/hoon/egg-timer.md
@@ -27,7 +27,7 @@ The bulk of the functionality of Arvo is divided up into kernel modules called v
 --
 ```
 
-The first thing to notice is that we are creating a core (`|%`) and a door (`|_`). This is a typical style of Gall programming where your types are defined in the first core and your application is defined in the following `door`.
+The first thing to notice is that we are creating a core (`|%`) and a door (`|_`). This is a typical style of Gall programming where your types are defined in the first core and your application is defined in the following door.
 
 ```hoon
 |%
@@ -40,13 +40,12 @@ The core here defines two types: `move` and `card`. A `move` is a `pair` of `bon
 
 It's important to note that the names `move` and `card` are technically arbitrary; you can call them whatever you'd like. By convention, however, you will see them called `move` and `card` practically everywhere.
 
-The sample of the door is:
+Next we have the door of the program. The door should be thought of as both the container for the logic of the app and the state of the app itself. The battery encodes the logic of the app, while the sample encodes the state of the program. When the state is updated, a new door is created with an updated sample to reflect the new state.
 
 ```hoon
-[bowl:gall ~]
+|_  [bowl:gall ~]
 ```
-
-As mentioned in [the previous lesson](@/docs/tutorials/hoon/gall.md), the `bowl` contains generic information used by nearly every Gall app. Relevant to our egg timer are the following faces:
+We see that the sample of the door is `[bowl:gall ~]`. As mentioned in [the previous lesson](@/docs/tutorials/hoon/gall.md), the `bowl` contains generic information used by nearly every Gall app. Relevant to our egg timer are the following faces:
 
 - `ost`  A `bone` that is a reference to the current chain of events
 - `now`  The current time
@@ -112,4 +111,4 @@ Next we have the same cast we used in `++poke-noun` to make sure we are producin
 
 `~&` is the debugging printf rune. Here we're using it to output a message. We could, however, modify this line of code to do any other computation we would want to happen when `++wait` gets called.
 
-Finally, we need to produce our `move`. Here the effect is simply `[~ +>.$]`, since we have no `move` to make and we are not changing the state of our app. We just use the door without changing its sample.
+Finally, we need to produce our `move`. Here the effect is simply `[~ +>.$]`, since we have no `move` to make and we are not changing the state of our app. We just pass forward our door with the battery and payload unchanged, which corresponds to no change in state.

--- a/tutorials/hoon/egg-timer.md
+++ b/tutorials/hoon/egg-timer.md
@@ -5,6 +5,10 @@ template = "doc.html"
 aliases = ["/docs/learn/hoon/hoon-tutorial/egg-timer/"]
 +++
 
+Note: as of 2019.12.02, this material is out of date. While this is being updated, please see the [Gall overview](@/docs/tutorials/arvo/gall.md) in the Arvo section to get oriented with Gall. Some material presented here may still be useful.
+
+## Egg Timer
+
 The bulk of the functionality of Arvo is divided up into kernel modules called vanes. Gall is the vane responsible for providing an API for building stateful applications in Urbit. Gall is a complex system that takes a lot of getting used to, so let's dip our toes in with a simple egg timer app.
 
 

--- a/tutorials/hoon/egg-timer.md
+++ b/tutorials/hoon/egg-timer.md
@@ -102,7 +102,7 @@ That's all for our `poke-noun` arm. But what about when the timer goes off? Behn
   [~ +>.$]
 ```
 
-`wake` is a gate that has two arguments: a `wire`, and a `(unit tang)` with the face `error`. The syntax of `=wire` is a shortcut for `wire=wire`; it's a common pattern to shadow the name of a type when you only have one instance of the type and are not going to refer to the type itself. A `wire` is just an alias for `path`. Our `wire` will be the `path` that we gave original `move`. If we needed to do something based on which request caused this gate to be called, we could use the wire to do so. In this case, we don't do perform such a dispatch.
+`wake` is a gate that has two arguments: a `wire`, and a `(unit tang)` with the face `error`. The syntax of `=wire` is a shortcut for `wire=wire`; it's a common pattern to shadow the name of a type when you only have one instance of the type and are not going to refer to the type itself. A `wire` is just an alias for `path`. Our `wire` will be the `path` that we gave the original `move`. If we needed to do something based on which request caused this gate to be called, we could use the wire to do so. In this case, we don't perform such a dispatch.
 
 Next we have the same cast we used in `++poke-noun` to make sure we are producing the correct thing for Gall. These casts are not strictly necessary, as the type system can infer what the type will be, but they can be very useful both for debugging our own code and for someone else trying to determine what our code should be producing.
 
@@ -112,4 +112,4 @@ Next we have the same cast we used in `++poke-noun` to make sure we are producin
 
 `~&` is the debugging printf rune. Here we're using it to output a message. We could, however, modify this line of code to do any other computation we would want to happen when `++wait` gets called.
 
-Finally, we need to produce our `move`. Here the effect is simply `[~ +>.$]`, since we have no `move` to make and we are not changing the state of our app. We just use the `door` without changing its sample.
+Finally, we need to produce our `move`. Here the effect is simply `[~ +>.$]`, since we have no `move` to make and we are not changing the state of our app. We just use the door without changing its sample.

--- a/tutorials/hoon/egg-timer.md
+++ b/tutorials/hoon/egg-timer.md
@@ -46,12 +46,9 @@ The sample of the door is:
 [bowl:gall ~]
 ```
 
-You can find the full definition of `bowl` in `sys/zuse.hoon`, but for now it's enough to know that this is the default app state and includes various faces for information. Below are some important such faces:
+As mentioned in [the previous lesson](@/docs/tutorials/hoon/gall.md), the `bowl` contains generic information used by nearly every Gall app. Relevant to our egg timer are the following faces:
 
-- `our`  The ship this code is running on
-- `src`  The ship the current event originated from
 - `ost`  A reference to the current chain of events
-- `eny`  Guaranteed-fresh entropy
 - `now`  The current time
 
 The door we've made has two arms `poke-noun` and `wake`. Gall is capable of dispatching `poke`s, or requests, to an app based on the mark of the data given along with that poke. These are sent to the arm with the name that matches the mark of the data. Here we use the generic `noun` mark:

--- a/tutorials/hoon/egg-timer.md
+++ b/tutorials/hoon/egg-timer.md
@@ -48,7 +48,7 @@ The sample of the door is:
 
 As mentioned in [the previous lesson](@/docs/tutorials/hoon/gall.md), the `bowl` contains generic information used by nearly every Gall app. Relevant to our egg timer are the following faces:
 
-- `ost`  A reference to the current chain of events
+- `ost`  A `bone` that is a reference to the current chain of events
 - `now`  The current time
 
 The door we've made has two arms `poke-noun` and `wake`. Gall is capable of dispatching `poke`s, or requests, to an app based on the mark of the data given along with that poke. These are sent to the arm with the name that matches the mark of the data. Here we use the generic `noun` mark:
@@ -67,7 +67,7 @@ In the above code, we create a gate that takes a single `@dr` argument. `@dr` is
 - `~m20`  20 minutes
 - `~d42`  42 days
 
-As a matter of good type hygiene, we explicitly cast the output of this gate with `^+` to ensure we are producing the correct thing for Gall to handle. `^+` is the rune for casting by example. Our example is a cell: `list` of `move`, which we bunt with `*`, is the head; `+>.$`, the enclosing core which is our door, is the tail.
+As a matter of good type hygiene, we explicitly cast the output of this gate with `^+` to ensure we are producing the correct thing for Gall to handle. `^+` is the rune for casting by example. Our example is a cell whose head is a `list` of `move`s, which we bunt with `*`, and whose tail is `+>.$`, which is the enclosing core, i.e. our door.
 
 Next we're going to use the `:_` rune which is just the inverted form a `:-` the cell construction rune. We use it twice so the actual data will end up looking something like:
 
@@ -75,10 +75,9 @@ Next we're going to use the `:_` rune which is just the inverted form a `:-` the
 [[[ost %wait /egg-timer (add now t)] ~] +>.$]
 ```
 
-`ost` is the `bone`, the opaque reference to a chain of events, that comes from `bowl`, so we're going to continue to use it here. `%wait` is the name of the `move`, in this case a request to the Behn vain to start a timer for us.
+`ost` is the `bone`, the opaque reference to a chain of events that comes from `bowl`, so we're going to continue to use it here. `%wait` is the name of the `move`, in this case a request to the Behn vane to start a timer for us.
 
-After `%wait`, we have the `path`, a `list` of `cords` that serves as the unique identifier for this `move`:
-
+After `%wait`, we have the `path`, which is a `list` of `cords` that serves as the unique identifier for this `move`:
 ```
 /egg-timer
 ```
@@ -93,7 +92,7 @@ The final part of this `move` is:
 
 `now` is the current time of type `@da`, and `t` was declared as `@dr`. Because they are both atoms, we can add `now` and `t` these two to get an atom that is `t` units of time into the future from `now`. That produced atom can be interpreted as a `@da`.
 
-That's all for our `poke-noun` arm. But what about when the timer goes off? Behn will create a `gift`, a similar construct to how we created a `card`, only this time it will end up being dispatched back to us via Gall in the `++wake` arm. Any app that wants to use a timer trigger needs to have an arm called `++wake`.
+That's all for our `poke-noun` arm. But what about when the timer goes off? Behn will create a `gift`, a similar construct to a `card`, only this time it will end up being dispatched back to us via Gall in the `++wake` arm. Any app that wants to use a timer trigger needs to have an arm called `++wake`.
 
 ```hoon
 ++  wake
@@ -103,7 +102,7 @@ That's all for our `poke-noun` arm. But what about when the timer goes off? Behn
   [~ +>.$]
 ```
 
-`wake` is a `gate` that has two arguments: a `wire`, and a `(unit tang)` with the face `error`. The syntax of `=wire` is a shortcut for `wire=wire`; it's a common pattern to shadow the name of a type when you only have one instance of the type and are not going to refer to the type itself. A `wire` is just an alias for `path`. Our `wire` will be the `path` that we gave original `move`. If we needed to do something based on which request caused this gate to be called, we could use the wire to do so. In this case, we don't do perform such a dispatch.
+`wake` is a gate that has two arguments: a `wire`, and a `(unit tang)` with the face `error`. The syntax of `=wire` is a shortcut for `wire=wire`; it's a common pattern to shadow the name of a type when you only have one instance of the type and are not going to refer to the type itself. A `wire` is just an alias for `path`. Our `wire` will be the `path` that we gave original `move`. If we needed to do something based on which request caused this gate to be called, we could use the wire to do so. In this case, we don't do perform such a dispatch.
 
 Next we have the same cast we used in `++poke-noun` to make sure we are producing the correct thing for Gall. These casts are not strictly necessary, as the type system can infer what the type will be, but they can be very useful both for debugging our own code and for someone else trying to determine what our code should be producing.
 

--- a/tutorials/hoon/egg-timer.md
+++ b/tutorials/hoon/egg-timer.md
@@ -5,7 +5,7 @@ template = "doc.html"
 aliases = ["/docs/learn/hoon/hoon-tutorial/egg-timer/"]
 +++
 
-The Arvo operating system is divided up into modules called vanes. Gall is the vane responsible for providing an API for building stateful applications in Urbit. Gall is a complex system that takes a lot of getting used to, so let's dip our toes in with a simple egg-timer app.
+The bulk of the functionality of Arvo is divided up into kernel modules called vanes. Gall is the vane responsible for providing an API for building stateful applications in Urbit. Gall is a complex system that takes a lot of getting used to, so let's dip our toes in with a simple egg timer app.
 
 
 ```hoon
@@ -27,7 +27,7 @@ The Arvo operating system is divided up into modules called vanes. Gall is the v
 --
 ```
 
-The first thing to notice is that we are creating a `core` (`|%`) and a `door` (`|_`). This is a typical style of Gall programming where your types are defined in the first `core` and your application is defined in the following `door`.
+The first thing to notice is that we are creating a core (`|%`) and a door (`|_`). This is a typical style of Gall programming where your types are defined in the first core and your application is defined in the following `door`.
 
 ```hoon
 |%
@@ -36,11 +36,11 @@ The first thing to notice is that we are creating a `core` (`|%`) and a `door` (
 --
 ```
 
-The `core` here defines two types: `move` and `card`. A `move` is a `pair` of `bone` and `card`. A `bone` is a Gall-only type that identifies app event chains by mapping atoms to them. We define `card` to be a request to Arvo to do something for us. In this case, the only valid `card` will be `%wait` which we'll discuss in a bit.
+The core here defines two types: `move` and `card`. A `move` is a `pair` of `bone` and `card`. A `bone` is a Gall-only type that identifies app event chains by mapping atoms to them. A `card` is a request to Arvo to do something for us. In this case, the only valid `card` will be `%wait` which we'll discuss in a bit.
 
 It's important to note that the names `move` and `card` are technically arbitrary; you can call them whatever you'd like. By convention, however, you will see them called `move` and `card` practically everywhere.
 
-The sample of the `door` is:
+The sample of the door is:
 
 ```hoon
 [bowl:gall ~]
@@ -54,7 +54,7 @@ You can find the full definition of `bowl` in `sys/zuse.hoon`, but for now it's 
 - `eny`  Guaranteed-fresh entropy
 - `now`  The current time
 
-The `door` we've made has two arms `poke-noun` and `wake`. Gall is capable of dispatching `pokes`, or requests, to an app based on the mark of the data given along with that poke. These are sent to the arm with the name that matches the mark of the data. Here we use the generic `noun` mark:
+The door we've made has two arms `poke-noun` and `wake`. Gall is capable of dispatching `poke`s, or requests, to an app based on the mark of the data given along with that poke. These are sent to the arm with the name that matches the mark of the data. Here we use the generic `noun` mark:
 
 ```hoon
 ++  poke-noun
@@ -70,7 +70,7 @@ In the above code, we create a gate that takes a single `@dr` argument. `@dr` is
 - `~m20`  20 minutes
 - `~d42`  42 days
 
-As a matter of good type hygiene, we explicitly cast the output of this gate with `^+` to ensure we are producing the correct thing for Gall to handle. `^+` is the rune for casting by example. Our example is a cell: `list` of `move`, which we `bunt` with `*`, is the head; `+>.$`, the enclosing core which is our `door`, is the tail.
+As a matter of good type hygiene, we explicitly cast the output of this gate with `^+` to ensure we are producing the correct thing for Gall to handle. `^+` is the rune for casting by example. Our example is a cell: `list` of `move`, which we bunt with `*`, is the head; `+>.$`, the enclosing core which is our door, is the tail.
 
 Next we're going to use the `:_` rune which is just the inverted form a `:-` the cell construction rune. We use it twice so the actual data will end up looking something like:
 

--- a/tutorials/hoon/egg-timer.md
+++ b/tutorials/hoon/egg-timer.md
@@ -50,7 +50,7 @@ We see that the sample of the door is `[bowl:gall ~]`. As mentioned in [the prev
 - `ost`  A `bone` that is a reference to the current chain of events
 - `now`  The current time
 
-The door we've made has two arms `poke-noun` and `wake`. Gall is capable of dispatching `poke`s, or requests, to an app based on the mark of the data given along with that poke. These are sent to the arm with the name that matches the mark of the data. Here we use the generic `noun` mark:
+The door we've made has two arms `poke-noun` and `wake`. Gall is capable of dispatching `poke`s, or requests, to an app based on the mark of the data given along with that poke. These are sent to the arm with the name that matches the mark of the data. Here we use the generic `%noun` mark:
 
 ```hoon
 ++  poke-noun

--- a/tutorials/hoon/gall.md
+++ b/tutorials/hoon/gall.md
@@ -5,7 +5,7 @@ template = "doc.html"
 aliases = ["/docs/learn/hoon/hoon-tutorial/gall/"]
 +++
 
-Gall is the Arvo vane responsible for handling user space applications. When writing a Gall application there are several things you will need to understand.
+Gall is the Arvo vane responsible for handling stateful user space applications. When writing a Gall application there are several things you will need to understand.
 
 ## bowl and moves
 

--- a/tutorials/hoon/gall.md
+++ b/tutorials/hoon/gall.md
@@ -9,7 +9,25 @@ Gall is the Arvo vane responsible for handling user space applications. When wri
 
 ## bowl and moves
 
-The core of a Gall app is a door whose subject has two parts: a `bowl:gall` which contains a lot of standard things used by Gall apps and a type containing app state information.
+The core of a Gall app is a door whose subject has two parts: a `bowl:gall` which contains standard things used by Gall apps and a type containing app state information.
+
+The data contained in `bowl:gall` is quite generic.
+```hoon
+  ++  bowl                                              ::  standard app state
+          $:  $:  our/ship                              ::  host
+                  src/ship                              ::  guest
+                  dap/term                              ::  agent
+              ==                                        ::
+              $:  wex/boat                              ::  outgoing subs
+                  sup/bitt                              ::  incoming subs
+              ==                                        ::
+              $:  ost/bone                              ::  opaque cause
+                  act/@ud                               ::  change number
+                  eny/@uvJ                              ::  entropy
+                  now/@da                               ::  current time
+                  byk/beak                              ::  load source
+          ==  ==
+```
 
 Vanes in Arvo communicate by means of `move`s. When a `move` is produced by an arm in a Gall app, it's dispatched by Arvo to the correct handler for the request, be it another application or another vane. A `move` is pair of `bone` and `card`. These are essential components to understand when learning to use Gall.
 
@@ -34,7 +52,7 @@ Gall applications can have a number of arms that get called depending on the `mo
 
 ### ++prep
 
-`++prep` is the arm that is called when an application is first started or when it's updated. This arm should be a gate that takes a `unit` of a noun and provides a way, if necessary, to make any changes to the application's data required by an upgrade. As a reminder, a `unit` is a type that may contain another type or it might contain `~`. They are used when there may or may not be some data available. 
+`++prep` is the arm that is called when an application is first started or when it's updated. This arm should be a gate that takes a `unit` of a noun and provides a way, if necessary, to make any changes to the application's data required by an upgrade.  As a reminder, `++unit` is a mold generator which takes in a type `a` and constructs a new type whose values are `~` to represent the absence of data and `[~ u=a]` to represent data of type `a`. Accordingly, they are used when there may or may not be some data available. 
 
 Often when developing an application you will not initially care about the data. Here is a sample `++prep` arm that will simply throw away the previous application state.
 
@@ -56,11 +74,11 @@ Many arms, `++poke` included, have variants that end in the name of a mark e.g. 
 
 ### ++peer
 
-`++peer` is used to handle subscriptions. When something subscribes to your application this arm will run. The something could be another Gall application on your ship or another ship or a tile from landscape or anything else that is able to communicate with Gall. Your outgoing subscriptions will not be tracked automatically but incoming ones will live in `sup.bowl` so that you can send information to them when required.
+`++peer` is used to handle subscriptions. When something subscribes to your application this arm will be called. The something could be another Gall application on your ship, another ship, a tile from Landscape, or anything else that is able to communicate with Gall. Your outgoing subscriptions will not be tracked automatically but incoming ones will live in `sup.bowl` so that you can send information to them when required.
 
 ### ++pull
 
-`++pull` is run when someone unsubscribes from your application, this is used to run any changes needed for your application when they unsubscribed. Their removal from `sup.bowl` is handled for you.
+`++pull` is called whenever something unsubscribes from your application. This is used to perform any changes needed for your application once the unsubscribe request is received and accepted. The removal of the subscription from `sup.bowl` is handled for you.
 
 ### ++quit
 
@@ -74,8 +92,4 @@ Many arms, `++poke` included, have variants that end in the name of a mark e.g. 
 
 `++diff` gets called when an application you are subscribed to has an update. It could either be an entirely new set of data for that application or an update to existing data.
 
-### ++sigh
-
-`++sigh` gets called when Eyre has a response to an http request made by our application.
-
-Let's take a look in the next section at an example Gall app.
+In the next section we will look at a simple example of a Gall app.

--- a/tutorials/hoon/gall.md
+++ b/tutorials/hoon/gall.md
@@ -44,7 +44,7 @@ A `card` describes the effect or event that is being requested. Each application
   ==
 ```
 
-Each `card` is a `pair` consisting of a tag and a noun. The tag indicates what the event being triggered is and the noun is any data required for that event.
+Each `card` is a `pair` consisting of a tag and a noun. The tag indicates what the event being triggered is (such a tag is referred to as a mark), and the noun is any data required for that event.
 
 ## Arms
 

--- a/tutorials/hoon/gall.md
+++ b/tutorials/hoon/gall.md
@@ -29,7 +29,7 @@ The data contained in `bowl:gall` is quite generic.
           ==  ==
 ```
 
-Vanes in Arvo communicate by means of `move`s. When a `move` is produced by an arm in a Gall app, it's dispatched by Arvo to the correct handler for the request, be it another application or another vane. A `move` is pair of `bone` and `card`. These are essential components to understand when learning to use Gall.
+Vanes in Arvo communicate by means of `move`s. When a `move` is produced by an arm in a Gall app, it's dispatched by Arvo to the correct handler for the request, be it another application or another vane. A `move` is `pair` of `bone` and `card`. These are essential components to understand when learning to use Gall.
 
 A `bone` is an opaque cause that initiates a request. When constructing a outgoing `move` you will frequently use `ost.bowl` to acquire essential information, such as a `bone` describing the initial cause. When responding to an incoming `move` you can use the `bone` in the received `move` to construct your response.
 
@@ -44,7 +44,7 @@ A `card` describes the effect or event that is being requested. Each application
   ==
 ```
 
-Each `card` is a pair consisting of a tag and a noun. The tag indicates what the event being triggered is and the noun is any data required for that event.
+Each `card` is a `pair` consisting of a tag and a noun. The tag indicates what the event being triggered is and the noun is any data required for that event.
 
 ## Arms
 

--- a/tutorials/hoon/gall.md
+++ b/tutorials/hoon/gall.md
@@ -5,6 +5,8 @@ template = "doc.html"
 aliases = ["/docs/learn/hoon/hoon-tutorial/gall/"]
 +++
 
+Note: as of 2019.12.02, this material is out of date. While this is being updated, please see the [Gall overview](@/docs/tutorials/arvo/gall.md) in the Arvo section to get oriented with Gall. Some material presented here may still be useful.
+
 Gall is the Arvo vane responsible for handling stateful user space applications. When writing a Gall application there are several things you will need to understand.
 
 ## bowl and moves

--- a/tutorials/hoon/gall.md
+++ b/tutorials/hoon/gall.md
@@ -14,18 +14,18 @@ The core of a Gall app is a door whose subject has two parts: a `bowl:gall` whic
 The data contained in `bowl:gall` is quite generic.
 ```hoon
   ++  bowl                                              ::  standard app state
-          $:  $:  our/ship                              ::  host
-                  src/ship                              ::  guest
-                  dap/term                              ::  agent
+          $:  $:  our=ship                              ::  host
+                  src=ship                              ::  guest
+                  dap=term                              ::  agent
               ==                                        ::
-              $:  wex/boat                              ::  outgoing subs
-                  sup/bitt                              ::  incoming subs
+              $:  wex=boat                              ::  outgoing subs
+                  sup=bitt                              ::  incoming subs
               ==                                        ::
-              $:  ost/bone                              ::  opaque cause
-                  act/@ud                               ::  change number
-                  eny/@uvJ                              ::  entropy
-                  now/@da                               ::  current time
-                  byk/beak                              ::  load source
+              $:  ost=bone                              ::  opaque cause
+                  act=@ud                               ::  change number
+                  eny=@uvJ                              ::  entropy
+                  now=@da                               ::  current time
+                  byk=beak                              ::  load source
           ==  ==
 ```
 

--- a/tutorials/hoon/gall.md
+++ b/tutorials/hoon/gall.md
@@ -9,13 +9,13 @@ Gall is the Arvo vane responsible for handling user space applications. When wri
 
 ## bowl and moves
 
-The core of a gall app is a door which has two parts of its subject, the first a `bowl:gall` which contains a lot of standard things used by gall apps, the second a type containing app state information.
+The core of a Gall app is a door whose subject has two parts: a `bowl:gall` which contains a lot of standard things used by Gall apps and a type containing app state information.
 
-Vanes in Arvo communicate by means of `moves`. When a move is produced by an arm in a gall app, it's dispatched by Arvo to the correct handler for the request, be it another application or another vane. A `move` is pair of `bone` and `card`. These are essential components to understand when learning to use gall.
+Vanes in Arvo communicate by means of `move`s. When a `move` is produced by an arm in a Gall app, it's dispatched by Arvo to the correct handler for the request, be it another application or another vane. A `move` is pair of `bone` and `card`. These are essential components to understand when learning to use Gall.
 
-A `bone` is an opaque cause that initiates a request. When constructing a `move` you can often use `ost.bowl` and when responding to an incoming `move` you can use the `bone` in that `move` to construct your response.
+A `bone` is an opaque cause that initiates a request. When constructing a outgoing `move` you will frequently use `ost.bowl` to acquire essential information, such as a `bone` describing the initial cause. When responding to an incoming `move` you can use the `bone` in the received `move` to construct your response.
 
-A `card` is the effect or event that is being requested. Each application should define the set of `cards` it can produce. Here is an excerpt from `clock.hoon` showing its `cards`
+A `card` describes the effect or event that is being requested. Each application should define the set of `card`s that it can produce. Here is an excerpt from `clock.hoon` showing its `card`s.
 
 ```hoon
 +$  card
@@ -26,15 +26,15 @@ A `card` is the effect or event that is being requested. Each application should
   ==
 ```
 
-Each `card` is a pair of a tag and a noun. The tag indicates what the event being triggered is and the noun is any data required for that event.
+Each `card` is a pair consisting of a tag and a noun. The tag indicates what the event being triggered is and the noun is any data required for that event.
 
 ## Arms
 
-Gall applications can have a number of arms that get called depending on the information they are sent.
+Gall applications can have a number of arms that get called depending on the `move`s they are sent. Here we describe several arms that nearly every Gall app will have.
 
 ### ++prep
 
-`++prep` is the arm that is called when an application is first started or when it's updated. This arm should be a gate that takes a `unit` of a noun and provides a way, if necessary, to make any changes to the application's data required by an upgrade. As a reminder, a `unit` is a type that may contain another type or it might contain `~`. They are used when there may or may not be some data available.
+`++prep` is the arm that is called when an application is first started or when it's updated. This arm should be a gate that takes a `unit` of a noun and provides a way, if necessary, to make any changes to the application's data required by an upgrade. As a reminder, a `unit` is a type that may contain another type or it might contain `~`. They are used when there may or may not be some data available. 
 
 Often when developing an application you will not initially care about the data. Here is a sample `++prep` arm that will simply throw away the previous application state.
 

--- a/tutorials/hoon/trees-sets-and-maps.md
+++ b/tutorials/hoon/trees-sets-and-maps.md
@@ -288,9 +288,9 @@ This result may be unexpected.  Why didn't it just give us `2`?  The answer has 
 
 Because there is no `%chicken` key in `c`, `get` simply returns `~` to indicate it's not in the map.  Otherwise it returns a pair like the one you see in the next to last example.
 
-`get` of `by` returns the key's value as a `unit`, not as raw data.  There are two kinds of `unit`s: null `~`, and non-null.  A non-null `unit` is a pair of `[~ value]`.  Unit types are constructed the way list, set, and map types are; for example, `(unit @)` is the type for a unit whose value is an atom.
+`get` of `by` returns the key's value as a `unit`, not as raw data.  There are two kinds of `unit`s: null `~`, and non-null.  A non-null `unit` is a pair of `[~ value]`.  Unit types are constructed the way list, set, and map types are; for example, `(unit @)` is the type for a unit whose value is an atom. `unit`s are Hoon's [option type](https://en.wikipedia.org/wiki/Option_type), which are helpful for error handling.
 
-If you want to get some key value without producing a unit, use `got` instead:
+If you want to get some key value without producing a `unit`, use `got` instead:
 
 ```
 > (~(got by c) %two)


### PR DESCRIPTION
I clarified and expanded some sections of the Gall tutorial, as well as fixed minor typos and grammar.

The most major changes I made were being more explicit about what bowls are, and emphasizing that the door of a Gall app contains the state and that is why the door itself is given as a move in the egg-timer example.

I also wrote a little more about unit types, mentioning that they are the option types of Hoon.