### PR TITLE
added !< entry

### DIFF
--- a/reference/hoon-expressions/rune/zap.md
+++ b/reference/hoon-expressions/rune/zap.md
@@ -60,14 +60,16 @@ a typed value from a `vase`.
 ##### Examples
 
 ```
-> !<  @p  !>  ~zod
-~zod
-
 > !<  @  !>  ~zod
 0
 
 > !<  @p  !>  0
 nest-fail
+
+> =m !>  0
+> =n !>  1
+> !<  [@ @]  (slop m n)
+[0 1]
 ```
 
 ### !: "zapcol"

--- a/reference/hoon-expressions/rune/zap.md
+++ b/reference/hoon-expressions/rune/zap.md
@@ -36,6 +36,40 @@ If you want just the type value, use a 'type spear'.  This is `-:!>`, i.e., the 
 #t/@ud
 ```
 
+### !< "zapgal"
+
+`[%zpld p=spec q=hoon]`
+
+Takes a mold and a `vase` and dynamically checks that the type in the `vase`
+matches the mold.
+
+##### Produces
+
+The value of `vase` typed with the type of the mold if possible, else a
+`nest-fail`.
+
+##### Syntax
+
+Regular:  **2-fixed**
+
+##### Discussion
+
+This is something like a partial inverse to the `!>` rune and can be used to extract
+a typed value from a `vase`.
+
+##### Examples
+
+```
+> !<  @p  !>  ~zod
+~zod
+
+> !<  @  !>  ~zod
+0
+
+> !<  @p  !>  0
+nest-fail
+```
+
 ### !: "zapcol"
 
 `[%dbug p=hoon]`: turn on stack trace


### PR DESCRIPTION
Addresses #749

I noticed while editing this page that some of the marks like `%zpgr` don't
match what is in `hoon.hoon`. This sort of thing keeps coming up and needs a
overall strategy, and is nested inside of some larger docs issues. I'll make an
issue about this. In this case, I just went with what is listed in `hoon.hoon`
instead of what it "ought" to be.

----

#