### PR TITLE
Behn public API

### DIFF
--- a/reference/vane-apis/behn.md
+++ b/reference/vane-apis/behn.md
@@ -60,16 +60,9 @@ If the set of timers is nonempty when Behn is `%pass`ed a `%crud` `task`, Behn
 
 `%drip` allows one to delay `gift`s until a timer set for `now` fires.
 
-For example, say an app is subscribed to updates from Clay. If Clay `%give`s
-updates to the app directly and the app crashes, this may cause Clay to crash as
-well. If instead Clay `%pass`es Behn a `%drip` `task` wrapping the update
-`gift`, Behn will set a timer for `now` that, when fired, will cause the update
-`gift` to be given. If it causes a crash then it will have been in response to
-the `%drip` move, thereby isolating Clay from the crash. Thus `%drip` acts as a sort of buffer against cascading
-sequences of crashes.
-
 `%drip` only handles `gift`s, and can only schedule `gift`s for as soon as
 possible after the prescribed timer fires.
+
 
 #### Accepts
 
@@ -82,10 +75,22 @@ mov=vase
 #### Returns
 
 In response to a `%drip` `task`, Behn will `%give` a `%meta` `gift` containing
-the `gift` originally `%give`n to Behn when `%drip` was first called.
+the `gift` originally `%give`n to Behn when `%drip` was first called. That makes
+Behn its own client for `%drip`.
 
-Is that really correct? It looks like the gift returned is actually a response to
-a pass it passed itself, not the original event?
+#### Example
+
+
+Client -- %drip --> Behn -- %wait --> Behn -- %wake --> Behn -- %give --> Target
+
+
+Say an app is subscribed to updates from Clay. If Clay `%give`s
+updates to the app directly and the app crashes, this may cause Clay to crash as
+well. If instead Clay `%pass`es Behn a `%drip` `task` wrapping the update
+`gift`, Behn will set a timer for `now` that, when fired, will cause the update
+`gift` to be given. If it causes a crash then it will have been in response to
+the `%drip` move, thereby isolating Clay from the crash. Thus `%drip` acts as a sort of buffer against cascading
+sequences of crashes.
 
 
 
@@ -142,8 +147,7 @@ This `task` has no arguments.
 
 #### Returns
 
-This `task` returns `[moves state]`.
-
+This task returns nothing.
 
 ### `%vega`
 
@@ -156,7 +160,7 @@ This `task` has no arguments.
 
 #### Returns
 
-This `task` returns `[moves state]`.
+This `task` returns nothing.
 
 
 

--- a/reference/vane-apis/behn.md
+++ b/reference/vane-apis/behn.md
@@ -66,13 +66,13 @@ the stack trace.
 
 `%drip` allows one to delay a `gift` until a timer set for `now` fires.
 
-A Client gives Behn a `%drip` task wrapping a `gift` to be `give`n to a Target.
+A Client `%slip`s Behn a `%drip` task wrapping a `gift` to be `give`n to a Target.
 This launches a sequence of `move`s as written here:
 
 ```
-Client -- %drip --> Behn -- %wait --> Behn -- %wake --> Behn -- %meta --> Target
+Client -- %slip %drip --> Behn -- %pass %wait --> Behn -- %give %wake --> Behn -- %give %meta --> Target
 ```
-Here the `%meta` move is a wrapper for the `%gift` inside of the initial `%drip` wrapper.
+Here the `%meta` `move` is a wrapper for the `%gift` inside of the initial `%drip` wrapper.
 
 `%drip` only handles `gift`s, and can only schedule `gift`s for as soon as
 possible after the prescribed timer fires.
@@ -88,7 +88,8 @@ mov=vase
 
 #### Returns
 
-In response to a `%drip` `task`, Behn will `%give` a `%meta` `gift` containing
+In response to a `%drip` `task`, Behn will `%pass` a `%wait` to itself, which
+then triggers a `%wake` `gift` to itself, which then causes Behn to `%give` a `%meta` `gift` containing
 the `gift` originally `%give`n to Behn when `%drip` was first called. That makes
 Behn its own client for `%drip`.
 

