### PR TITLE
Corrects the description of Jael

### DIFF
--- a/glossary/jael.md
+++ b/glossary/jael.md
@@ -5,4 +5,4 @@ template = "doc.html"
 category = "arvo"
 +++
 
-**Jael** is the [vane](../vane) that handles security and encryption.
+**Jael** is the [vane](../vane) that keeps track of [Azimuth](../azimuth) related information. For each [ship](../ship), this consists of its networking keys, its revision number (or _life_), its breach number, and who the sponsor of the ship is.


### PR DESCRIPTION
I checked a few potential places and didn't see that we explain exactly what life number and breach number are anywhere in the glossary (or even the docs for that matter). This doesn't seem like the right place to hide those definitions, but should probably be mentioned in the docs somewhere and linked to from here. I'll make an issue for it.