### PR TITLE
Fixed life and rift number definition

### DIFF
--- a/glossary/ames.md
+++ b/glossary/ames.md
@@ -8,7 +8,10 @@ category = "arvo"
 **Ames** is the name of the Urbit network and the [vane](../vane) that communicates over it. It's an encrypted peer-to-peer network composed of instances of the [Arvo](../arvo) operating system. Each [galaxy](../galaxy), [star](../star), [planet](../planet), [moon](../moon), and [comet](../comet) communicates over the network utilizing the Ames protocol.
 
 Your ship upgrades itself with [OTA updates](../ota-updates) via communication over Ames. The web interface, [Landscape](../landscape), of ships can be accessed by typing `sampel-palnet.arvo.network` into a browser, where `sampel-palnet` is the name of your ship.
-
+ 
+Network continuity occasionally needs to be broken, either at an individual
+level to fix networking issues or at a network-wide level to update Arvo beyond
+what OTA updates are capable of doing. These events are called [breaches](../breach).
 ### Further Reading
 
 - [The Ames tutorial](@/docs/tutorials/arvo/ames.md): An in-depth technical guide to the Ames protocol.

--- a/glossary/breach.md
+++ b/glossary/breach.md
@@ -12,18 +12,21 @@ history, called a **personal breach**, or cause the entire network to forget its
 history, called a **network breach**.
 
 Personal breaches are always initiated by the user, frequently in response to a
-connectivity error. Each one increments the _life_ number of the ship by one, which is
+connectivity error. The easiest way to do this is with [Bridge](../bridge).
+There are two types of personal breaches: changing private keys, and changing
+the Urbit ID ownership address. Each one increments the _life_ number of the ship by one, which is
 an integer that represents how many personal breaches have been performed on
-that ship.
+that ship. Transferring the ID to a new address will also increase the _rift_
+number of the ship in addition to the life number.
+
+You can check your life and rift number by typing `+keys`
+into dojo and pressing Enter.
 
 Network breaches happen when a major Arvo revision that cannot be implemented 
 via an [OTA update](../ota-updates) occurs. When this happens, a new binary
-will need to be downloaded. Each network breach increments the _rift_ number of
-the network by one, which is an integer that represents how many network
-breaches have been performed.
+will need to be downloaded, and your ship's pier needs to be moved to the
+directory containing the new binary.
 
-You can check your life number and the current rift number by typing `+keys`
-into dojo and pressing Enter.
 
 ### Further Reading
 

--- a/glossary/breach.md
+++ b/glossary/breach.md
@@ -19,7 +19,7 @@ an integer that represents how many personal breaches have been performed on
 that ship. Transferring the ID to a new address will also increase the _rift_
 number of the ship in addition to the life number.
 
-You can check your life and rift number by typing `+keys`
+You can check your life and rift number by typing `+keys our`
 into dojo and pressing Enter.
 
 Network breaches happen when a major Arvo revision that cannot be implemented 

--- a/glossary/breach.md
+++ b/glossary/breach.md
@@ -11,13 +11,15 @@ history, called a **personal breach**, or cause the entire network to forget its
 history, called a **network breach**.
 
 Personal breaches are always initiated by the user, frequently in response to a
-connectivity error. Each one increments the _life_ of the ship by one, which is
+connectivity error. Each one increments the _life_ number of the ship by one, which is
 an integer that represents how many personal breaches have been performed on
 that ship.
 
 Network breaches happen when a major Arvo revision that cannot be implemented 
 via an [OTA update](../ota-updates) occurs. When this happens, a new binary
-will need to be downloaded.
+will need to be downloaded. Each network breach increments the _rift_ number of
+the network by one, which is an integer that represents how many network
+breaches have been performed.
 
 You can check your life number and the current rift number by typing `+keys`
 into dojo and pressing Enter.

--- a/glossary/breach.md
+++ b/glossary/breach.md
@@ -1,0 +1,28 @@
++++
+title = "Breach"
+template = "doc.html"
++++
+
+Continuity on the [Ames](../ames) network occasionally needs to be broken at
+this early stage in order to correct a networking error or make major changes to
+Arvo. These infrequent events are known as
+**breaches** which either cause an individual ship to forget its network message
+history, called a **personal breach**, or cause the entire network to forget its
+history, called a **network breach**.
+
+Personal breaches are always initiated by the user, frequently in response to a
+connectivity error. Each one increments the _life_ of the ship by one, which is
+an integer that represents how many personal breaches have been performed on
+that ship.
+
+Network breaches happen when a major Arvo revision that cannot be implemented 
+via an [OTA update](../ota-updates.md) occurs. When this happens, a new binary
+will need to be downloaded.
+
+You can check your life number and the current rift number by typing `+keys`
+into dojo and pressing Enter.
+
+### Further Reading
+
+- [Guide to breaches](@/docs/tutorials/guide-to-breaches.md): A more in-depth
+  explanation of breaches, including how to perform a personal breach.