--- a/reference/vane-apis/behn.md
+++ b/reference/vane-apis/behn.md
@@ -1,0 +1,366 @@
++++
+title = "Behn"
+weight = 2
+template = "doc.html"
++++
+
+# Behn
+
+In this document we describe the public interface for Behn. Namely, we describe
+each `task` that Behn can be `pass`ed, and which `gift`(s) Behn can `give` in return.
+
+
+## Tasks
+
+### `%born`
+
+Each time you start your Urbit, the Arvo kernel calls the `%born` task for Behn. When
+called, Behn gets the current time from Unix and updates its list of timers
+accordingly.
+
+#### Accepts
+
+```hoon
+[~]
+```
+
+#### Returns
+
+`%born` does not return a `gift`.
+
+#### Source
+```hoon
+::  +born: urbit restarted; refresh :next-wake and store wakeup timer duct
+  ::
+  ++  born  set-unix-wake(next-wake.state ~, unix-duct.state duct)
+```
+
+
+### `%crud`
+
+`%crud` is called whenever an error involving Behn occurs, which for now means
+that Behn has no timers in its state.
+
+When called, it checks to see if the set of timers is empty. If so, it prints
+and error report containing `error`, otherwise it passes the error to `+wake`.
+
+Behn should be the first vane to be activated in a `%wake`. Occasionally this does not
+happen, but we do not yet handle this error.
+
+#### Accepts
+
+```hoon
+[tag=@tas error=tang]
+```
+Here, `tag` is a `@tas` denoting the type of error, and `error` is an error message.
+
+#### Returns
+
+If the set of timers is nonempty when Behn is `%pass`ed a `%crud` `task`, Behn
+`%give`s a `%wake` `card` to itself.
+
+```hoon
+[%wake %behn-crud-no-timer tag error]
+```
+ 
+
+#### Source
+```hoon
+++  crud
+    |=  [tag=@tas error=tang]
+    ^+  [moves state]
+    ::  behn must get activated before other vanes in a %wake
+    ::
+    ::    TODO: uncomment this case after switching %crud tags
+    ::
+    ::    We don't know how to handle other errors, so relay them to %dill
+    ::    to be printed and don't treat them as timer failures.
+    ::
+    ::  ?.  =(%wake tag)
+    ::    ~&  %behn-crud-not-first-activation^tag
+    ::    [[duct %slip %d %flog %crud tag error]~ state]
+    ::
+    ?:  =(~ timers.state)  ~|  %behn-crud-no-timer^tag^error  !!
+    ::
+    (wake `error)
+ ```
+ 
+
+### `%drip`
+
+`%drip` is utilized to delay `%give`ing a `gift`.
+
+`%drip` allows one to delay `gift`s until a given condition is met. For example,
+if Clay crashes and you do not wish for an app to then crash when it tries to
+access Clay before it is restarted, `%drip` can delay that access until Clay has
+been restored. 
+
+`%drip` only handles `gift`s, and can only schedule `gift`s for as soon as
+possible after the prescribed condition is met.
+
+#### Accepts
+
+```hoon
+mov=vase
+```
+
+`%drip` takes in a `%give` `move` in a `vase`.
+
+#### Returns
+
+In response to a `%drip` `task`, Behn will `%give` a `%meta` `gift` containing
+the `gift` originally `%give`n to Behn when `%drip` was first called.
+
+Is that really correct? It looks like the gift returned is actually a response to
+a pass it passed itself, not the original event?
+
+#### Source
+
+```hoon
+  ::  +drip:  XX
+  ::
+  ++  drip
+    |=  mov=vase
+    =<  [moves state]
+    ^+  event-core
+    =.  moves
+      [duct %pass /drip/(scot %ud count.drips.state) %b %wait +(now)]~
+    =.  movs.drips.state
+      (~(put by movs.drips.state) count.drips.state mov)
+    =.  count.drips.state  +(count.drips.state)
+    event-core
+```
+
+
+
+### `%huck`
+
+Immediately gives back an input move.
+
+#### Accepts
+
+```hoon
+mov=vase
+```
+
+Behn takes in a `move` contained in a `vase`.
+
+#### Returns
+
+```hoon
+[%give %meta mov]
+```
+
+Behn returns the input `move` as a `%meta` `gift`.
+
+#### Source
+
+```hoon
+  ::  +huck: give back immediately
+  ::
+  ::    Useful if you want to continue working after other moves finish.
+  ::
+  ++  huck
+    |=  mov=vase
+    =<  [moves state]
+    event-core(moves [duct %give %meta mov]~)
+```
+
+
+
+### `%rest`
+
+Cancels a timer that was previously set.
+
+Behn takes in a `@da` and cancels the timer at that time if it exists, then
+adjusts the next wakeup call from Unix if necessary.
+
+#### Task
+
+```hoon
+@da
+```
+
+
+#### Gift
+
+This `task` returns no `gift`s.
+
+
+#### Source
+
+```hoon
+::  +rest: cancel the timer at :date, then adjust unix wakeup
+++  rest  |=(date=@da set-unix-wake(timers.state (unset-timer [date duct])))
+```
+
+
+
+### `%trim`
+
+This `task` is sent by the interpreter in order to free up memory.
+ This `task` is empty for Behn, since it is not a good idea to forget your timers.
+
+#### Accepts
+
+This `task` has no arguments. 
+
+#### Returns
+
+This `task` returns `[moves state]`.
+
+#### Source
+
+```hoon
+  ::  +trim: in response to memory pressue
+  ::
+  ++  trim  [moves state]
+```
+
+
+
+### `%vega`
+
+This `task` informs the vane that the kernel has been upgraded. Behn does not do
+anything in response to this.
+
+#### Accepts
+
+This `task` has no arguments.
+
+#### Returns
+
+This `task` returns `[moves state]`.
+
+#### Source
+
+```hoon
+  ::  +vega: learn of a kernel upgrade
+  ::
+  ++  vega  [moves state]
+```
+
+
+
+### `%wait`
+
+This `task` takes in a `@da` which Behn then adds to `timers.state`, the list of timers.
+
+#### Accepts
+
+```hoon
+@da
+```
+ 
+#### Returns
+
+This `task` returns nothing.
+
+#### Source
+
+```hoon
+::  +wait: set a new timer at :date, then adjust unix wakeup
+++  wait  |=(date=@da set-unix-wake(timers.state (set-timer [date duct])))
+```
+
+
+
+### `%wake`
+
+This `task` is sent by the kernel when the Unix timer tells the kernel that it
+is time for Behn to wake up. This is often caused by a `%doze` `gift` that
+Behn originally sent to the kernel that is then forwarded to Unix, which is
+where the real timekeeping occurs. 
+
+Upon receiving this `task`, Behn processes the elapsed timer and then sets
+`:next-wake`.
+
+`%wake` is also a `gift` that Behn can `%give`. This is done to inform other
+vanes or apps that a timer has expired, and may include an error message.
+
+#### Accepts
+
+As a `task`, `%wake` takes in `~`.
+
+As a `gift`, `%wake` may include an error message.
+
+```hoon
+error=(unit tang)
+```
+
+
+#### Returns
+
+In response to receiving this `task`, Behn may `%give` a `%doze` `gift`
+containing the `@da` of the next timer to elapse. Behn may also `%give` a
+`%wake` `gift` to itself.
+
+#### Source
+
+```hoon
+  ::  +wake: unix says wake up; process the elapsed timer and set :next-wake
+  ::
+  ++  wake
+    |=  error=(unit tang)
+    ^+  [moves state]
+    ::  no-op on spurious but innocuous unix wakeups
+    ::
+    ?~  timers.state
+      ~?  ?=(^ error)  %behn-wake-no-timer^u.error
+      [moves state]
+    ::  if we errored, pop the timer and notify the client vane of the error
+    ::
+    ?^  error
+      =<  set-unix-wake
+      (emit-vane-wake(timers.state t.timers.state) duct.i.timers.state error)
+    ::  if unix woke us too early, retry by resetting the unix wakeup timer
+    ::
+    ?:  (gth date.i.timers.state now)
+      set-unix-wake(next-wake.state ~)
+    ::  pop first timer, tell vane it has elapsed, and adjust next unix wakeup
+    ::
+    =<  set-unix-wake
+    (emit-vane-wake(timers.state t.timers.state) duct.i.timers.state ~)
+
+```
+
+
+
+### `%wegh`
+
+This `task` asks Behn to product a memory usage report.
+
+#### Accepts
+
+This `task` has no arguments.
+
+#### Returns
+
+```hoon
+:_  state  :_  ~
+    :^  duct  %give  %mass
+    :+  %behn  %|
+    :~  timers+&+timers.state
+        dot+&+state
+```
+
+When Behn is `%pass`ed this `task`, it will `%give` a `%mass` `gift` in response
+containing Behn's current memory usage.
+
+#### Source
+
+```hoon
+  ::  +wegh: produce memory usage report for |mass
+  ::
+  ++  wegh
+    ^+  [moves state]
+    :_  state  :_  ~
+    :^  duct  %give  %mass
+    :+  %behn  %|
+    :~  timers+&+timers.state
+        dot+&+state
+    ==
+```
+
+
+

--- a/reference/vane-apis/behn.md
+++ b/reference/vane-apis/behn.md
@@ -64,7 +64,15 @@ the stack trace.
 
 ### `%drip`
 
-`%drip` allows one to delay `gift`s until a timer set for `now` fires.
+`%drip` allows one to delay a `gift` until a timer set for `now` fires.
+
+A Client gives Behn a `%drip` task wrapping a `gift` to be `give`n to a Target.
+This launches a sequence of `move`s as written here:
+
+```
+Client -- %drip --> Behn -- %wait --> Behn -- %wake --> Behn -- %meta --> Target
+```
+Here the `%meta` move is a wrapper for the `%gift` inside of the initial `%drip` wrapper.
 
 `%drip` only handles `gift`s, and can only schedule `gift`s for as soon as
 possible after the prescribed timer fires.
@@ -87,10 +95,7 @@ Behn its own client for `%drip`.
 #### Example
 
 
-Client -- %drip --> Behn -- %wait --> Behn -- %wake --> Behn -- %give --> Target
-
-
-Say an app is subscribed to updates from Clay. If Clay `%give`s
+Say an app (the Target) is subscribed to updates from Clay (the Client). If Clay `%give`s
 updates to the app directly and the app crashes, this may cause Clay to crash as
 well. If instead Clay `%pass`es Behn a `%drip` `task` wrapping the update
 `gift`, Behn will set a timer for `now` that, when fired, will cause the update

--- a/reference/vane-apis/behn.md
+++ b/reference/vane-apis/behn.md
@@ -35,7 +35,7 @@ accordingly.
 `%wake` a program that has crashed.
 
 When called, it checks to see if the set of timers is empty. If so, it prints
-and error report containing `error`, otherwise it passes the error to `+wake`.
+an error report containing `error`, otherwise it passes the error to `+wake`.
 
 #### Accepts
 
@@ -46,12 +46,13 @@ Here, `tag` is a `@tas` denoting the type of error, and `error` is an error mess
 
 #### Returns
 
-If the set of timers is nonempty when Behn is `%pass`ed a `%crud` `task`, Behn
-`%give`s a `%wake` `card` to itself.
-
 ```hoon
 [%wake %behn-crud-no-timer tag error]
 ```
+
+If the set of timers is nonempty when Behn is `%pass`ed a `%crud` `task`, Behn
+`%give`s a `%wake` `card` containing the error to the next client in the set of timers.
+
 
 #### Example
 

--- a/reference/vane-apis/behn.md
+++ b/reference/vane-apis/behn.md
@@ -172,8 +172,7 @@ This `task` takes in a `@da` which Behn then adds to `timers.state`, the list of
  
 #### Returns
 
-This `task` returns nothing.
-
+This `task` returns a `%wake` `gift` once the timer has fired.
 
 
 ### `%wake`

--- a/reference/vane-apis/behn.md
+++ b/reference/vane-apis/behn.md
@@ -28,13 +28,6 @@ accordingly.
 
 `%born` does not return a `gift`.
 
-#### Source
-```hoon
-::  +born: urbit restarted; refresh :next-wake and store wakeup timer duct
-  ::
-  ++  born  set-unix-wake(next-wake.state ~, unix-duct.state duct)
-```
-
 
 ### `%crud`
 
@@ -63,29 +56,6 @@ If the set of timers is nonempty when Behn is `%pass`ed a `%crud` `task`, Behn
 [%wake %behn-crud-no-timer tag error]
 ```
  
