### PR TITLE
Dill public api

### DIFF
--- a/reference/vane-apis/dill.md
+++ b/reference/vane-apis/dill.md
@@ -306,7 +306,7 @@ This `task` updates the kernel.
 [p=@t q=@t]
 ```
 
-`p` is related to hoon and `q` is related to Arvo but I don't know how.
+`p` is the contents of the new `hoon.hoon` and `q` is the contents of the new `arvo.hoon`.
 
 #### Returns
 
@@ -340,6 +340,11 @@ This `task` is used to install `zuse` and vanes. It is handled by `+veer` in
 ```hoon
 [p=@ta q=path r=@t]
 ```
+
+`p` is the vane letter, `q` is the formal `path` to the
+vane, and `r` is the source code for the vane. The vane letter is `%` followed
+by the first letter of the vane in lowercase, such as `%d` for Dill. `p=%$` in
+the case of `zuse`.
 
 #### Returns
 

--- a/reference/vane-apis/dill.md
+++ b/reference/vane-apis/dill.md
@@ -123,17 +123,7 @@ and sends the bare `task` to itself over the default `duct`.
 
 ### `%flow`
 
-`%flow` is used to configure the terminal.
- 
-#### Accepts
-
-```hoon
-[p=@tas q=(list gill:gall)]
-```
-
-#### Returns
-
-`%flow` does not return any `gift`s.
+This `task` is not used.
 
 
 ### `%hail`
@@ -172,21 +162,12 @@ return a `%mass` `gift`.
 
 ### `%hook`
 
-This appears in `zuse.hoon` but not in `dill.hoon` -  is it deprecated?
-
-#### Accepts
-
-#### Returns
-
+This task is not used.
 
 
 ### `%harm`
 
-Not sure what this does - see PR.
-
-#### Accepts
-
-#### Returns
+This `task` is not used. 
 
 
 ### `%init`
@@ -275,16 +256,7 @@ This `task` returns no `gift`s.
 
 ### `%talk`
 
-This appears in `zuse.hoon` but not in `dill.hoon`. Is it deprecated?
-
-#### Accepts
-
-```hoon
-[p=tank]
-```
-
-#### Returns
-
+This `task` is not used.
 
 ### `%text`
 

--- a/reference/vane-apis/dill.md
+++ b/reference/vane-apis/dill.md
@@ -1,0 +1,265 @@
++++
+title = "Dill"
+weight = 3
+template = "doc.html"
++++
+
+# Dill
+
+In this document we describe the public interface for Dill. Namely, we describe
+each `task` that Dill can be `pass`ed, and which `gift`(s) Dill can `give` in return.
+
+
+## Tasks
+
+
+### `%belt`
+
+Every keystroke entered into the console triggers a `%belt` `task` for Dill which contains information about the keystroke, such as which key was pressed
+and from which terminal. 
+
+#### Accepts
+
+`%belt` `task`s come in a number of different types, corresponding to different
+keystrokes. You can find this list in `+dill-belt` in `zuse.hoon`.
+
+```hoon
+++  dill-belt                                         ::  new belt
+    $%  {$aro p/?($d $l $r $u)}                         ::  arrow key
+        {$bac ~}                                        ::  true backspace
+        {$cru p/@tas q/(list tank)}                     ::  echo error
+        {$ctl p/@}                                      ::  control-key
+        {$del ~}                                        ::  true delete
+        {$hey ~}                                        ::  refresh
+        {$met p/@}                                      ::  meta-key
+        {$ret ~}                                        ::  return
+        {$rez p/@ud q/@ud}                              ::  resize, cols, rows
+        {$txt p/(list @c)}                              ::  utf32 text
+        {$yow p/gill:gall}                              ::  connect to app
+    ==                                                  ::
+```
+
+#### Returns
+
+Dill returns no `gift` in response to a `%belt` `task`.
+
+
+### `%blew`
+
+This `task` is called whenever the terminal emulator is resized, so that Dill can adjust
+the text output to fit the new window size.
+
+#### Accepts
+
+```hoon
+[p=@ud q=@ud]
+```
+
+`p` is the number of columns and `q` is the number of rows.
+
+#### Returns
+
+Dill returns no `gift` in response to a `%blew` `task`.
+
+
+### `%boot`
+
+This `task` is used only once, when Arvo first enters the [adult
+stage](@/docs/tutorials/arvo/arvo.md#structural-interface-core). Dill is
+technically the first vane to be activated, via the `%boot` `task`, which then
+send Jael (considered the the "true" first vane) an `%init` `task`, which then goes on to
+call `%init` `task`s for other vanes (including Dill). 
+
+#### Accepts
+
+`%boot` takes an argument that is either `%dawn` or `%fake`. `%dawn` is the one
+used in any typical scenario and activates the ordinary vane initialization
+process outlined above, while `%fake` is a debugging tool.
+
+#### Returns
+
+`%boot` does not return a `gift`.
+
+
+
+### `%crud`
+
+This `task` is used by Dill to produce error reports. It prints the received
+error message(s) (a `(list tank)`) to the terminal. The level of detail of the
+error message is set by `$log-level`, which is either `%hush`, `%soft`, or `%loud`.
+
+#### Accepts
+
+```hoon
+[err=@tas tac=(list tank)]
+```
+
+`err` is the type of error and `tac` is the associated error message.
+
+#### Returns
+
+`%crud` does not return a `gift`. 
+
+
+### `%flog`
+
+A `%flog` `task` is a wrapper over a `task` sent by another vane. Dill removes the wrapper
+and sends the bare `task` to itself over the default `duct`.
+
+#### Accepts
+
+`%flog` `task`s can take any valid Dill `task` as an argument.
+
+#### Returns
+
+`%flog` never returns a `gift` on its own, but the wrapped `task` might.
+
+#### Examples
+
+`%crud` `task`s from other vanes are typically passed to Dill wrapped in a
+`%flog` `task` to print errors to the terminal.
+
+
+
+### `%flow`
+ 
+#### Accepts
+
+#### Returns
+
+#### Source
+
+
+### `%hail`
+
+#### Accepts
+
+#### Returns
+
+#### Source
+
+
+### `%heft`
+
+#### Accepts
+
+#### Returns
+
+#### Source
+
+
+### `%hook`
+
+#### Accepts
+
+#### Returns
+
+#### Source
+
+
+### `%harm`
+
+#### Accepts
+
+#### Returns
+
+#### Source
+
+
+### `%init`
+
+This `task` is called only once, when Arvo first enters the [adult
+stage](@/docs/tutorials/arvo/arvo.md#structural-interface-core). It performs
+initial setup for Dill, such as setting the width of the console.
+
+Note that this is not actually the first `task` passed to Dill - see [%boot](#%boot).
+
+#### Accepts
+
+`%init` takes no arguments.
+
+#### Returns
+
+`%init` returns no `gift`s.
+
+
+### `%knob`
+
+`%knob` sets the verbosity level for each error tag.
+
+#### Accepts
+
+```hoon
+[tag=@tas level=log-level]
+```
+
+`tag` is the error tag. `level` is the verbosity, set to either `%hush`,
+`%soft`, or `%loud`.
+
+#### Returns
+
+`%knob` does not return a gift.
+
+
+
+### `%lyra`
+
+#### Accepts
+
+#### Returns
+
+
+### `%noop`
+
+#### Accepts
+
+#### Returns
+
+
+### `%pack`
+
+#### Accepts
+
+#### Returns
+
+
+### `%talk`
+
+#### Accepts
+
+#### Returns
+
+
+### `%text`
+
+#### Accepts
+
+#### Returns
+
+
+### `%trim`
+
+#### Accepts
+
+#### Returns
+
+
+### `%veer`
+
+#### Accepts
+
+#### Returns
+
+
+### `%vega`
+
+#### Accepts
+
+#### Returns
+
+
+### `%verb`
+
+#### Accepts
+
+#### Returns

--- a/reference/vane-apis/dill.md
+++ b/reference/vane-apis/dill.md
@@ -114,7 +114,7 @@ and sends the bare `task` to itself over the default `duct`.
 
 `%flog` never returns a `gift` on its own, but the wrapped `task` might.
 
-#### Examples
+#### Example
 
 `%crud` `task`s from other vanes are typically passed to Dill wrapped in a
 `%flog` `task` to print errors to the terminal.
@@ -122,48 +122,71 @@ and sends the bare `task` to itself over the default `duct`.
 
 
 ### `%flow`
+
+`%flow` is used to configure the terminal.
  
 #### Accepts
 
+```hoon
+[p=@tas q=(list gill:gall)]
+```
+
 #### Returns
 
-#### Source
+`%flow` does not return any `gift`s.
 
 
 ### `%hail`
 
+`%hail` refreshes the terminal by sending an empty message to the default duct
+for Dill,
+causing the terminal to redraw itself (?)
+
 #### Accepts
+
+```hoon
+[ ~ ]
+```
 
 #### Returns
 
-#### Source
+`%hail` returns no `gift`s.
 
 
 ### `%heft`
 
+`%heft` causes Dill to `pass` a `%wegh` `task` to all other vanes (but not to
+itself), thus obtaining a complete digest of Arvo's memory usage. 
+
 #### Accepts
+
+```hoon
+[ ~ ]
+```
 
 #### Returns
 
-#### Source
+`%heft` does not directly return any `gift`s, but each `%wegh` `task` sent will
+return a `%mass` `gift`.
 
 
 ### `%hook`
 
+This appears in `zuse.hoon` but not in `dill.hoon` -  is it deprecated?
+
 #### Accepts
 
 #### Returns
 
-#### Source
 
 
 ### `%harm`
 
+Not sure what this does - see PR.
+
 #### Accepts
 
 #### Returns
-
-#### Source
 
 
 ### `%init`
@@ -204,62 +227,140 @@ Note that this is not actually the first `task` passed to Dill - see [%boot](#%b
 
 ### `%lyra`
 
+Comment in `zuse` says it upgrades the kernel.
+
 #### Accepts
+
+```hoon
+[p=@t q=@t]
+```
 
 #### Returns
 
 
 ### `%noop`
 
+`%noop` does nothing - it stands for "no operation".
+
 #### Accepts
 
+```hoon
+[ ~ ]
+```
+
 #### Returns
+
+This `task`, predictably, returns nothing.
+
+#### Example
+
+This can be useful if a shell command requires a Dill `task` but you don't want
+Dill to do anything.
 
 
 ### `%pack`
 
+Comment says "compact memory". Like `%lyra`, this just runs `dump kyz`.
+
 #### Accepts
 
+```hoon
+[ ~ ]
+```
+
 #### Returns
+
+This `task` returns no `gift`s.
 
 
 ### `%talk`
 
+This appears in `zuse.hoon` but not in `dill.hoon`. Is it deprecated?
+
 #### Accepts
+
+```hoon
+[p=tank]
+```
 
 #### Returns
 
 
 ### `%text`
 
+This `task` prints a `tape` to the dojo by first converting it from a UTF8
+`tape` to a `list` of UTF32 codepoints (`@c`'s) and then recursively popping off a character from the
+`tape` and sending it to to Unix to be printed into the terminal via a `%blit` event.
+
 #### Accepts
 
+```hoon
+[p=tape]
+```
+
 #### Returns
+
+This `task` returns zero or more `%blit` `gift`s, each containing a .
 
 
 ### `%trim`
 
+`%trim` is a common vane `task` used to reduce memory usage. However, it does
+nothing for Dill.
+
 #### Accepts
 
+```hoon
+[p=@ud]
+```
+
+This is a common parameter for `%trim` `task`s across all vanes but does nothing
+for Dill.
+
 #### Returns
+
+This `task` returns no `gift`s.
 
 
 ### `%veer`
 
+See comment in PR.
+
 #### Accepts
+
+```hoon
+[p=@ta q=path r=@t]
+```
 
 #### Returns
 
 
 ### `%vega`
 
+This is a common vane `task` used to inform the vane that the kernel has been
+upgraded. Dill does not do anything in response to this. 
+
 #### Accepts
 
+```hoon
+[ ~ ]
+```
+
 #### Returns
+
+This `task` returns no `gift`s.
 
 
 ### `%verb`
 
+This `task` toggles verbose mode for Dill.
+
 #### Accepts
 
+```hoon
+[ ~ ]
+```
+
 #### Returns
+
+This `task` returns no `gift`s.

--- a/reference/vane-apis/dill.md
+++ b/reference/vane-apis/dill.md
@@ -9,8 +9,13 @@ template = "doc.html"
 In this document we describe the public interface for Dill. Namely, we describe
 each `task` that Dill can be `pass`ed, and which `gift`(s) Dill can `give` in return.
 
+Dill is unique among vanes since it is technically the first vane to be booted (though we
+regard Jael as the "true" first vane). As a result, there are four `task`s in
+`task:able:dill` for which Dill acts only as a middleman that passes the `task`s
+directly to the Arvo kernel. Thus we have split this document into a [Dill
+tasks](#dill-tasks) section and an [Arvo tasks](#arvo-tasks) section.
 
-## Tasks
+## Dill Tasks
 
 
 ### `%belt`
@@ -206,18 +211,6 @@ Note that this is not actually the first `task` passed to Dill - see [%boot](#%b
 
 
 
-### `%lyra`
-
-Comment in `zuse` says it upgrades the kernel.
-
-#### Accepts
-
-```hoon
-[p=@t q=@t]
-```
-
-#### Returns
-
 
 ### `%noop`
 
@@ -238,20 +231,6 @@ This `task`, predictably, returns nothing.
 This can be useful if a shell command requires a Dill `task` but you don't want
 Dill to do anything.
 
-
-### `%pack`
-
-Comment says "compact memory". Like `%lyra`, this just runs `dump kyz`.
-
-#### Accepts
-
-```hoon
-[ ~ ]
-```
-
-#### Returns
-
-This `task` returns no `gift`s.
 
 
 ### `%talk`
@@ -294,18 +273,6 @@ for Dill.
 This `task` returns no `gift`s.
 
 
-### `%veer`
-
-See comment in PR.
-
-#### Accepts
-
-```hoon
-[p=@ta q=path r=@t]
-```
-
-#### Returns
-
 
 ### `%vega`
 
@@ -321,6 +288,53 @@ upgraded. Dill does not do anything in response to this.
 #### Returns
 
 This `task` returns no `gift`s.
+
+
+
+## Arvo tasks
+
+These `task`s live in `task:able:dill` but are passed directly to the Arvo
+kernel for processing.
+
+### `%lyra`
+
+Comment in `zuse` says it upgrades the kernel.
+
+#### Accepts
+
+```hoon
+[p=@t q=@t]
+```
+
+#### Returns
+
+
+### `%pack`
+
+Comment says "compact memory". Like `%lyra`, this just runs `dump kyz`.
+
+#### Accepts
+
+```hoon
+[ ~ ]
+```
+
+#### Returns
+
+This `task` returns no `gift`s.
+
+
+### `%veer`
+
+See comment in PR.
+
+#### Accepts
+
+```hoon
+[p=@ta q=path r=@t]
+```
+
+#### Returns
 
 
 ### `%verb`

--- a/reference/vane-apis/dill.md
+++ b/reference/vane-apis/dill.md
@@ -298,7 +298,7 @@ kernel for processing.
 
 ### `%lyra`
 
-Comment in `zuse` says it upgrades the kernel.
+This `task` updates the kernel.
 
 #### Accepts
 
@@ -306,12 +306,18 @@ Comment in `zuse` says it upgrades the kernel.
 [p=@t q=@t]
 ```
 
