### PR TITLE
Modernize reel, roll, sort examples

### DIFF
--- a/reference/library/2b.md
+++ b/reference/library/2b.md
@@ -589,15 +589,13 @@ The accumulator, which is a noun.
 #### Examples
 
 ```
-    > =sum =|([p=@ q=@] |.((add p q)))
-    > (reel (limo [1 2 3 4 5 ~]) sum)
+    > (reel `(list @)`[1 2 3 4 5 ~] add)
     15
 
-    > =a =|([p=@ q=@] |.((sub p q)))
-    > (reel (limo [6 3 1 ~]) a)
+    > (reel `(list @)`[6 3 1 ~] sub)
     4
 
-    > (reel (limo [3 6 1 ~]) a)
+    > (reel `(list @)`[3 6 1 ~] sub)
     ! subtract-underflow
     ! exit
 ```
@@ -640,16 +638,14 @@ The accumulator, which is a noun.
 #### Examples
 
 ```
-    > =sum =|([p=@ q=@] |.((add p q)))
-    > (roll (limo [1 2 3 4 5 ~]) sum)
+    > (roll `(list @)`[1 2 3 4 5 ~] add)
     q=15
 
-    > =a =|([p=@ q=@] |.((sub p q)))
-    > (roll (limo [6 3 1 ~]) a)
+    > (roll `(list @)`[6 3 1 ~] sub)
     ! subtract-underflow
     ! exit
 
-    > (roll (limo [1 3 6 ~]) a)
+    > (roll `(list @)`[1 3 6 ~] sub)
     q=4
 ```
 
@@ -1040,8 +1036,7 @@ A list
 #### Examples
 
 ```
-        > =a =|([p/@ q/@] |.((gth p q)))
-        > (sort (limo [0 1 2 3 ~]) a)
+        > (sort `(list @)`[0 1 2 3 ~] gth)
         ~[3 2 1 0]
 ```
 


### PR DESCRIPTION
These were using some weird construction to make a wrapper gate, probably for long-gone compatibility reasons. This just passes in the 

Also does a typecast instead of `limo`. Plenty of other examples seem to do so, and this is more common in recently-written hoon.