-
-#### Source
-```hoon
-++  crud
-    |=  [tag=@tas error=tang]
-    ^+  [moves state]
-    ::  behn must get activated before other vanes in a %wake
-    ::
-    ::    TODO: uncomment this case after switching %crud tags
-    ::
-    ::    We don't know how to handle other errors, so relay them to %dill
-    ::    to be printed and don't treat them as timer failures.
-    ::
-    ::  ?.  =(%wake tag)
-    ::    ~&  %behn-crud-not-first-activation^tag
-    ::    [[duct %slip %d %flog %crud tag error]~ state]
-    ::
-    ?:  =(~ timers.state)  ~|  %behn-crud-no-timer^tag^error  !!
-    ::
-    (wake `error)
- ```
- 
-
 ### `%drip`
 
 `%drip` is utilized to delay `%give`ing a `gift`.
@@ -114,23 +84,6 @@ the `gift` originally `%give`n to Behn when `%drip` was first called.
 Is that really correct? It looks like the gift returned is actually a response to
 a pass it passed itself, not the original event?
 
-#### Source
-
-```hoon
-  ::  +drip:  XX
-  ::
-  ++  drip
-    |=  mov=vase
-    =<  [moves state]
-    ^+  event-core
-    =.  moves
-      [duct %pass /drip/(scot %ud count.drips.state) %b %wait +(now)]~
-    =.  movs.drips.state
-      (~(put by movs.drips.state) count.drips.state mov)
-    =.  count.drips.state  +(count.drips.state)
-    event-core
-```
-
 
 
 ### `%huck`
@@ -153,19 +106,6 @@ Behn takes in a `move` contained in a `vase`.
 
 Behn returns the input `move` as a `%meta` `gift`.
 
-#### Source
-
-```hoon
-  ::  +huck: give back immediately
-  ::
-  ::    Useful if you want to continue working after other moves finish.
-  ::
-  ++  huck
-    |=  mov=vase
-    =<  [moves state]
-    event-core(moves [duct %give %meta mov]~)
-```
-
 
 
 ### `%rest`
@@ -187,14 +127,6 @@ adjusts the next wakeup call from Unix if necessary.
 This `task` returns no `gift`s.
 
 
-#### Source
-
-```hoon
-::  +rest: cancel the timer at :date, then adjust unix wakeup
-++  rest  |=(date=@da set-unix-wake(timers.state (unset-timer [date duct])))
-```
-
-
 
 ### `%trim`
 
@@ -209,15 +141,6 @@ This `task` has no arguments.
 
 This `task` returns `[moves state]`.
 
-#### Source
-
-```hoon
-  ::  +trim: in response to memory pressue
-  ::
-  ++  trim  [moves state]
-```
-
-
 
 ### `%vega`
 
@@ -231,14 +154,6 @@ This `task` has no arguments.
 #### Returns
 
 This `task` returns `[moves state]`.
-
-#### Source
-
-```hoon
-  ::  +vega: learn of a kernel upgrade
-  ::
-  ++  vega  [moves state]
-```
 
 
 
@@ -255,13 +170,6 @@ This `task` takes in a `@da` which Behn then adds to `timers.state`, the list of
 #### Returns
 
 This `task` returns nothing.
-
-#### Source
-
-```hoon
-::  +wait: set a new timer at :date, then adjust unix wakeup
-++  wait  |=(date=@da set-unix-wake(timers.state (set-timer [date duct])))
-```
 
 
 
@@ -295,35 +203,6 @@ In response to receiving this `task`, Behn may `%give` a `%doze` `gift`
 containing the `@da` of the next timer to elapse. Behn may also `%give` a
 `%wake` `gift` to itself.
 
-#### Source
-
-```hoon
-  ::  +wake: unix says wake up; process the elapsed timer and set :next-wake
-  ::
-  ++  wake
-    |=  error=(unit tang)
-    ^+  [moves state]
-    ::  no-op on spurious but innocuous unix wakeups
-    ::
-    ?~  timers.state
-      ~?  ?=(^ error)  %behn-wake-no-timer^u.error
-      [moves state]
-    ::  if we errored, pop the timer and notify the client vane of the error
-    ::
-    ?^  error
-      =<  set-unix-wake
-      (emit-vane-wake(timers.state t.timers.state) duct.i.timers.state error)
-    ::  if unix woke us too early, retry by resetting the unix wakeup timer
-    ::
-    ?:  (gth date.i.timers.state now)
-      set-unix-wake(next-wake.state ~)
-    ::  pop first timer, tell vane it has elapsed, and adjust next unix wakeup
-    ::
-    =<  set-unix-wake
-    (emit-vane-wake(timers.state t.timers.state) duct.i.timers.state ~)
-
-```
-
 
 
 ### `%wegh`
@@ -346,21 +225,6 @@ This `task` has no arguments.
 
 When Behn is `%pass`ed this `task`, it will `%give` a `%mass` `gift` in response
 containing Behn's current memory usage.
-
-#### Source
-
-```hoon
-  ::  +wegh: produce memory usage report for |mass
-  ::
-  ++  wegh
-    ^+  [moves state]
-    :_  state  :_  ~
-    :^  duct  %give  %mass
-    :+  %behn  %|
-    :~  timers+&+timers.state
-        dot+&+state
-    ==
-```
 
 
 

--- a/reference/vane-apis/behn.md
+++ b/reference/vane-apis/behn.md
@@ -58,15 +58,18 @@ If the set of timers is nonempty when Behn is `%pass`ed a `%crud` `task`, Behn
  
 ### `%drip`
 
-`%drip` is utilized to delay `%give`ing a `gift`.
+`%drip` allows one to delay `gift`s until a timer set for `now` fires.
 
-`%drip` allows one to delay `gift`s until a given condition is met. For example,
-if Clay crashes and you do not wish for an app to then crash when it tries to
-access Clay before it is restarted, `%drip` can delay that access until Clay has
-been restored. 
+For example, say an app is subscribed to updates from Clay. If Clay `%give`s
+updates to the app directly and the app crashes, this may cause Clay to crash as
+well. If instead Clay `%pass`es Behn a `%drip` `task` wrapping the update
+`gift`, Behn will set a timer for `now` that, when fired, will cause the update
+`gift` to be given. If it causes a crash then it will have been in response to
+the `%drip` move, thereby isolating Clay from the crash. Thus `%drip` acts as a sort of buffer against cascading
+sequences of crashes.
 
 `%drip` only handles `gift`s, and can only schedule `gift`s for as soon as
-possible after the prescribed condition is met.
+possible after the prescribed timer fires.
 
 #### Accepts
 

--- a/reference/vane-apis/behn.md
+++ b/reference/vane-apis/behn.md
@@ -31,14 +31,11 @@ accordingly.
 
 ### `%crud`
 
-`%crud` is called whenever an error involving Behn occurs, which for now means
-that Behn has no timers in its state.
+`%crud` is called whenever an error involving Behn occurs, such as trying to
+`%wake` a program that has crashed.
 
 When called, it checks to see if the set of timers is empty. If so, it prints
 and error report containing `error`, otherwise it passes the error to `+wake`.
-
-Behn should be the first vane to be activated in a `%wake`. Occasionally this does not
-happen, but we do not yet handle this error.
 
 #### Accepts
 
@@ -55,7 +52,15 @@ If the set of timers is nonempty when Behn is `%pass`ed a `%crud` `task`, Behn
 ```hoon
 [%wake %behn-crud-no-timer tag error]
 ```
+
+#### Example
+
+The most common error that occurs is when Behn tries to `%wake` up a program that has crashed. When this happens
+the entire event (i.e. sequence of `move`s) that led up to the `%wake` is thrown
+away, and Vere then causes the kernel to `pass` Behn a `%crud` `task` containing
+the stack trace.
  
+
 ### `%drip`
 
 `%drip` allows one to delay `gift`s until a timer set for `now` fires.


### PR DESCRIPTION
This PR adds a new page, `reference/vane-apis/behn.md`, that lists each of the
`task`s that Behn performs, what they do, and what `gift`s they may return in
response.

Some possible issues:
i) I include the source code for each arm. Since we currently do not have a way
to pull source automatically into the docs, this creates an issue where it could be
out of date quickly. I think I will probably remove it, but would like feedback
on that choice first. Furthermore, sometimes what each arm does is split into
several places (and this is especially true for other vanes), so showing the
source for just the arm can be deceptive.
ii) I am not yet an expert on reading Hoon, so I cannot be sure that I've
covered all possible `gift` responses correctly. I'm pretty sure I have for
Behn, but not as much for e.g. Ames.
iii) For returns, I only talk about what `gift`s may be returned, which is not
the same thing as what the arms return. This is not what is done in
the Gall API docs, which instead focuses on what the arms return. A more
complete documentation would include both.
iv) I don't include any examples. After some time messing around with a simple
goad-like app to pass vanes `card`s to get very artificial examples, I've come
to think that it would be better for engineers to provide the examples, since
they have a much better feel for how these things are actually used in practice
than I do. Coming up with examples myself I think would eat up a lot more
manhours than just having engineers write the examples themselves, since what
I'd end up doing is just talking to engineers to get the examples anyways. Best
to cut out the middleman.

----

#