### PR TITLE
tutorials/*.md: text, typographic, and formatting corrections

### DIFF
--- a/tutorials/_index.md
+++ b/tutorials/_index.md
@@ -14,14 +14,14 @@ Arvo is a clean-slate system software stack defined as a deterministic computer.
 
 ## [Hoon Tutorial](@/docs/tutorials/hoon/_index.md)
 
-Hoon is a high-level, statically typed, functional programming language, custom-designed for use with Urbit. For a functional language it has a surprisingly imperative style, and mastering it doesn't require knowing any advanced mathematics. The Hoon Tutorial is the best place to start if you want to learn Urbit.
+Hoon is a high-level, statically typed, functional programming language, custom-designed for use with Urbit. For a functional language it has a surprisingly imperative style, and mastering it doesn’t require knowing any advanced mathematics. The Hoon Tutorial is the best place to start if you want to learn Urbit.
 
 ## [Nock](@/docs/tutorials/nock/_index.md)
 
-Nock is the low-level functional programming language that is interpreted by Vere. You don't need to know Nock to write Hoon, or even to work on most parts of Vere.  But if you want to understand the foundations of Urbit and are mathematically-inclined, dive right in.
+Nock is the low-level functional programming language that is interpreted by Vere. You don’t need to know Nock to write Hoon, or even to work on most parts of Vere. But if you want to understand the foundations of Urbit and are mathematically-inclined, dive right in.
 
 ## [Vere](@/docs/tutorials/vere/_index.md)
 
 The Nock runtime system, written in C.
 
-Keep reading if you're planning to work on the Urbit interpreter, you're a language implementation geek, or you don't really understand anything until you've seen the actual structs.
+Keep reading if you’re planning to work on the Urbit interpreter, you’re a language implementation geek, or you don’t really understand anything until you’ve seen the actual structs.

--- a/tutorials/creating-an-invite-pool.md
+++ b/tutorials/creating-an-invite-pool.md
@@ -22,7 +22,7 @@ Giving your friends a piece of Urbit only takes a few minutes: send an invite po
 
 1. Log into Bridge using your ownership address for your star.
 
-2. Get the name (like `~poldec-tonteg`) of the planet to whom you'd like to give invites, it can be one you control or a friend's.
+2. Get the name (like `~poldec-tonteg`) of the planet to whom you’d like to give invites, it can be one you control or a friend’s.
 
 3. Click “Manage Invite Pools” to assign an invite pool to the planet. You may receive a notification that you need to assign your spawn proxy to the address of the Delegated Sending contract. This is so that the contract can send invites on your behalf when the recipient claims them.
 

--- a/tutorials/guide-to-breaches.md
+++ b/tutorials/guide-to-breaches.md
@@ -10,9 +10,9 @@ There are two kinds of breaches: **personal breaches** and **network breaches**.
 
 ## Personal Breaches
 
-Ships on the Ames network sometimes need to reset their continuity. A personal breach is when an individual ship announces to the network: "I forgot who I am, let's start over from scratch." That is, it clears its own event log and sends an announcement to the network, asking all ships that have communicated with it to reset its networking information in their state. This makes it as though the ship was just started for the first time again, since everyone has network has forgotten about it.
+Ships on the Ames network sometimes need to reset their continuity. A personal breach is when an individual ship announces to the network: “I forgot who I am, let’s start over from scratch.” That is, it clears its own event log and sends an announcement to the network, asking all ships that have communicated with it to reset its networking information in their state. This makes it as though the ship was just started for the first time again, since everyone on the network has forgotten about it.
 
-Personal breaches often fix connectivity issues, but should only be used as a last resort. Before performing a personal breach, look at alternative fixes in the [Ship Troubleshooting](../ship-troubleshooting) guide. Also reach out for help in `~dopzod/urbit-help`, or, failing that, in the #ship-starting-support channel in our [Discord server](https://discord.gg/n9xhMdz) to see if there is another option. 
+Personal breaches often fix connectivity issues, but should only be used as a last resort. Before performing a personal breach, look at alternative fixes in the [Ship Troubleshooting](../ship-troubleshooting) guide. Also reach out for help in `~dopzod/urbit-help`, or, failing that, in the `#ship-starting-support` channel in our [Discord server](https://discord.gg/n9xhMdz) to see if there is another option. 
 
 To perform a personal breach, follow the steps below.
 
@@ -28,17 +28,17 @@ There are two types of personal breaches: changing private keys, and changing
 the Ethereum address that holds the Urbit ID.
 
 Performing a personal breach on your ship increments an integer value called
-your ship's _life_ by one, which refers to your ship's [Azimuth](@/docs/tutorials/concepts/azimuth.md) _key
+your ship’s _life_ by one, which refers to your ship’s [Azimuth](@/docs/tutorials/concepts/azimuth.md) _key
 revision number_. This value is utilized by
 Ames and Jael to ensure that you are
 communicating with a ship created using its most recent set of keys. Your
-ship's life is written at the end of the name of its keyfile, e.g.
-`sampel-palnet4.key`. Changing the Etherum address that holds the Urbit ID,
-called _reticketing_, also increments a number called the ship's _rift_ by one.
-Rift refers to your ship's Azimuth _continuity number_.
+ship’s life is written at the end of the name of its keyfile, e.g.
+`sampel-palnet-4.key`. Changing the Etherum address that holds the Urbit ID,
+called _reticketing_, also increments a number called the ship’s _rift_ by one.
+Rift refers to your ship’s Azimuth _continuity number_.
 
 You can check your current life and rift number by running the
-`+keys our` generator in dojo. You can inspect another ship's life and rift can be checked by
+`+keys our` generator in Dojo. You can inspect another ship’s life and rift can be checked by
 running `+keys ~sampel-palnet`.
 
 

--- a/tutorials/hoon-errors.md
+++ b/tutorials/hoon-errors.md
@@ -5,25 +5,25 @@ template = "doc.html"
 +++
 
 In this section we explore strategies for debugging and understanding what your
-Hoon code is doing. We cover common errors that dojo may spit out, how to turn
+Hoon code is doing. We cover common errors that Dojo may spit out, how to turn
 on debugging and verbose mode, and how to use debugging printfs.
 
 ## Syntax errors
 
-When you get a syntax error, you'll see a message like
+When you get a syntax error, you’ll see a message like:
 
 ```
 syntax error at [10 12]
 ```
 
 This is a line and column number; more exactly, the line and
-column of the first byte the parser couldn't interpret as part of
-a correct Hoon file.  These values are always correct.
+column of the first byte the parser couldn’t interpret as part of
+a correct Hoon file. These values are always correct.
 
 Usually, the line and column tell you everything you need to
-know.  But the worst-case scenario for a syntax error is that,
-somewhere above, you've confused Hoon's tall form by using the
-wrong fanout for a rune.  For example, `%+` ([**cenlus**](@/docs/reference/hoon-expressions/rune/cen.md#cenlus),
+know. But the worst-case scenario for a syntax error is that,
+somewhere above, you’ve confused Hoon’s tall form by using the
+wrong fanout for a rune. For example, `%+` ([**cenlus**](@/docs/reference/hoon-expressions/rune/cen.md#cenlus),
 a function call whose sample is a cell) has three subhoons:
 
 ```hoon
@@ -32,44 +32,44 @@ a function call whose sample is a cell) has three subhoons:
 baz
 ```
 
-But if you make a mistake and write
+But if you make a mistake and write …
 
 ```hoon
 %+  foo
 bar
 ```
 
-the parser will eat the next reference below and try to treat it as a
-part of the `%+`.  This can cause a cascading error somewhere
+… the parser will eat the next reference below and try to treat it as a
+part of the `%+`. This can cause a cascading error somewhere
 below, usually stopped by a `==` or `--`.
 
-When this happens, don't panic!  Binary search actually works
-quite well.  Any reference can be stubbed out as `!!`.  Find the
+When this happens, don’t panic! Binary search actually works
+quite well. Any reference can be stubbed out as `!!`. Find the
 prefix of your file that compiles, then work forward until
 the actual error appears.
 
 ## Semantic errors
 
-Now your code parses but doesn't compile.
+Now your code parses but doesn’t compile.
 
 ### Turn on debugging or verbose mode
 
-Your first step should be to put a `!:` ("zapcol") rune at the
-top of the file.  This is like calling the C compiler with `-g`;
+Your first step should be to put a `!:` (“zapcol”) rune at the
+top of the file. This is like calling the C compiler with `-g`;
 it tells the Hoon compiler to generate tracing references.
 
-Bear in mind that `!:` breaks tail-call optimization.  This is a
-bug, but a relatively low-priority bug.  `!.` turns off `!:`.
+Bear in mind that `!:` breaks tail-call optimization. This is a
+bug, but a relatively low-priority bug. `!.` turns off `!:`.
 Note that `!:` and `!.` are reference-level, not file-level; you can
 wrap any reference in either.
 
-You may also find it helpful to turn on verbose mode by entering `|verb` into dojo, which prints (almost)
+You may also find it helpful to turn on verbose mode by entering `|verb` into Dojo, which prints (almost)
 everything happening in the kernel to the console. This is useful for performing
 stack trace. An extensive stack trace tutorial is [below](#stack-trace-tutorial).
 
 ### Error trace
 
-If you have `!:` on, you'll see an error trace, like
+If you have `!:` on, you’ll see an error trace, like:
 
 ```
 /~zod/home/0/gen/hello:<[7 3].[11 21]>
@@ -85,31 +85,31 @@ The bottom of this trace is the line and column of the reference which
 failed to compile, then the cause of the error (`nest-fail`).
 
 Hoon does not believe in inundating you with possibly irrelevant
-debugging information.  Your first resort is always to just look
-at the code and try to figure out what's wrong.  This practice
+debugging information. Your first resort is always to just look
+at the code and try to figure out what’s wrong. This practice
 strengthens your Hoon muscles.
 
 (Consider the opposite extreme; imagine if you had a magic bot
-that always fixed your compiler errors for you.  Pro: no time
-wasted on compiler errors.  Con: you never learn Hoon.)
+that always fixed your compiler errors for you. Pro: no time
+wasted on compiler errors. Con: you never learn Hoon.)
 
 ## Common errors
 
-Moral fiber is all very well and good, but sometimes you're
-stumped.  Couldn't the compiler help a little?  These messages do
-mean something.  Here are the three most common:
+Moral fiber is all very well and good, but sometimes you’re
+stumped. Couldn’t the compiler help a little? These messages do
+mean something. Here are the three most common:
 
 ### `nest-fail`
 
-This is a type mismatch (`nest` is the Hoon typechecker).  It
+This is a type mismatch (`nest` is the Hoon typechecker). It
 means you tried to pound a square peg into a round hole.
 
-What was the peg and what was the hole?  Hoon doesn't tell you by
+What was the peg and what was the hole? Hoon doesn’t tell you by
 default, because moral fiber, and also because in too many cases
-trivial errors lead to large intimidating dumps.  However, you
+trivial errors lead to large intimidating dumps. However, you
 can use the `~!` rune ([**sigzap**](@/docs/reference/hoon-expressions/rune/sig.md#sigzap)) to print the type of any hoon in your stack trace.
 
-For instance, you wrote `(foo bar)` and got a `nest-fail`.  Change
+For instance, you wrote `(foo bar)` and got a `nest-fail`. Change
 your code to be:
 
 ```hoon
@@ -118,16 +118,16 @@ your code to be:
 (foo bar)
 ```
 
-You'll get the same `nest-fail`, but this will show the type of
+You’ll get the same `nest-fail`, but this will show the type of
 `bar`, then the type of the sample of the `foo` gate.
 
 ### `find.foo`
 
-A `find.foo` error means limb `foo` wasn't found in the subject.
-In other words, "undeclared variable."
+A `find.foo` error means limb `foo` wasn’t found in the subject.
+In other words, “undeclared variable.”
 
 The most common subspecies of `find` error is `find.$`, meaning
-the empty name `$` was not found.  This often happens when you
+the empty name `$` was not found. This often happens when you
 use a reference that does not produce a gate/mold, as a gate/mold. For
 instance, `(foo bar)` will give `find.$` if `foo` is not actually a
 function.
@@ -135,17 +135,17 @@ function.
 ### `mint-vain` and `mint-lost`
 
 These are errors caused by type inference in pattern matching.
-`mint-vain` means this hoon is never executed.  `mint-lost` means there's a case in a `?-` ([**wuthep**](@/docs/reference/hoon-expressions/rune/wut.md#wuthep)) that isn't handled.
+`mint-vain` means this hoon is never executed. `mint-lost` means there’s a case in a `?-` ([**wuthep**](@/docs/reference/hoon-expressions/rune/wut.md#wuthep)) that isn’t handled.
 
 ## Runtime crashes
 
-If your code crashes at runtime or overflows the stack, you'll
-see a stack trace that looks just like the trace above.  Don't
+If your code crashes at runtime or overflows the stack, you’ll
+see a stack trace that looks just like the trace above. Don’t
 confuse runtime crashes with compilation errors, though.
 
-If your code goes into an infinite loop, kill it with `ctrl-c` (you'll
+If your code goes into an infinite loop, kill it with `ctrl-c` (you’ll
 need to be developing on the local console; otherwise, the
-infinite loop will time out either too slowly or too fast).  The
+infinite loop will time out either too slowly or too fast). The
 stack trace will show what your code was doing when interrupted.
 
 The counterpart of `~!` for runtime crashes is `~|`
@@ -157,15 +157,15 @@ The counterpart of `~!` for runtime crashes is `~|`
 ```
 
 If `(foo bar)` crashes, the value of `foo` is printed in the
-stack trace.  Otherwise, the `~|` has no effect.
+stack trace. Otherwise, the `~|` has no effect.
 
 ## Debugging printfs
 
 The worst possibility, of course, is that your code runs but does
-the wrong thing.  This is relatively unusual in a typed
+the wrong thing. This is relatively unusual in a typed
 functional language, but it still happens.
 
-`~&` ([**sigpam**](@/docs/reference/hoon-expressions/rune/sig.md#sigpam)) is Hoon's debugging printf.
+`~&` ([**sigpam**](@/docs/reference/hoon-expressions/rune/sig.md#sigpam)) is Hoon’s debugging printf.
 This pretty-prints its argument:
 
 ```hoon
@@ -173,7 +173,7 @@ This pretty-prints its argument:
 (foo bar)
 ```
 
-will always print `foo` every time it executes.  A variant is
+will always print `foo` every time it executes. A variant is
 `~?` ([**sigwut**](@/docs/reference/hoon-expressions/rune/sig.md#sigwut)), which prints only if a condition is
 true:
 
@@ -183,7 +183,7 @@ true:
 ```
 
 For now, you need to be on the local console to see these debug
-printfs (which are implemented by interpreter hints).  This is a
+printfs (which are implemented by interpreter hints). This is a
 bug and, like all bugs, will be fixed at some point.
 
 

--- a/tutorials/sail-and-udon.md
+++ b/tutorials/sail-and-udon.md
@@ -284,7 +284,7 @@ Add `/` after tag name to start an href.
 
 To add attributes to the link, like target specifications, add the
 desired attribute after the closing `"` of the link url and before the `:` of
-the `img` tag.
+the `a` tag.
 
 For example:
 

--- a/tutorials/sail-and-udon.md
+++ b/tutorials/sail-and-udon.md
@@ -7,7 +7,7 @@ aliases = ["docs/using/sail-and-udon/"]
 
 Sail is Hoon markup that’s used to render a web page with XML. But what makes it special is that you can run arbitrary Hoon code within such a web page without using a separate markup language.
 
-Udon is a way to write content for the web. It's a minimalist markup language for creating and rendering text documents, with a Markdown-inspired syntax. It's integrated with our Hoon programming language, allowing it to be used as standalone prose in its own file or embedded inside a Hoon source file, in which case it will be parsed into a tree of HTML nodes using Sail.
+Udon is a way to write content for the web. It’s a minimalist markup language for creating and rendering text documents, with a Markdown-inspired syntax. It’s integrated with our Hoon programming language, allowing it to be used as standalone prose in its own file or embedded inside a Hoon source file, in which case it will be parsed into a tree of HTML nodes using Sail.
 
 This document will be divided into two main sections: the Sail guide and the Udon guide. Also, you should read the Getting Started section below, which applies to both Udon and Sail.
 
@@ -27,7 +27,7 @@ Before starting with either Sail or Udon, make sure that your ship is
 To host that output, your ship also has a web-server that can be found at
 `localhost` (default port 80) if it’s your first ship that’s running on the
 machine, `http://localhost:8081/` if it’s the second ship on that same machine,
-and so on. In the startup messages, a ship will tell you which HTTP port it's
+and so on. In the startup messages, a ship will tell you which HTTP port it’s
 using.
 
 Udon and Sail files are often run as independent files (`.udon` and `.hoon`
@@ -35,7 +35,7 @@ respectively), but for the purpose of this guide, we will run them out of the
 `frontpage.hoon` file located in the `/gen` directory. The default content of
 `frontpage.hoon` is Sail code.
 
-To use `frontpage.hoon`, we use a `|serve` command like this one in your ship's
+To use `frontpage.hoon`, we use a `|serve` command like this one in your ship’s
 Dojo:
 
 ```
@@ -54,7 +54,7 @@ Run the command `|serve /test %home /gen/frontpage/hoon`. Now navigate to
 `localhost/test` (or `localhost:8081/test` if your ship is on that port) in your
 browser, and you should see the rendered Sail.
 
-**Note:** Important to remember that every time you edit a file in your ship's
+**Note:** Important to remember that every time you edit a file in your ship’s
 pier (Unix directory), including `frontpage.hoon`, you need to run `|commit %home`
 to copy those changes to Urbit.
 
@@ -72,7 +72,7 @@ It’s easy to see how Sail can directly translate to HTML:
   ;body
     ;h1: Welcome!
     ; Hello, world!
-    ; We're on the web.
+    ; We’re on the web.
     ;div;
     ;script@"http://unsafely.tracking.you/cookiemonster.js";
   ==
@@ -98,10 +98,10 @@ It’s easy to see how Sail can directly translate to HTML:
 
 You can test above Sail code by placing it
 under `^-  manx` in your `frontpage.hoon` file, and then running `|commit %home`
-in the Dojo. If you've already run the `|serve` command code from the first
+in the Dojo. If you’ve already run the `|serve` command code from the first
 section, the new content should appear at `localhost/test`.
 
-It shouldn't be hard to see the similarities between Sail and HTML. So let's go
+It shouldn’t be hard to see the similarities between Sail and HTML. So let’s go
 into more detail about what the differences are.
 
 ### Tags and Closing
@@ -147,7 +147,7 @@ with `==`, because they expect a list of sub-tags. If we nest a line of plain
 text with no tag, a `<p>` is prepended.
 
 Sail, like Hoon, is white-space sensitive. Unlike in Hoon, however, two spaces
-(called a "gap") is not necessarily equivalent to a line-break in Sail.
+(called a “gap”) is not necessarily equivalent to a line-break in Sail.
 
 ```
 ;body
@@ -353,7 +353,7 @@ Then enter the following command in the Dojo:
 > .
 ```
 
-You'll notice that the Sail subject is like a stripped-down version of the Dojo
+You’ll notice that the Sail subject is like a stripped-down version of the Dojo
 subject. Its final line should match the Dojo subject.
 
 Now swap the code below into your Sail file.
@@ -368,9 +368,9 @@ Now swap the code below into your Sail file.
 ==
 ```
 
-You'll find that the resulting Sail subject is much larger. If you look closely,
-you'll see that there's some new similarities with the Dojo subject, such as
-containing the name of your ship. There's also some new differences, since
+You’ll find that the resulting Sail subject is much larger. If you look closely,
+you’ll see that there’s some new similarities with the Dojo subject, such as
+containing the name of your ship. There’s also some new differences, since
 `fuel:html` contains things that are specifically useful for performing
 web-related operations.
 
@@ -402,13 +402,13 @@ example we saw before.
     ;span:  Check it out!
     ;+  ?:  show-list
         ;ol
-          ;li(style "color: green"): We're doing interesting stuff now.
-          ;li: We're pretty-printing this sum with Hoon: {<(add 50 50)>}.
+          ;li(style "color: green"): We’re doing interesting stuff now.
+          ;li: We’re pretty-printing this sum with Hoon: {<(add 50 50)>}.
           ;li: The code above is shorthand for {(scow %ud (add 50 50))}.
           ;li: I am {(trip '~lodleb-ritrul')}.
-          ;li: Actually, my name is {<p.bem.gas>}. I'm a {what-kind}.
+          ;li: Actually, my name is {<p.bem.gas>}. I’m a {what-kind}.
         ==
-        ;div: My name is {<p.bem.gas>}. I'm a {what-kind}.
+        ;div: My name is {<p.bem.gas>}. I’m a {what-kind}.
   ==
 ==
 ```
@@ -432,7 +432,7 @@ our subject with the information that we need, we use  `/=  gas  /$  fuel:html`.
 
 The above expression uses two Ford runes, `/=` and `/$`, to add the relevant
 information to the current subject. We can pull the ship’s name out of this
-augmented subject later. It's important to note that these runes are not part of
+augmented subject later. It’s important to note that these runes are not part of
 Hoon. They are part of Ford, our build system.
 
 `/$` is used to get data from the environment, and `/=` adds that data to
@@ -481,7 +481,7 @@ subject and gives it the face `wid`. This noun is produced by the the
 standard-library function [`met`](/docs/reference/library/2c), which measures the number of
 [blocks](/docs/reference/library/1c/) of size `a` within `b`. Blocks are units that have a
 bitwidth of `2^a`. So, in this case, it measures how many bytes (blocks of size
-3 are bitwidths of 8; `2^3 = 8`) are fully contained in your ship's address.
+3 are bitwidths of 8; `2^3 = 8`) are fully contained in your ship’s address.
 
 Galaxies contain zero to one 3-blocks; stars contain two 3-blocks; planets
 contain three to four 3-blocks; moons contain five to eight 3-blocks; comets
@@ -549,7 +549,7 @@ Thus, this program resolves to the first child of `show-list`, the node `;ol`.
 That node creates an ordered list, and the items contained within that node.
 
 ```
-            ;li(style "color: green"): We're doing more interesting stuff now.
+            ;li(style "color: green"): We’re doing more interesting stuff now.
 ```
 
 The line above  is the only element of this list that does not use
@@ -560,7 +560,7 @@ The next items in the list use `{}`. Recall that these braces, pronounced “lob
 and “rob” in Hoon-speak, allow for the interpolation of code within a string.
 
 ```
-            ;li: We're pretty-printing this sum with Hoon: {<(add 50 50)>}.
+            ;li: We’re pretty-printing this sum with Hoon: {<(add 50 50)>}.
 ```
 
 The line above is interpolated with Hoon code that produces the sum of 50 plus
@@ -589,7 +589,7 @@ tape. So, by converting `~lodleb-ritrul` to a tape, it can be included in the
 tape that we are trying to insert it into without getting a type error.
 
 ```
-            ;li: Actually, my name is {<p.bem.gas>}. I'm a {what-kind}.
+            ;li: Actually, my name is {<p.bem.gas>}. I’m a {what-kind}.
           ==
 ```
 
@@ -603,7 +603,7 @@ within `gas`, which happens to be where the name of the ship is located.
 Note that `{what-kind}` does not have a `<>` wrapper. Why do you think this is?
 
 ```
-        ;div; My name is {<p.bem.gas>}. I'm a {ship}.
+        ;div; My name is {<p.bem.gas>}. I’m a {ship}.
   ==
 ==
 ```
@@ -638,7 +638,7 @@ line 20 and modify it a bit:
         ;li: Actually, my name is {<p.bem.gas>}.
         ==
       ;=
-    ;div: My name is {<p.bem.gas>}. I'm a {what-kind}.
+    ;div: My name is {<p.bem.gas>}. I’m a {what-kind}.
     ;div: No list here!
       ==
   ==
@@ -667,15 +667,15 @@ learn more about how the renderer works, take a look at the
 
 ## Udon: A Guide {#udon}
 
-Udon is a way to write content for the web. It's a minimalist
+Udon is a way to write content for the web. It’s a minimalist
 markup language for creating and rendering text documents, with a
-Markdown-inspired syntax. It's integrated with our Hoon programming language,
+Markdown-inspired syntax. It’s integrated with our Hoon programming language,
 allowing it to be used as standalone prose in its own file or embedded inside a
 Hoon source file, in which case it will be parsed into a tree of HTML nodes
-using Hoon's XML-templating syntax, Sail.
+using Hoon’s XML-templating syntax, Sail.
 
 There are quite a few similarities between Udon and the
-CommonMark standard, but there are enough differences that you shouldn't rely on
+CommonMark standard, but there are enough differences that you shouldn’t rely on
 existing knowledge of the latter. Udon generally supports only one
 syntax for each type of HTML node it emits. Udon is also stricter than
 Markdown: some syntax errors will prevent the file from being parsed at all.
@@ -687,7 +687,7 @@ will use the `frontpage.hoon` method that we are already familiar with.
 
 To test out Udon, put a `;>` under the `^-  manx` in your `frontpage.hoon` file,
 and then put all your Udon code under that `;>`. Then run `|commit %home`
-in the Dojo. If you've already run the `|serve` command code from the first
+in the Dojo. If you’ve already run the `|serve` command code from the first
 section, the new content should appear at `localhost/test`.
 
 ## Udon Syntax
@@ -701,7 +701,7 @@ The first thing on a `.udon` file is a chunk of code called the front matter. It
 contains metadata about your page, such as date, title, and position relative
 to sibling pages.
 
-As an example, let's look at the front matter of this very page:
+As an example, let’s look at the front matter of this very page:
 
 ```
 :-  :~  navhome/'/docs/'
@@ -711,14 +711,14 @@ As an example, let's look at the front matter of this very page:
 ;>
 ```
 
-What's going on here?
+What’s going on here?
 
 `:-`, the Hoon rune for creating a cell, creates a cell composed of
 the `:~` Hoon rune for creating a list, and `;>`, which is a Sail rune
 for Udon.
 
 `:~` creates a list out of the three elements: `navhome/'/docs/'`, which
-indicates that navigating "home" will bring you to the urbit.org/docs section
+indicates that navigating “home” will bring you to the urbit.org/docs section
 of the website; `sort/'28',` which assigns it the 28th position of the
 immediate section that contains it, the one you see in the sidebar;
 and `title/'Udon'`, which gives the page its title. The `==` digraph
@@ -726,7 +726,7 @@ terminates the list.
 
 `;>` is a Sail rune that creates a node that contains everything that follows
 it, telling the parser that that text should be interpreted as Udon.
-It's not technically front matter, but you'll always find it following the
+It’s not technically front matter, but you’ll always find it following the
 front matter, since all Udon must come after this rune.
 
 The categories listed in the example above -- `navhome`, `sort`, and `title` --
@@ -793,22 +793,22 @@ the _same line_.
 **Example:**
 
 ```
-Here's the first line.
+Here’s the first line.
 
-This second line is separated by two newlines, so it's a separate paragraph.
+This second line is separated by two newlines, so it’s a separate paragraph.
 
-This line looks like a distinct paragraph, but...
-It's only separated by a single newline, so it's included in the same paragraph.
+This line looks like a distinct paragraph, but …
+It’s only separated by a single newline, so it’s included in the same paragraph.
 ```
 **Produces:**
 
 
-Here's the first line.
+Here’s the first line.
 
-This second line is separated by two newlines, so it's a separate paragraph.
+This second line is separated by two newlines, so it’s a separate paragraph.
 
-This line looks like a distinct paragraph, but...
-It's only separated by a single newline, so it's included in the same paragraph.
+This line looks like a distinct paragraph, but …
+It’s only separated by a single newline, so it’s included in the same paragraph.
 
 #### Backslash Line Break
 
@@ -860,13 +860,13 @@ New list elements are delineated by newlines beginning with list symbols of
 the appropriate type (`-` or `+`).
 
 Just as with non-list text, text on a bare newline will appear on line before,
-separated by a space. A `\\` is used to create a line-break that isn't the list
-itself and isn't a list. Both of these kinds of newlines must be indented by two
+separated by a space. A `\\` is used to create a line-break that isn’t the list
+itself and isn’t a list. Both of these kinds of newlines must be indented by two
 spaces, or else the page will not parse.
 
 Indentation is also used for creating nested sub-lists. Sub-lists of one kind
-can be used with parent lists of the other kind. Sub-lists can't be nested
-directly after either kind of aforementioned newline that isn't a list element;
+can be used with parent lists of the other kind. Sub-lists can’t be nested
+directly after either kind of aforementioned newline that isn’t a list element;
 only lines that are themselves list elements can nest sub-lists.
 
 A newline after a blank line is interpreted as a new paragraph in normal text.
@@ -884,15 +884,15 @@ followed by a `\\` on its own line.
 - Chicken\
   Make sure that you get enough for the barbecue
 - Bread
-  + Ask the baker what's fresh
+  + Ask the baker what’s fresh
   + Buy the second-freshest batch
 - Cereal
 
 \
 + First, separate eggs into a bowl
 + Then, add a splash of cream
-  - If you don't have cream, you can use milk, but cream is preferred
-    + If you don't have milk or cream, melt an eighth of a stick of butter on
+  - If you don’t have cream, you can use milk, but cream is preferred
+    + If you don’t have milk or cream, melt an eighth of a stick of butter on
       a skillet
     + Scramble the eggs in the bowl
     + Pour the eggs onto the skillet before the butter browns
@@ -914,15 +914,15 @@ Produces
 - Chicken\
   Make sure that you get enough for the barbecue
 - Bread
-    1. Ask the baker what's fresh
+    1. Ask the baker what’s fresh
     1. Buy the second-freshest batch
 - Cereal
 
 \
 1. First, separate eggs into a bowl
 1. Then, add a splash of cream
-    - If you don't have cream, you can use milk, but cream is preferred
-        1. If you don't have milk or cream, melt an eighth of a stick of butter on
+    - If you don’t have cream, you can use milk, but cream is preferred
+        1. If you don’t have milk or cream, melt an eighth of a stick of butter on
            a skillet
         1. Scramble the eggs in the bowl
         1. Pour the eggs onto the skillet before the butter browns
@@ -945,26 +945,26 @@ destination.
 **Example:**
 
 ```
-[I'm an inline-style link](https://urbit.org/operations/#using-the-shell)
+[I’m an inline-style link](https://urbit.org/operations/#using-the-shell)
 ```
 
 **Produces:**
 
-[I'm an inline-style link](https://urbit.org/operations/#using-the-shell)
+[I’m an inline-style link](https://urbit.org/operations/#using-the-shell)
 
 The second type is a reference-style link, which uses a relative path, based on
-the current page's location. Instead of the full url, we use `..` to fill in
+the current page’s location. Instead of the full url, we use `..` to fill in
 the all of the URL that the destination has in common with the origin page.
 
 **Example:**
 
 ```
-[I'm a reference-style link](../shell)
+[I’m a reference-style link](../shell)
 ```
 
 **Produces:**
 
-[I'm a reference-style link](../shell)
+[I’m a reference-style link](../shell)
 
 If this page is located at `https://www.urbit.org/docs/reference/`, then these two
 examples should have the same destination.
@@ -984,9 +984,9 @@ anchor.
 ```
 Check out this [section](#here-we-are) that we want to jump to.
 
-Four score and seven years ago....
+Four score and seven years ago …
 
-It was the best of times, it was the worst of times...
+It was the best of times, it was the worst of times …
 
 ## Here we are!
 ```
@@ -995,9 +995,9 @@ It was the best of times, it was the worst of times...
 
 Check out this [section](#here-we-are) that we want to jump to.
 
-Four score and seven years ago....
+Four score and seven years ago …
 
-It was the best of times, it was the worst of times...
+It was the best of times, it was the worst of times …
 
 ## Here we are!
 
@@ -1036,19 +1036,19 @@ inside a `<code>` HTML element with monospace font and highlighted with a
 different background color.
 
 Using `` ` `` is useful when you want to designated only part of a line as code.
-Since this page is written in Udon, we've been using this operation
+Since this page is written in Udon, we’ve been using this operation
 throughout this guide to `format text` to distinguish code from prose.
 
 **Example:**
 ```
-`*[a 2 b c] -> *[*[a b] *[a c]]` is like lisp's `apply`.
+`*[a 2 b c] -> *[*[a b] *[a c]]` is like lisp’s `apply`.
 ```
 **Produces:**
 
-`*[a 2 b c] -> *[*[a b] *[a c]]` is like lisp's `apply`.
+`*[a 2 b c] -> *[*[a b] *[a c]]` is like lisp’s `apply`.
 
 Also, using the `++` prefix before a word will cause the word to be rendered as
-code with the `++` displayed, since that's the standard notation for an arm in
+code with the `++` displayed, since that’s the standard notation for an arm in
 Hoon.
 
 **Example:**
@@ -1201,7 +1201,7 @@ indent the text in question with **eight spaces**.
 
 ## Sail Expressions
 
-It's possible to use Udon as an HTML templating language akin to
+It’s possible to use Udon as an HTML templating language akin to
 PHP, ERB, JSP, or Handlebars templates. This facility derives
 in part from the support for embedding Hoon code inside the markup.
 
@@ -1217,7 +1217,7 @@ Example:
 ```
 ;=
   ;p
-    ;strong: Don't panic!
+    ;strong: Don’t panic!
     ;br;
     ;small: [reactive publishing intensifies]
   ==
@@ -1228,7 +1228,7 @@ Produces:
 
 
 <p>
-    <strong>Don't panic!</strong>
+    <strong>Don’t panic!</strong>
     <br>
     <small>[reactive publishing intensifies]</small>
 </p>

--- a/tutorials/sail-and-udon.md
+++ b/tutorials/sail-and-udon.md
@@ -25,7 +25,7 @@ Before starting with either Sail or Udon, make sure that your ship is
 [mounted to Unix](@/using/install.md).
 
 To host that output, your ship also has a web-server that can be found at
-`localhost` (default port 80) if it’s your first ship that’s running on the
+`http://localhost/` (default port 80) if it’s your first ship that’s running on the
 machine, `http://localhost:8081/` if it’s the second ship on that same machine,
 and so on. In the startup messages, a ship will tell you which HTTP port it’s
 using.
@@ -44,14 +44,14 @@ Dojo:
 
 This command has three arguments:
 - The first is the URL we want to bind our site to. We chose `/test`, so the URL
-we will find our site at is `localhost/test`.
+we will find our site at is `http://localhost/test`.
 - The second is the desk we want to serve. We will be serving from `%home` in
 this tutorial.
 - The third is the file that we want to serve. In this tutorial, we will be
 using `/gen/frontpage/hoon`, which refers to `frontpage.hoon`.
 
 Run the command `|serve /test %home /gen/frontpage/hoon`. Now navigate to
-`localhost/test` (or `localhost:8081/test` if your ship is on that port) in your
+`http://localhost/test` (or `http://localhost:8081/test` if your ship is on that port) in your
 browser, and you should see the rendered Sail.
 
 **Note:** Important to remember that every time you edit a file in your ship’s
@@ -99,7 +99,7 @@ It’s easy to see how Sail can directly translate to HTML:
 You can test above Sail code by placing it
 under `^-  manx` in your `frontpage.hoon` file, and then running `|commit %home`
 in the Dojo. If you’ve already run the `|serve` command code from the first
-section, the new content should appear at `localhost/test`.
+section, the new content should appear at `http://localhost/test`.
 
 It shouldn’t be hard to see the similarities between Sail and HTML. So let’s go
 into more detail about what the differences are.
@@ -688,7 +688,7 @@ will use the `frontpage.hoon` method that we are already familiar with.
 To test out Udon, put a `;>` under the `^-  manx` in your `frontpage.hoon` file,
 and then put all your Udon code under that `;>`. Then run `|commit %home`
 in the Dojo. If you’ve already run the `|serve` command code from the first
-section, the new content should appear at `localhost/test`.
+section, the new content should appear at `http://localhost/test`.
 
 ## Udon Syntax
 

--- a/tutorials/sail-and-udon.md
+++ b/tutorials/sail-and-udon.md
@@ -48,7 +48,7 @@ we will find our site at is `http://localhost/test`.
 - The second is the desk we want to serve. We will be serving from `%home` in
 this tutorial.
 - The third is the file that we want to serve. In this tutorial, we will be
-using `/gen/frontpage/hoon`, which refers to `frontpage.hoon`.
+using `/gen/frontpage/hoon`, which refers to `/gen/frontpage.hoon`.
 
 Run the command `|serve /test %home /gen/frontpage/hoon`. Now navigate to
 `http://localhost/test` (or `http://localhost:8081/test` if your ship is on that port) in your
@@ -147,7 +147,7 @@ with `==`, because they expect a list of sub-tags. If we nest a line of plain
 text with no tag, a `<p>` is prepended.
 
 Sail, like Hoon, is white-space sensitive. Unlike in Hoon, however, two spaces
-(called a “gap”) is not necessarily equivalent to a line-break in Sail.
+(called a `gap`) is not necessarily equivalent to a line-break in Sail.
 
 ```
 ;body
@@ -160,11 +160,10 @@ Equals:
 
 ```
 <body>
-    <h1>Blog title</h1>
-    <p>This is some good content.</p>
+  <h1>Blog title</h1>
+  <p>This is some good content.</p>
 </body>
 ```
-
 
 Conversely, if we want to write a string with no tag at all, then we can prepend
 those untagged lines with `;`.
@@ -187,7 +186,6 @@ Equals:
 </body>
 ```
 
-
 #### Attributes
 
 Attributes are key-value pairs that go into an HTML node.
@@ -198,14 +196,13 @@ the same node by using `,`.
 
 Attributes can be used in two forms: flat, which uses one line; and tall, which
 uses multiple lines, when a single line would not be practical. Flat forms and
-flat forms are two syntaxes of semantically equivalent expressions.
-
+tall forms are two syntaxes of semantically equivalent expressions.
 
 #### Generic
 
 The code below produces a “Submit” button on the page.
 
-Wide-form Sail:
+Flat-form Sail:
 
 ```
 ;input(type "submit", value "Submit");
@@ -223,7 +220,7 @@ Tall-form Sail:
 Equals:
 
 ```
-<input type="submit" value="Submit">`
+<input type="submit" value="Submit">
 ```
 
 #### IDs
@@ -242,27 +239,34 @@ Add `#` after tag name to add an ID.
 
 #### Classes
 
-`;h1.text-blue: Title` equals `<h1 class="text-blue">Title</h1>`
+`;h1.text-blue: Title`
 
-Add `.` after tag name to add a class. However, if you want a class name that
+Equals:
+
+`<h1 class="text-blue">Title</h1>`
+
+Add `.` after tag name to add a class. However, if you want a class list that
 contains a space, you will need to use use the syntax of a generic attribute:
 
-`;div(class "logo inverse");` equals `<div class="logo inverse"></div>`
+`;div(class "logo inverse");`
 
+Equals:
+
+`<div class="logo inverse"></div>`
 
 #### Image
 
 `;img@"example.png";`
 
-Equals
+Equals:
 
-`<img src="example.png"/>`
+`<img src="example.png" />`
 
 Add `@` after the tag name to link your source.
 
 To add attributes to the image, like size specifications, add the
-desired attribute after the `"` of the image name and before the final `;` of
-the `img` tag.
+desired attribute after the closing `"` of the image name and before the final
+`;` of the `img` tag.
 
 For example:
 
@@ -272,11 +276,19 @@ For example:
 
 `;a/"urbit.org": A link to Urbit.org`
 
-Equals
+Equals:
 
 `<a href="urbit.org">A link to Urbit.org</a>`
 
 Add `/` after tag name to start an href.
+
+To add attributes to the link, like target specifications, add the
+desired attribute after the closing `"` of the link url and before the `:` of
+the `img` tag.
+
+For example:
+
+`;a/"urbit.org"(target "_blank"): A link to Urbit.org`
 
 ### Hoon in Sail
 
@@ -424,9 +436,9 @@ piece.
 /=  gas  /$  fuel:html
 ```
 
-Later in this code we want produce the name of the ship is hosting it, something
-that looks like ~lodleb-ritrul. In a generator, we could produce our ship name
-by writing `our` -- try it in the Dojo. But remember that Sail is rendered
+Later in this code we want to produce the name of the ship which is hosting it,
+something that looks like ~lodleb-ritrul. In a generator, we could produce our ship
+name by writing `our` -- try it in the Dojo. But remember that Sail is rendered
 against its own subject, `our` is not part of the default subject. To augment
 our subject with the information that we need, we use  `/=  gas  /$  fuel:html`.
 
@@ -532,7 +544,7 @@ attributes, it continues the line without formatting. Following `;span:` with
 **two** spaces causes there to be single space following the produced `<span>`
 element, because one of those spaces is syntactically necessary.
 
-In the following lines, we beginning to use some Hoon expressions again.
+In the following lines, we begin to use some Hoon expressions again.
 
 ```
   ;+  ?:  show-list
@@ -542,7 +554,7 @@ In the following lines, we beginning to use some Hoon expressions again.
 In the top line in the chunk above, we use the `;+` Sail rune, which
 resolves an expression to a single node. That expression, in this case, is
 `?:`, which tests the truth value of `show-list`, which we assigned the value
-`&` (meaning “true”) at the beginning of the program. It’s closed by the `==` on
+`&` (meaning `true`) at the beginning of the program. It’s closed by the `==` on
 the last line.
 
 Thus, this program resolves to the first child of `show-list`, the node `;ol`.
@@ -567,7 +579,6 @@ The line above is interpolated with Hoon code that produces the sum of 50 plus
 50, which is wrapped in `<>` to put the product in double quotes to make it a
 tape, like the rest of the line.
 
-
 ```
             ;li: The code above is shorthand for {(scow %ud (add 50 50))}.
 ```
@@ -576,7 +587,6 @@ The `{(scow %ud (add 50 50)}` on this line is just a different way
 writing the `{<(add 50 50)>}` expression. `scow` is a Hoon function that turns a
 noun into a `tape`, Hoon’s string type. `%ud` tells `scow` that its argument
 should be displayed in the form of an unsigned decimal.
-
 
 ```
             ;li: I am {(trip '~lodleb-ritrul')}.
@@ -594,10 +604,10 @@ tape that we are trying to insert it into without getting a type error.
 ```
 
 The line above has interpolated code that uses a wing expression to access the
-name of the host ship, and then accesses the face `what-kind` contains a string
-describing what type of ship it is. We declared `gas` on the very first line so
-that we could add that sort of information to the subject that our Sail is
-rendered against. The wing expression `p.bem.gas` looks for `p` within `bem`
+name of the host ship, and then accesses the face `what-kind` that contains a
+string describing what type of ship it is. We declared `gas` on the very first
+line so that we could add that sort of information to the subject that our Sail
+is rendered against. The wing expression `p.bem.gas` looks for `p` within `bem`
 within `gas`, which happens to be where the name of the ship is located.
 
 Note that `{what-kind}` does not have a `<>` wrapper. Why do you think this is?
@@ -609,8 +619,8 @@ Note that `{what-kind}` does not have a `<>` wrapper. Why do you think this is?
 ```
 
 The `;div;` node above is only rendered, as an alternative to the above list,
-if `show-list` is evaluated as true. This means it won’t be shown with your
-default code. To show this line, change the `&` on line 2 to `|` (“false”).
+if `show-list` is evaluated as `true`. This means it won’t be shown with your
+default code. To show this line, change the `&` on line 2 to `|` (`false`).
 
 ### Sail Runes
 
@@ -626,7 +636,6 @@ multiple nodes side-by-side, and not just the children of a single node, this
 is the expression that we use.
 
 `;=` turns a tuple of nodes into a list of nodes.
-
 
 To see how these runes work, let’s take a chunk of our previous code starting at
 line 20 and modify it a bit:
@@ -661,9 +670,9 @@ You should now have foundational knowledge for making web pages with Sail. There
 is, of course, more to learn.
 
 The [Ford manual](https://urbit.org/docs/arvo/internals/ford/runes/)
-can show you how to access various ship resources for user in your pages. To
+can show you how to access various ship resources for use in your pages. To
 learn more about how the renderer works, take a look at the
-`/home/ren/urb.hoon` file inside your urbit.
+`/home/ren/urb.hoon` file inside your pier.
 
 ## Udon: A Guide {#udon}
 
@@ -705,7 +714,7 @@ As an example, let’s look at the front matter of this very page:
 
 ```
 :-  :~  navhome/'/docs/'
-        sort/'11'
+        sort/'28'
         title/'Udon'
     ==
 ;>
@@ -719,13 +728,13 @@ for Udon.
 
 `:~` creates a list out of the three elements: `navhome/'/docs/'`, which
 indicates that navigating “home” will bring you to the urbit.org/docs section
-of the website; `sort/'28',` which assigns it the 28th position of the
+of the website; `sort/'28'`, which assigns it the 28th position of the
 immediate section that contains it, the one you see in the sidebar;
 and `title/'Udon'`, which gives the page its title. The `==` digraph
 terminates the list.
 
 `;>` is a Sail rune that creates a node that contains everything that follows
-it, telling the parser that that text should be interpreted as Udon.
+it, telling the parser that this text should be interpreted as Udon.
 It’s not technically front matter, but you’ll always find it following the
 front matter, since all Udon must come after this rune.
 
@@ -749,16 +758,18 @@ parsing.
 
 Headers in Udon begin the line with one or more `#` characters,
 followed by a single space. After that space comes the actual text to be
-displayed. The number of leading `#`s corresponds to the resulting HTML
+displayed. The number of leading `#` characters corresponds to the resulting HTML
 header-size element: `#` yields an `<h1>`, `##` yields an `<h2>`, and so on,
 through `<h6>`. The header for this section is `### Headers`.
 
 **Example:**
+
 ```
 #### Header (h4)
 
 ##### Header (h5)
 ```
+
 **Produces:**
 
 #### Header (h4)
@@ -772,7 +783,6 @@ element.
 
 Enclosing text with `*` will cause that text to appear bolded, using a `<b>`
 element.
-
 
 **Example:**
 
@@ -800,8 +810,8 @@ This second line is separated by two newlines, so it’s a separate paragraph.
 This line looks like a distinct paragraph, but …
 It’s only separated by a single newline, so it’s included in the same paragraph.
 ```
-**Produces:**
 
+**Produces:**
 
 Here’s the first line.
 
@@ -813,15 +823,17 @@ It’s only separated by a single newline, so it’s included in the same paragr
 #### Backslash Line Break
 
 A backslash at the end of a line inserts a line break (`<br>`)
-after that line. This contrasts with the normal udon behavior of
+after that line. This contrasts with the normal Udon behavior of
 converting newlines to spaces.
 
 **Example:**
+
 ```
 I wonder how long each line
 will be if I put backslashes\
 at the ends of the lines.
 ```
+
 **Produces:**
 
 I wonder how long each line
@@ -837,14 +849,13 @@ as an escape character, causing it to be rendered raw.
 
 ```
 Here is some *bold* text.
-Here is some \*not bold* text.
+Here is some \*not bold\* text.
 ```
 
 **Produces:**
 
 Here is some **bold** text.
-Here is some \*not bold* text.
-
+Here is some \*not bold\* text.
 
 ### List
 
@@ -859,7 +870,7 @@ a number corresponding to its position in that list.
 New list elements are delineated by newlines beginning with list symbols of
 the appropriate type (`-` or `+`).
 
-Just as with non-list text, text on a bare newline will appear on line before,
+Just as with non-list text, text on a bare newline will appear on the line before,
 separated by a space. A `\\` is used to create a line-break that isn’t the list
 itself and isn’t a list. Both of these kinds of newlines must be indented by two
 spaces, or else the page will not parse.
@@ -870,7 +881,7 @@ directly after either kind of aforementioned newline that isn’t a list element
 only lines that are themselves list elements can nest sub-lists.
 
 A newline after a blank line is interpreted as a new paragraph in normal text.
-Between to list elements, however, a blank line is semantically equivalent to
+Between two list elements, however, a blank line is semantically equivalent to
 a bare newline. To separate two lists with blank space, create a blank line
 followed by a `\\` on its own line.
 
@@ -954,7 +965,7 @@ destination.
 
 The second type is a reference-style link, which uses a relative path, based on
 the current page’s location. Instead of the full url, we use `..` to fill in
-the all of the URL that the destination has in common with the origin page.
+all of the URL that the destination has in common with the origin page.
 
 **Example:**
 
@@ -978,6 +989,8 @@ The destination for the anchor link is designated with the HTML element `id`,
 so we need to use some [Sail](#sail). If there are two or more anchors with
 the same `id` on the page, you will arrive at the earliest instance of the the
 anchor.
+
+Note that each HTML element `id` should be unique and not be used more than once.
 
 **Example:**
 
@@ -1015,7 +1028,6 @@ opening and closing quotes -- that is, `“` and `”`.
 
 “Yes,” he said. “That is the way with him.”
 
-
 ### Code Literal
 
 There are two ways to show the literal text of code without running it: inline
@@ -1035,14 +1047,16 @@ Enclosing some text in `` ` `` characters will cause it to be displayed as code,
 inside a `<code>` HTML element with monospace font and highlighted with a
 different background color.
 
-Using `` ` `` is useful when you want to designated only part of a line as code.
+Using `` ` `` is useful when you want to designate only part of a line as code.
 Since this page is written in Udon, we’ve been using this operation
-throughout this guide to `format text` to distinguish code from prose.
+throughout this guide to _format text_ to distinguish `code` from prose.
 
 **Example:**
+
 ```
 `*[a 2 b c] -> *[*[a b] *[a c]]` is like lisp’s `apply`.
 ```
+
 **Produces:**
 
 `*[a 2 b c] -> *[*[a b] *[a c]]` is like lisp’s `apply`.
@@ -1070,7 +1084,6 @@ Most of our examples so far have used.
 
 **Example:**
 
-
     ```
     (def Y (fn [f]
            ((fn [x]
@@ -1094,7 +1107,7 @@ Most of our examples so far have used.
 ### Hoon Constants
 
 Hoon has several syntactic forms for literals (numbers, strings, dates, etc.)
-that can be used in udon as well. Udon detects such code, and so these
+that can be used in Udon as well. Udon detects such code, and so these
 forms will automatically appear inside a `<code>` element like inline code.
 
 Example:
@@ -1105,17 +1118,16 @@ Example:
 %term
 ```
 
-produces:\
+Produces:\
 
 `~2017.8.29` \
 `0xdead.beef` \
 `%term`
 
-
 ### Horizontal Rule
 
 Three or more hyphens, such as `---`, on their own line produce an `<hr>`
-element, the 'horizontal rule'. This is rendered as a horizontal line the
+element, the “horizontal rule”. This is rendered as a horizontal line the
 width of its containing paragraph.
 
 **Example:**
@@ -1130,7 +1142,6 @@ And below this line, too
 
 **Produces:**
 
-
 Above the line
 
 ---
@@ -1144,7 +1155,7 @@ And below this line, too
 ### Block Quote
 
 A section of text with the first line beginning with `>` and a space,
-and each successive newline indented by two spaces yields a
+and each successive newline indented by two spaces, yields a
 `<blockquote>` HTML element. This block quote can itself contain more Udon,
 including more block quotes to render nested levels of quotation.
 
@@ -1175,7 +1186,6 @@ Quote break.
 
 > He is pale and thin, he wears a thin and ragged linen shirt.
 
-
 ### Poem
 
 A poem is a section of text with meaningful newlines.  Recall that,
@@ -1191,6 +1201,7 @@ indent the text in question with **eight spaces**.
         Is moving its slow thighs, while all about it
         Reel shadows of the indignant desert birds.
 ```
+
 **Produces:**
 
         A shape with lion body and the head of a man,
@@ -1198,13 +1209,11 @@ indent the text in question with **eight spaces**.
         Is moving its slow thighs, while all about it
         Reel shadows of the indignant desert birds.
 
-
 ## Sail Expressions
 
 It’s possible to use Udon as an HTML templating language akin to
 PHP, ERB, JSP, or Handlebars templates. This facility derives
 in part from the support for embedding Hoon code inside the markup.
-
 
 Sail is a domain-specific language within Hoon for creating XML nodes,
 including HTML. It can be used directly within Udon to provide
@@ -1226,9 +1235,8 @@ Example:
 
 Produces:
 
-
 <p>
-    <strong>Don’t panic!</strong>
-    <br>
-    <small>[reactive publishing intensifies]</small>
+  <strong>Don’t panic!</strong>
+  <br />
+  <small>[reactive publishing intensifies]</small>
 </p>

--- a/tutorials/sail-and-udon.md
+++ b/tutorials/sail-and-udon.md
@@ -191,7 +191,7 @@ Equals:
 Attributes are key-value pairs that go into an HTML node.
 
 Adding attributes is simple: just add the desired attribute between parentheses,
-right after the tag name without a space.  We separate different attributes of
+right after the tag name without a space. We separate different attributes of
 the same node by using `,`.
 
 Attributes can be used in two forms: flat, which uses one line; and tall, which
@@ -332,7 +332,7 @@ interpolate with something that results in an atom. Try this now:
 ```
 
 We get a similar result, but we know that it’s a tape because it’s wrapped in
-`""`. Bingo!  With this knowledge, let’s perform a successful interpolation:
+`""`. Bingo! With this knowledge, let’s perform a successful interpolation:
 
 ```
 > "I am a l{<(mul 3 11)>}t Urbit user."
@@ -517,7 +517,7 @@ perform less-than tests to see what kind of ship is running the web-server.
 Sail proper begins here. These four lines are four nodes. The `;html` node
 indicates that the contained code should be rendered as HTML; this tag is closed
 on the final line. The `;head` node contains metadata, and is closed three lines
-later.  The `;meta` node sets the character set to UTF-8, and the `;title` node
+later. The `;meta` node sets the character set to UTF-8, and the `;title` node
 sets the title of the page that shows up in the browser tab.
 
 ```
@@ -1188,7 +1188,7 @@ Quote break.
 
 ### Poem
 
-A poem is a section of text with meaningful newlines.  Recall that,
+A poem is a section of text with meaningful newlines. Recall that,
 normally in Udon, newlines are treated as spaces and do not create a
 new line of text. If you want to embed text where newlines are retained, then
 indent the text in question with **eight spaces**.

--- a/tutorials/ship-troubleshooting.md
+++ b/tutorials/ship-troubleshooting.md
@@ -5,7 +5,7 @@ template = "doc.html"
 aliases = ["docs/using/ship-troubleshooting/"]
 +++
 
-Urbit is still in the development stage, so there's a chance that your ship won't start properly, or will stop working properly when you're running it. That's ok! This document is intended to help you in such an event.
+Urbit is still in the development stage, so there’s a chance that your ship won’t start properly, or will stop working properly when you’re running it. That’s ok! This document is intended to help you in such an event.
 
 ## Table of Contents
 
@@ -17,7 +17,7 @@ Urbit is still in the development stage, so there's a chance that your ship won'
 
 ## Best Practices {#best-practices}
 
-An ounce of prevention is worth a pound of cure, so let's first go over some best practices to keep your ship in working order.
+An ounce of prevention is worth a pound of cure, so let’s first go over some best practices to keep your ship in working order.
 
 ### Only boot with your keyfile once
 
@@ -27,22 +27,22 @@ If you accidentally booted with the same keyfile twice, the only remedy is perfo
 
 ### Do not delete your pier
 
-Urbit is stateful, meaning that it needs to hold onto all your data. If you delete your pier and start your ship again, you won't be able to talk to any ship you've talked to before. The only solution to this is performing a [personal breach](#personal-breach)
+Urbit is stateful, meaning that it needs to hold onto all your data. If you delete your pier and start your ship again, you won’t be able to talk to any ship you’ve talked to before. The only solution to this is performing a [personal breach](#personal-breach)
 
 ### Keep track of the directory that you put your ship in
 
-When you first start your ship, you should make sure you put it a place where you can find it again and where it won't get accidentally deleted. Remember that you must perform `|mount %` in your ship's Dojo to make your ship visible as a directory in the Unix file system.
+When you first start your ship, you should make sure you put it a place where you can find it again and where it won’t get accidentally deleted. Remember that you must perform `|mount %` in your ship’s Dojo to make your ship visible as a directory in the Unix file system.
 
 ### Avoid killing the Urbit process directly
 The best way to end an urbit process is to use `ctrl-d` from the Dojo. Unix methods to kill the process, such as with `ctrl-z` or with the `kill` Bash command, or simply closing the window, should only be used if `ctrl-d` does not work.
 
 ### Keep up-to-date builds
 
-Check for latest Urbit version at https://github.com/urbit/urbit/releases. If you're behind, update using [this guide](@using/install.md).
+Check for latest Urbit version at https://github.com/urbit/urbit/releases. If you’re behind, update using [this guide](@using/install.md).
 
-### `|hi` your star to see if you're connected
+### `|hi` your star to see if you’re connected
 
-Find out who your star is by running `(sein:title our now our)` in the Dojo. Then, run `|hi ~star`, where `~star` is the star's name, and if things are working properly, you should get the message `hi ~star successful`. It could also be helpful to use `|hi` to check connectivity with `~zod` or another planet that you're in a Talk channel with.
+Find out who your star is by running `(sein:title our now our)` in the Dojo. Then, run `|hi ~star`, where `~star` is the star’s name, and if things are working properly, you should get the message `hi ~star successful`. It could also be helpful to use `|hi` to check connectivity with `~zod` or another planet that you’re in a Talk channel with.
 
 ### Turn your ship off and on again
 
@@ -50,11 +50,11 @@ Use `ctrl-d` to gracefully exit your ship, and then start it again. This can sol
 
 ### Use the `|knob` command to customize your error messages
 
-Error messages can be by overwhelming, so the `|knob` command is intended to remedy this. It's used to silence errors that aren't important.
+Error messages can be by overwhelming, so the `|knob` command is intended to remedy this. It’s used to silence errors that aren’t important.
 
 The command takes two arguments, and comes in the form of `|knob %error-tag %level`.
 
-`%error-tag` is the name of the error in question. It's usually printed at the top of the stack trace, such as in `crud: %hole event failed` -- `%hole` here is an example of an error tag.
+`%error-tag` is the name of the error in question. It’s usually printed at the top of the stack trace, such as in `crud: %hole event failed` -- `%hole` here is an example of an error tag.
 
 `%level` determines how much you will see of errors with your chosen `%error-tag`. There are three levels:
 
@@ -78,21 +78,21 @@ Run `|wash-gall`. This clears caches in Gall, and may result in steep performanc
 
 ### My urbit is frozen
 
-Sometimes this happens if you're processing a very large event, or if you're in an infinite loop, or for a variety of other reasons.
+Sometimes this happens if you’re processing a very large event, or if you’re in an infinite loop, or for a variety of other reasons.
 
-Before doing anything, try waiting for a minute: an event might finish processing. If it doesn't clear up, then use Unix kill-command, `ctrl-z`, to end your ship's process. Then restart your ship.
+Before doing anything, try waiting for a minute: an event might finish processing. If it doesn’t clear up, then use Unix kill-command, `ctrl-z`, to end your ship’s process. Then restart your ship.
 
 ### When I try to type into the Dojo, it prints `dy-noprompt`
 
 This happens when your Dojo is waiting on a request, such as an HTTP request. You can fix it simply by typing `backspace` or (`delete` on Mac).
 
-### My ship doesn't recognize file changes that I make in my pier
+### My ship doesn’t recognize file changes that I make in my pier
 
-Since version `0.8.0`, changes no longer automatically sync between the Unix side (your pier) and your ship. To sync your file changes, you must run `|commit %desk` in your Dojo, where `%desk` is the desk you'd like to sync.
+Since version `0.8.0`, changes no longer automatically sync between the Unix side (your pier) and your ship. To sync your file changes, you must run `|commit %desk` in your Dojo, where `%desk` is the desk you’d like to sync.
 
 ## Connectivity Issues {#connectivity-issues}
 
-### I can't communicate with anyone
+### I can’t communicate with anyone
 
 You may have booted a ship with your keyfile twice in the same era. To fix this, you must perform a [personal breach](#personal-breach).
 
@@ -100,15 +100,15 @@ You may have booted a ship with your keyfile twice in the same era. To fix this,
 
 You may see a message like this one: `/~zod/home/~2019.7.22..18.55.46..83a3/sys/vane/ames:<[line column].[line column]>`. This is a clay path to a Hoon file, pointing to the line and column where an expression crashed. This kind of error might be accompanied by a `crud` message.
 
-This means that another ship is sending invalid packets to you. This could be because one of the ships has not updated the other ship's "life number," which is the number that starts at one and increments every time that ship performs a personal breach.
+This means that another ship is sending invalid packets to you. This could be because one of the ships has not updated the other ship’s “life number,” which is the number that starts at one and increments every time that ship performs a personal breach.
 
-This can happen if they have the wrong keys of yours, or if you have the wrong keys of theirs. You can figure out who has the wrong keys by running this scry command in your dojo: `.^(* %j /=life=/shipname)`, where shipname is the other ship's name. Save that information. Then, go to the [Azimuth contract on Etherscan](https://etherscan.io/address/0x223c067f8cf28ae173ee5cafea60ca44c335fecb#readContract), scroll down to `32. points`, and put in the hexadecimal representation of the other ship's `@p`. You can find the hexadecimal representation by running...
+This can happen if they have the wrong keys of yours, or if you have the wrong keys of theirs. You can figure out who has the wrong keys by running this scry command in your dojo: `.^(* %j /=life=/shipname)`, where shipname is the other ship’s name. Save that information. Then, go to the [Azimuth contract on Etherscan](https://etherscan.io/address/0x223c067f8cf28ae173ee5cafea60ca44c335fecb#readContract), scroll down to `32. points`, and put in the hexadecimal representation of the other ship’s `@p`. You can find the hexadecimal representation by running...
 
 ```
 `@ux`~sampel-palnet
 ```
 
-in the Dojo, where `~sampel-palnet` is the other ship's name. Then, compare it to the scry information that you saved. If that information matches up, it means that the other ship is the problem. If it **doesn't** match up, your ship has wrong information about the other ship. If you have such wrong information, you can fix this by running:
+in the Dojo, where `~sampel-palnet` is the other ship’s name. Then, compare it to the scry information that you saved. If that information matches up, it means that the other ship is the problem. If it **doesn’t** match up, your ship has wrong information about the other ship. If you have such wrong information, you can fix this by running:
 
 ```
 :azimuth-tracker|listen ~ %app %azimuth-tracker
@@ -124,13 +124,13 @@ The last line above syncs from an Ethereum node for _all_ ships on the network. 
 
 The above commands work if you have the wrong keys of other ships. If other ships have wrong keys of _yours_, you need to somehow ask them to to run such a command.
 
-### I can talk to some ships, but I can't talk to my sponsor and some other ships
+### I can talk to some ships, but I can’t talk to my sponsor and some other ships
 
 This is the result of deleting your pier and starting your ship again. To fix this, you must perform a [personal breach](#personal-breach).
 
 ## Booting Issues {#booting-issues}
 
-### My ship won't boot and gets a `terminals database is inaccessible` message
+### My ship won’t boot and gets a `terminals database is inaccessible` message
 
 This happens when you try to run the Urbit binary through your `$PATH`. When running the command, you need to be explicit and specify the actual path to it in the filesystem. This is a side-effect of the way we build the release binaries, which will be fixed.
 
@@ -138,7 +138,7 @@ This happens when you try to run the Urbit binary through your `$PATH`. When run
 
 You may have used the wrong arguments when booting your ship for the first time. Delete this comet and try again.
 
-### My development ship ("fakezod") gets a `boot: malformed` failure
+### My development ship (“fakezod”) gets a `boot: malformed` failure
 
 This means that you gave your development ship an invalid `@p`. So, you will get this error if you write, for example, `urbit -F zodzod` instead of `urbit -F zod`.
 
@@ -154,9 +154,9 @@ However, if you get a `bail` error again, you should perform a personal breach.
 
 You can get help with you problem by creating an issue at github.com/urbit/urbit. But to make a good issue, you need to include some information.
 
-When your urbit crashes with a `bail`, you'll probably get a core dump, which is a file that contains the program state of your urbit when it crashed. On Mac, core dumps can be found in `/cores`. On Linux, cores can often be found in `/var/crash`, or the home directory.
+When your urbit crashes with a `bail`, you’ll probably get a core dump, which is a file that contains the program state of your urbit when it crashed. On Mac, core dumps can be found in `/cores`. On Linux, cores can often be found in `/var/crash`, or the home directory.
 
-Navigate to the folder containing your core dumps. Find the most recent core dump by looking at the dates after you run `ls -l`. Then `lldb -c <corename>`. Once that loads, you'll be at an `(lldb)` prompt; type `bt` at this prompt. This will create a stack trace that looks like this:
+Navigate to the folder containing your core dumps. Find the most recent core dump by looking at the dates after you run `ls -l`. Then `lldb -c <corename>`. Once that loads, you’ll be at an `(lldb)` prompt; type `bt` at this prompt. This will create a stack trace that looks like this:
 
 ```
 (lldb) bt
@@ -175,7 +175,7 @@ Copy this stack trace and include it in your GitHub issue.
 
 1. Make sure you are running version to `0.8.2` if you are not already on it.
 
-2. Restart your ship. If you don't crash again, everything may be fine. If you **do** crash again, then you should perform a [personal breach](#personal-breach).
+2. Restart your ship. If you don’t crash again, everything may be fine. If you **do** crash again, then you should perform a [personal breach](#personal-breach).
 
 ### My ship crashed with a `bail: oops` error
 

--- a/tutorials/ship-troubleshooting.md
+++ b/tutorials/ship-troubleshooting.md
@@ -33,7 +33,8 @@ Urbit is stateful, meaning that it needs to hold onto all your data. If you dele
 
 When you first start your ship, you should make sure you put it a place where you can find it again and where it won’t get accidentally deleted. Remember that you must perform `|mount %` in your ship’s Dojo to make your ship visible as a directory in the Unix file system.
 
-### Avoid killing the Urbit process directly
+### Avoid killing the urbit process directly
+
 The best way to end an urbit process is to use `ctrl-d` from the Dojo. Unix methods to kill the process, such as with `ctrl-z` or with the `kill` Bash command, or simply closing the window, should only be used if `ctrl-d` does not work.
 
 ### Keep up-to-date builds
@@ -42,7 +43,7 @@ Check for latest Urbit version at https://github.com/urbit/urbit/releases. If yo
 
 ### `|hi` your star to see if you’re connected
 
-Find out who your star is by running `(sein:title our now our)` in the Dojo. Then, run `|hi ~star`, where `~star` is the star’s name, and if things are working properly, you should get the message `hi ~star successful`. It could also be helpful to use `|hi` to check connectivity with `~zod` or another planet that you’re in a Talk channel with.
+Find out who your star is by running `(sein:title our now our)` in the Dojo. Then, run `|hi ~star`, where `~star` is the star’s name, and if things are working properly, you should get the message `hi ~star successful`. It could also be helpful to use `|hi` to check connectivity with `~zod` or another planet that you’re in a Chat channel with.
 
 ### Turn your ship off and on again
 
@@ -66,9 +67,9 @@ So for example, to silence all Ames packet-related errors, try `|knob %hole %hus
 
 ### Perform a personal breach. {#personal-breach}
 
-A personal breach is when a ship tells all the other ships that have communicated with it to treat it as though the ship was just started for the first time again, since everyone has network has forgotten about it.
+A personal breach is when a ship tells all the other ships that have communicated with it to treat it as though the ship was just started for the first time again, since everyone on the network has forgotten about it.
 
-Personal breaches often fix connectivity issues, but should only be used as a last resort. To find out how to perform a personal breach, check out our [Guide to Breaches](../guide-to-breaches). Before taking such a drastic measure, try other methods in this guide. You can also ask for help on `~dopzod/urbit-help`, or, failing that, in the #ship-starting-support channel in our [Discord server](https://discord.gg/n9xhMdz).
+Personal breaches often fix connectivity issues, but should only be used as a last resort. To find out how to perform a personal breach, check out our [Guide to Breaches](../guide-to-breaches). Before taking such a drastic measure, try other methods in this guide. You can also ask for help on `~dopzod/urbit-help`, or, failing that, in the `#ship-starting-support` channel in our [Discord server](https://discord.gg/n9xhMdz).
 
 ## Operation Issues {#operation-issues}
 
@@ -80,7 +81,7 @@ Run `|wash-gall`. This clears caches in Gall, and may result in steep performanc
 
 Sometimes this happens if you’re processing a very large event, or if you’re in an infinite loop, or for a variety of other reasons.
 
-Before doing anything, try waiting for a minute: an event might finish processing. If it doesn’t clear up, then use Unix kill-command, `ctrl-z`, to end your ship’s process. Then restart your ship.
+Before doing anything, try waiting for a minute: an event might finish processing. If it doesn’t clear up, then use the Unix kill-command, `ctrl-z`, to end your ship’s process. Then restart your ship.
 
 ### When I try to type into the Dojo, it prints `dy-noprompt`
 
@@ -102,13 +103,13 @@ You may see a message like this one: `/~zod/home/~2019.7.22..18.55.46..83a3/sys/
 
 This means that another ship is sending invalid packets to you. This could be because one of the ships has not updated the other ship’s “life number,” which is the number that starts at one and increments every time that ship performs a personal breach.
 
-This can happen if they have the wrong keys of yours, or if you have the wrong keys of theirs. You can figure out who has the wrong keys by running this scry command in your dojo: `.^(* %j /=life=/shipname)`, where shipname is the other ship’s name. Save that information. Then, go to the [Azimuth contract on Etherscan](https://etherscan.io/address/0x223c067f8cf28ae173ee5cafea60ca44c335fecb#readContract), scroll down to `32. points`, and put in the hexadecimal representation of the other ship’s `@p`. You can find the hexadecimal representation by running...
+This can happen if they have the wrong keys of yours, or if you have the wrong keys of theirs. You can figure out who has the wrong keys by running this scry command in your dojo: `.^(* %j /=life=/shipname)`, where shipname is the other ship’s name. Save that information. Then, go to the [Azimuth contract on Etherscan](https://etherscan.io/address/0x223c067f8cf28ae173ee5cafea60ca44c335fecb#readContract), scroll down to `32. points`, and put in the hexadecimal representation of the other ship’s `@p`. You can find the hexadecimal representation by running …
 
 ```
 `@ux`~sampel-palnet
 ```
 
-in the Dojo, where `~sampel-palnet` is the other ship’s name. Then, compare it to the scry information that you saved. If that information matches up, it means that the other ship is the problem. If it **doesn’t** match up, your ship has wrong information about the other ship. If you have such wrong information, you can fix this by running:
+… in the Dojo, where `~sampel-palnet` is the other ship’s name. Then, compare it to the scry information that you saved. If that information matches up, it means that the other ship is the problem. If it **doesn’t** match up, your ship has wrong information about the other ship. If you have such wrong information, you can fix this by running:
 
 ```
 :azimuth-tracker|listen ~ %app %azimuth-tracker
@@ -146,13 +147,13 @@ This means that you gave your development ship an invalid `@p`. So, you will get
 
 ### I got a `bail` error and my ship crashed
 
-Try just bringing it back up; it will often start working just fine again.
+Try bringing it back up; it will often start working just fine again.
 
-However, if you get a `bail` error again, you should perform a personal breach.
+However, if you get a `bail` error again, you should perform a [personal breach](#personal-breach).
 
 #### Making a GitHub issue out of your `bail`
 
-You can get help with you problem by creating an issue at github.com/urbit/urbit. But to make a good issue, you need to include some information.
+You can get help with you problem by creating an issue at [github.com/urbit/urbit](https://github.com/urbit/urbit/issues). But to make a good issue, you need to include some information.
 
 When your urbit crashes with a `bail`, you’ll probably get a core dump, which is a file that contains the program state of your urbit when it crashed. On Mac, core dumps can be found in `/cores`. On Linux, cores can often be found in `/var/crash`, or the home directory.
 
@@ -179,7 +180,7 @@ Copy this stack trace and include it in your GitHub issue.
 
 ### My ship crashed with a `bail: oops` error
 
-Restart your ship. These issues often just go away on their own. If this error repeats after restart two or more times, post the messages in an issue at github.com/urbit/urbit/issues.
+Restart your ship. These issues often just go away on their own. If this error repeats after restart two or more times, post the messages in an issue at [github.com/urbit/urbit](https://github.com/urbit/urbit/issues).
 
 This same error might also appear with a message like `Assertion '0'`.
 

--- a/tutorials/ship-troubleshooting.md
+++ b/tutorials/ship-troubleshooting.md
@@ -23,7 +23,7 @@ An ounce of prevention is worth a pound of cure, so let’s first go over some b
 
 Once your ship is booted with your keyfile, you should never use that same keyfile again. If you do boot with the same keyfile twice, any other ship on the network that your ship has communicated with will not be able to talk to your ship.
 
-If you accidentally booted with the same keyfile twice, the only remedy is performing a [personal breach](#personal-breach),  which is explained in the next section.
+If you accidentally booted with the same keyfile twice, the only remedy is performing a [personal breach](#personal-breach), which is explained in the next section.
 
 ### Do not delete your pier
 


### PR DESCRIPTION
This commit fixes some text/typo, typographic, capitalisation, formatting, and indentation related issues in the `Sail and Udon` tutorial.