+`p` is related to hoon and `q` is related to Arvo but I don't know how.
+
 #### Returns
+
+This `task` returns no `gift`s. 
 
 
 ### `%pack`
 
-Comment says "compact memory". Like `%lyra`, this just runs `dump kyz`.
+This `task` defragments and deduplicates Arvo's memory. This is ultimately
+performed by the interpreter so you won't find the code in `arvo.hoon` but
+rather under `c3__pack` in `urbit/worker/main.c`.
 
 #### Accepts
 
@@ -326,7 +332,8 @@ This `task` returns no `gift`s.
 
 ### `%veer`
 
-See comment in PR.
+This `task` is used to install `zuse` and vanes. It is handled by `+veer` in
+`arvo.hoon`. 
 
 #### Accepts
 
@@ -336,10 +343,14 @@ See comment in PR.
 
 #### Returns
 
+This `task` returns no `gift`s.
+
 
 ### `%verb`
 
-This `task` toggles verbose mode for Dill.
+This `task` toggles verbose mode for all of Arvo, which is located here since
+Dill is the vane that prints errors. To be precise, `%verb` toggles the laconic
+bit `lac` in the [Arvo state](@/docs/tutorials/arvo/arvo.md#the-state).
 
 #### Accepts
 


### PR DESCRIPTION
This is a rough draft of documentation of the Dill public API. It is a work in progress and there are several areas that need work:

I don't understand how `%flow` works. It's a lark expression `+>` that is just the core it
is defined in and thus contains the card and I'm not sure what that gets sent
to. It has the form `[p=@tas q=(list gill:gall)]`

Similarly, `%harm` only appears as `+>` in `+call` in `dill.hoon` and the
associated card is empty. I don't see how this can do anything.

`$hook`, `$talk` appears in task:able:dill in `zuse.hoon` and has the comment "this term
hung up" but hook appears nowhere in `dill.hoon`. is `hook` deprecated?

I'm pretty sure what `%talk` does is print a `tape` to the screen, but following
along what is going on in `+from` is difficult.

The comments say that `%veer` is for installing vanes but I can't see how that
is happening in `dill.hoon` as its another `dump kyz` call, and I also don't
understand why that functionality would be in Dill (related to the fact that
Dill is technically the first vane?)

`%verb` is a task with an empty card that is commented as verbose mode. I assume
this must toggle verbose mode but I don't see how - its another `dump kyz` task.
