### PR TITLE
fixes link on updating to a new binary

### DIFF
--- a/tutorials/ship-troubleshooting.md
+++ b/tutorials/ship-troubleshooting.md
@@ -38,7 +38,7 @@ The best way to end an urbit process is to use `ctrl-d` from the Dojo. Unix meth
 
 ### Keep up-to-date builds
 
-Check for latest Urbit version at https://github.com/urbit/urbit/releases. If you're behind, update using [this guide](/operations/)
+Check for latest Urbit version at https://github.com/urbit/urbit/releases. If you're behind, update using [this guide](@using/install.md).
 
 ### `|hi` your star to see if you're connected
 


### PR DESCRIPTION
----
Previous link was broken, and we don't really have any guide about how to update
to a new binary anywhere are far as I can tell, so I changed the link to go to
the install page per Rob's recommendation. But that is written from the
perspective of a completely new install and so is not exactly what the reader
would be expecting.

I definitely think we need to
explain this somewhere, so perhaps it would be better to write a couple
paragraphs about that somewhere and make it part of this PR.
#