### PR TITLE
More correct chat glossary entry

### DIFF
--- a/glossary/chat.md
+++ b/glossary/chat.md
@@ -1,24 +1,24 @@
 +++
-title = "chat-cli"
+title = "chat"
 
 template = "doc.html"
 [extra]
 category = "arvo"
 +++
 
-**Chat**, also referred to as `:chat-cli`, is an application that handles communication between ships.
+**Chat** is a suite of applications that handle "instant messaging"-style communication between ships.
 
-There are four types of chats (lowercase). Each is a named collection of messages created by and hosted on a ship's [Hall](../hall), usually represented as `~ship-name/circle-name`. Most of Chat revolves around doing things with these chats.
+A chat is a named collection of messages created by and hosted in a ship's chat-store, usually represented as `~ship-name/circle-name`. Most of Chat revolves around doing things with these chats.
 
-Circles are subscribed to by some number of ships which are permitted to post and retrieve messages from the circle.
+Chats are subscribed to by some number of ships which are permitted to post and retrieve messages from the chat.
 
-There are several default types of chats.
+There are four "kinds" of chats, that use different permission modes:
 
- * A channel is a chat that is publicly readable and writable, with a blacklist for blocking.
- * A village is an invite-only chat.
- * A journal is publicly readable and privately writable, with a whitelist for authors.
- * A mailbox is readable by its owner and publicly writable, with a blacklist for blocking.
+ * A `channel` is a chat that is publicly readable and writable, with a blacklist for blocking.
+ * A `village` is an invite-only chat.
+ * A `journal` is publicly readable and privately writable, with a whitelist for authors.
+ * A `mailbox` is readable by its owner and publicly writable, with a blacklist for blocking.
 
 ### Further Reading
 
-- [Messaging guide](@/using/operations/using-your-ship.md#messaging): A guide to using Chat.
+- [Messaging guide](@/using/operations/using-your-ship.md#messaging): A guide to using Chat from the command line.


### PR DESCRIPTION
This was all kinds of messed up. I don't even know why we have glossary entries for hall and talk. They say they're dead, so why bother describing them?