### PR TITLE
add key:by and val:by to map reference

### DIFF
--- a/reference/library/2i.md
+++ b/reference/library/2i.md
@@ -610,6 +610,46 @@ A map.
 ```
 
 ---
+
+### `++  key:by`
+
+Set of keys
+
+Produces a the set of all keys in map `a` that is prepended to set `b`,
+which is empty by default.
+
+#### Accepts
+
+`a` is a map.
+
+`b` is a set.
+
+#### Produces
+
+A set.
+
+#### Source
+
+```hoon
+++  key
+  =+  b=`(set _?>(?=(^ a) p.n.a))`~
+  |-  ^+  b
+  ?~  a   b
+  $(a r.a, b $(a l.a, b (~(put in b) p.n.a)))
+```
+
+#### Examples
+
+```
+  > =m (my [['a' 1] ['b' 2] ~])
+  [n=[p='b' q=2] l={[p='a' q=1]} r={}]
+
+  > ~(key by m)
+  {'b' 'a'}
+```
+
+---
+
 ### `+-mar:by`
 
 Assert and add
@@ -1054,6 +1094,45 @@ An atom.
 
     > ~(wyt by (~(uni by m) o))
     4
+```
+
+---
+
+### `++  val:by`
+
+List of values
+
+Produces a the list of all values in map `a` that is prepended to list `b`,
+which is empty by default.
+
+#### Accepts
+
+`a` is a map.
+
+`b` is a list.
+
+#### Produces
+
+A list.
+
+#### Source
+
+```hoon
+++  val
+  =+  b=`(list _?>(?=(^ a) q.n.a))`~
+  |-  ^+  b
+  ?~  a   b
+  $(a r.a, b [q.n.a $(a l.a)])
+```
+
+#### Examples
+
+```
+  > =m (my [['a' 1] ['b' 2] ~])
+  [n=[p='b' q=2] l={[p='a' q=1]} r={}]
+
+  > ~(val by m)
+  ~[1 2]
 ```
 
 ---

--- a/reference/library/2i.md
+++ b/reference/library/2i.md
@@ -615,7 +615,7 @@ A map.
 
 Set of keys
 
-Produces a the set of all keys in map `a` that is prepended to set `b`,
+Produces a set of all keys in map `a` that is prepended to set `b`,
 which is empty by default.
 
 #### Accepts
@@ -1102,7 +1102,7 @@ An atom.
 
 List of values
 
-Produces a the list of all values in map `a` that is prepended to list `b`,
+Produces a list of all values in map `a` that is prepended to list `b`,
 which is empty by default.
 
 #### Accepts


### PR DESCRIPTION
adds key:by and val:by to map reference documentation.

Have used `++` despite it being inconsistent with the rest of the documentation, because `+-` is no longer used. 