--- a/glossary/breach.md
+++ b/glossary/breach.md
@@ -1,6 +1,7 @@
 +++
 title = "Breach"
 template = "doc.html"
+category = "arvo"
 +++
 
 Continuity on the [Ames](../ames) network occasionally needs to be broken at

--- a/glossary/breach.md
+++ b/glossary/breach.md
@@ -16,7 +16,7 @@ an integer that represents how many personal breaches have been performed on
 that ship.
 
 Network breaches happen when a major Arvo revision that cannot be implemented 
-via an [OTA update](../ota-updates.md) occurs. When this happens, a new binary
+via an [OTA update](../ota-updates) occurs. When this happens, a new binary
 will need to be downloaded.
 
 You can check your life number and the current rift number by typing `+keys`
@@ -26,3 +26,4 @@ into dojo and pressing Enter.
 
 - [Guide to breaches](@/docs/tutorials/guide-to-breaches.md): A more in-depth
   explanation of breaches, including how to perform a personal breach.
+- [Ship Troubleshooting](@/docs/tutorials/ship-troubleshooting.md): General instructions on getting your ship to work, which includes network connectivity issues.

--- a/tutorials/guide-to-breaches.md
+++ b/tutorials/guide-to-breaches.md
@@ -29,7 +29,9 @@ your ship's _life_ by one, which refers to your ship's [Azimuth](@/docs/tutorial
 revision number_. This value is utilized by
 Ames and Jael to ensure that you are
 communicating with a ship created using its most recent set of keys. Your
-ship's life is written at the end of the name of its keyfile, e.g. `sampel-palnet4.key.`
+ship's life is written at the end of the name of its keyfile, e.g.
+`sampel-palnet4.key`. You can also check your current life number by running the
+`+keys` generator in dojo.
 
 
 ## Network Breaches
@@ -47,4 +49,5 @@ If a network breach is happening, follow the steps below.
 Each network breach increments an integer value called the _rift_ of the network
 by one, which is recorded by each ship and refers to the current Azimuth
 _continuity number_. Only ships with the same rift number can
-communicate over Ames.
+communicate over Ames. You can check the current rift number by running the
+`+keys` generator in dojo.

--- a/tutorials/guide-to-breaches.md
+++ b/tutorials/guide-to-breaches.md
@@ -38,9 +38,8 @@ called _reticketing_, also increments a number called the ship's _rift_ by one.
 Rift refers to your ship's Azimuth _continuity number_.
 
 You can check your current life and rift number by running the
-`+keys` generator in dojo. To inspect a ship's life number, type `.^(* %j
-/=life=/(scot %p <ship>))` into dojo. To inspect a ship's rift number, type `.^(* %j /=rift=/(scot %p <ship>))`
- into dojo.
+`+keys our` generator in dojo. You can inspect another ship's life and rift can be checked by
+running `+keys ~sampel-palnet`.
 
 
 ## Network Breaches

--- a/tutorials/guide-to-breaches.md
+++ b/tutorials/guide-to-breaches.md
@@ -24,14 +24,23 @@ To perform a personal breach, follow the steps below.
 - Create a new pier by booting your ship with your new keyfile.
 - Rejoin your favorite chat channels and subscriptions.
 
-Performing a personal breach on your ship increments an integer value called
+There are two types of personal breaches: changing private keys, and changing
+the Ethereum address that holds the Urbit ID.
+
+Each type of personal breach increments an integer value called
 your ship's _life_ by one, which refers to your ship's [Azimuth](@/docs/tutorials/concepts/azimuth.md) _key
 revision number_. This value is utilized by
 Ames and Jael to ensure that you are
 communicating with a ship created using its most recent set of keys. Your
 ship's life is written at the end of the name of its keyfile, e.g.
-`sampel-palnet4.key`. You can also check your current life number by running the
-`+keys` generator in dojo.
+`sampel-palnet4.key`. Changing the Etherum address that holds the Urbit ID,
+called _reticketing_, also increments a number called the ship's _rift_ by one.
+Rift refers to your ship's Azimuth _continuity number_.
+
+You can check your current life and rift number by running the
+`+keys` generator in dojo. To inspect a ship's life number, type `.^(* %j
+/=life=/(scot %p <ship>))` into dojo. To inspect a ship's rift number, type `.^(* %j /=rift=/(scot %p <ship>))`
+ into dojo.
 
 
 ## Network Breaches
@@ -46,8 +55,3 @@ If a network breach is happening, follow the steps below.
 - Create a new pier by booting your ship with your key, according to the instructions on the install page. (Note: You do _not_ need to use a new key to boot into a new continuity era.)
 - Rejoin your favorite chat channels and subscriptions.
 
-Each network breach increments an integer value called the _rift_ of the network
-by one, which is recorded by each ship and refers to the current Azimuth
-_continuity number_. Only ships with the same rift number can
-communicate over Ames. You can check the current rift number by running the
-`+keys` generator in dojo.

--- a/tutorials/guide-to-breaches.md
+++ b/tutorials/guide-to-breaches.md
@@ -4,13 +4,13 @@ weight = 10
 template = "doc.html"
 +++
 
-An important concept on the Arvo network is that of continuity. Continuity refers to how ships remember the order of their own network messages and the network messages of others -- these messages are numbered, starting from zero. A _breach_ is when ships on the network agree to forget about this sequence and treat one or more ships like they are brand new.
+An important concept on the [Ames](@/docs/tutorials/arvo/ames.md) network is that of continuity. Continuity refers to how ships remember the order of their own network messages and the network messages of others -- these messages are numbered, starting from zero. A _breach_ is when ships on the network agree to forget about this sequence and treat one or more ships like they are brand new.
 
 There are two kinds of breaches: **personal breaches** and **network breaches**.
 
 ## Personal Breaches
 
-Ships on the Arvo network sometimes need to reset their continuity. A personal breach is when an individual ship announces to the network: "I forgot who I am, let's start over from scratch." That is, it clears its own event log and sends an announcement to the network, asking all ships that have communicated with it to reset its networking information in their state. This makes it as though the ship was just started for the first time again, since everyone has network has forgotten about it.
+Ships on the Ames network sometimes need to reset their continuity. A personal breach is when an individual ship announces to the network: "I forgot who I am, let's start over from scratch." That is, it clears its own event log and sends an announcement to the network, asking all ships that have communicated with it to reset its networking information in their state. This makes it as though the ship was just started for the first time again, since everyone has network has forgotten about it.
 
 Personal breaches often fix connectivity issues, but should only be used as a last resort. Before performing a personal breach, look at alternative fixes in the [Ship Troubleshooting](../ship-troubleshooting) guide. Also reach out for help in `~dopzod/urbit-help`, or, failing that, in the #ship-starting-support channel in our [Discord server](https://discord.gg/n9xhMdz) to see if there is another option. 
 
@@ -24,6 +24,14 @@ To perform a personal breach, follow the steps below.
 - Create a new pier by booting your ship with your new keyfile.
 - Rejoin your favorite chat channels and subscriptions.
 
+Performing a personal breach on your ship increments an integer value called
+your ship's _life_ by one, which refers to your ship's [Azimuth](@/docs/tutorials/concepts/azimuth.md) _key
+revision number_. This value is utilized by
+Ames and Jael to ensure that you are
+communicating with a ship created using its most recent set of keys. Your
+ship's life is written at the end of the name of its keyfile, e.g. `sampel-palnet4.key.`
+
+
 ## Network Breaches
 
 A network breach is an event where all ships on the network are required to update to a new continuity era. Network breaches happen when an Arvo update is released that is too large to release over the air. The current continuity era is given by a value in Ames, our networking vane, that is incremented when a network breaches; only ships with the same such value are able to communicate with one another.
@@ -35,3 +43,8 @@ If a network breach is happening, follow the steps below.
 - Download the new Urbit binary by following the instructions in the [Install page](https://urbit.org/using/install/).
 - Create a new pier by booting your ship with your key, according to the instructions on the install page. (Note: You do _not_ need to use a new key to boot into a new continuity era.)
 - Rejoin your favorite chat channels and subscriptions.
+
+Each network breach increments an integer value called the _rift_ of the network
+by one, which is recorded by each ship and refers to the current Azimuth
+_continuity number_. Only ships with the same rift number can
+communicate over Ames.


### PR DESCRIPTION
Addresses #770 and fixes #807. Somewhere along the line I got the wrong
impression of what rift number was and thought it referred to network continuty
number. This is now (hopefully) accurate.

I also added in commands to check any ship's life and rift number to the guide
to breaches, in addition to the `+keys` generator that checks your own. It might
make better sense to add that information to
using/operations/using-your-ship.md instead or in addition to putting it here.
I'll make that a separate PR.

----

#