### PR TITLE
gall intro: correct default-agent usage

### DIFF
--- a/tutorials/arvo/gall.md
+++ b/tutorials/arvo/gall.md
@@ -203,7 +203,7 @@ implemented as:
 =|  state=@
 |_  =bowl:gall
 +*  this      .
-    default   ~(. (default-agent %|) bowl)
+    default   ~(. (default-agent this %|) bowl)
 ::
 ++  on-init   on-init:default
 ++  on-save   on-save:default


### PR DESCRIPTION
Needs you to pass in the outer agent core.

People were copy-pasting this and running it, and it was giving not-straightforward error messages.