### PR TITLE
remove manual hoon tutorial index

### DIFF
--- a/tutorials/hoon/_index.md
+++ b/tutorials/hoon/_index.md
@@ -2,7 +2,7 @@
 title = "Hoon"
 weight = 1
 sort_by = "weight"
-template = "sections/docs/chapters.html"
+template = "sections/docs/hoon.html"
 aliases = ["/docs/byte/0/", "/docs/byte", "/docs/learn/hoon/hoon-tutorial/"]
 +++
 
@@ -13,55 +13,3 @@ Chapter 1 introduces and explains the fundamental concepts you need in order to 
 Hoon is a 'subject-oriented' programming language -- every expression of Hoon is evaluated relative to a **subject**.  The subject is a piece of data that represents the environment, or the context, of an expression.  After reading Chapter 1 you should understand what the subject is and how to refer to its various parts.  In this chapter you'll also learn about **cores**, which are an important data structure in Hoon.  Once you get the hang of cores you'll be able to write your own functions in Hoon.
 
 Chapter 2 covers the type system, and writing apps, and the workings of the Arvo kernel.
-
-
-## Lessons
-
-### Chapter 1
-
-- [1.1 Setup](setup)
-- [1.1.1 Walkthrough: List of Numbers](list-of-numbers)
-- [1.2 Nouns](nouns)
-- [1.3 Hoon Syntax](hoon-syntax)
-- [1.3.1 Walkthrough: Conditionals](conditionals)
-- [1.4 Gates (Hoon Functions)](gates)
-- [1.4.1 Walkthrough: Recursion](recursion)
-- [1.5 Lists](lists)
-- [1.5.1 Walkthrough: Fibonacci Sequence](fibonacci)
-- [1.6 The Subject and Its Legs](the-subject-and-its-legs)
-- [1.6.1 Walkthrough: Ackermann Function](ackermann)
-- [1.7 Arms and Cores](arms-and-cores)
-- [1.7.1 Walkthrough: Caesar Cipher](caesar)
-- [1.8 Doors](doors)
-- [1.8.1 Walkthough: Bank Account](bank-account)
-- [1.9 Generators](generators)
-
-### Chapter 2
-
-- [2.1 Atoms, Auras, and Simple Cell Types](atoms-auras-and-simple-cell-types)
-- [2.2 Type Checking and Type Inference](type-checking-and-type-inference)
-- [2.3 Structures and Complex Types](structures-and-complex-types)
-- [2.3.1 Walkthrough: Libraries](libraries)
-- [2.4 Standard Library: Trees, Sets, and Maps](trees-sets-and-maps)
-- [2.5 Type Polymorphism](type-polymorphism)
-- [2.5.1 Walkthrough: Iron Polymorphism](iron-polymorphism)
-- [2.5.2 Walkthrough: Lead Polymorphism](lead-polymorphism)
-- [2.6 Behn](behn)
-- [2.7 Gall](gall)
-- [2.7.1 Gall Walkthrough: Egg Timer](egg-timer)
-- [2.7.2 Gall: Async Monad](async-monad)
-- [2.8 Ford](ford)
-- [2.8.1 Walkthrough Ford Testing Suite Walkthrough](test-sets)
-- [2.9.1 Walkthrough: Landscape Tile](landscape-tile)
-
-
-## Other Resources
-
-Want to know how to style your code? Check out the [style guide](style).
-
-Consult the [standard library documentation](@/docs/reference/library/_index.md) or [rune reference](@/docs/reference/hoon-expressions/_index.md) to look up any unknown rune or standard library function you don't understand.
-
-As you work your way through these lessons you may want to work on example problems from the [Hoon Workbook](@/docs/tutorials/hoon/workbook/_index.md) for practice.  Once you finish the lessons here you may want to write more versatile Hoon programs which can make use of more of your urbit's environment, in which case you'll want to check out the [Generators](@/docs/tutorials/hoon/generators.md) documentation. Learn about [Udon and Sail](@/docs/tutorials/sail-and-udon.md), Urbit's stripped-down version of Markdown, and a subset of Hoon used for generating XML nodes respectively.
-
-
-> Last major revision of this section: November 2019

--- a/tutorials/hoon/style.md
+++ b/tutorials/hoon/style.md
@@ -1,5 +1,5 @@
 +++
-title = "Hoon Style Guide"
+title = "Appendix: Hoon Style Guide"
 weight = 100
 template = "doc.html"
 aliases = ["docs/learn/hoon/style/"]


### PR DESCRIPTION
Paired with [urbit.org/#333](https://github.com/urbit/urbit.org/pull/333). Strips the manual index from the Hoon tutorial (and the additional info — if it should be preserved *below the lesson list*, it should go into the template directly, unfortunately).

Also adds "Appendix:" to the Hoon Style Guide to make it a more logical section of the list; it's cleanly separated from the chapters and lessons.