### PR TITLE
Jael public API

### DIFF
--- a/reference/vane-apis/jael.md
+++ b/reference/vane-apis/jael.md
@@ -9,11 +9,40 @@ template = "doc.html"
 In this document we describe the public interface for Jael.  Namely, we describe
 each `task` that Jael can be `%pass`ed, and which `gift`(s) Jael can `%give` in return.
 
+
 ## Tasks
 
 ### `%dawn`
 
+This `task` is called only a single time per ship during the vane initialization
+phase immediately following the beginning of the [adult
+stage](@/docs/tutorials/arvo/arvo.md#structural-interface-core) to load Azimuth information such as private keys and the sponsor into
+Jael. This `task` is `%pass`ed to Jael by Dill, as Dill is the first vane to be loaded for
+technical reasons, though we consider Jael to be the true "first" vane.
+
 #### Accepts
+
+`%dawn` accepts a `dawn-event`:
+
+```hoon
+    +$  dawn-event
+      $:  =seed
+          spon=(list [=ship point:azimuth-types])
+          czar=(map ship [=rift =life =pass])
+          turf=(list turf)
+          bloq=@ud
+          node=(unit purl:eyre)
+      ==
+```
+
+The `seed` is `[who=ship lyf=life key=ring sig=(unit oath:pki)]`. `who` is the
+`@p` of the ship running the `task`, `lyf` is the current ship key revision, `key`
+
+
+`spon` is a list (why?) of sponsors for the ship, `czar` is a map of ships you
+know to their rift, life, and public key? 
+
+`turf` is a `(list @t)` "::  domain, tld first" ?? something to do with DNS?
 
 #### Returns
 

--- a/reference/vane-apis/jael.md
+++ b/reference/vane-apis/jael.md
@@ -159,7 +159,7 @@ This `task` returns no `gift`s.
 
 ### `%moon`
 
-This `task` sets the public keys of a moon. 
+This `task` sets the public keys of a moon.
 
 #### Accepts
 
@@ -167,12 +167,14 @@ This `task` sets the public keys of a moon.
 [=ship =udiff:point]
 ```
 
-The `ship` is the `@p` of the moon. The `task` will no-op if the `@p` is not that
-of a moon, or the moon does not belong to the ship.
+The `ship` is the `@p` of the moon. The `task` will be a no-op if the `@p` is not that
+of a moon, or if the moon does not belong to the ship.
 
-`udiff:point` is the 
+`udiff:point` contains the new public keys to be stored for the moon.
 
 #### Returns
+
+This `task` returns no `gift`s.
 
 
 ### `%nuke`

--- a/reference/vane-apis/jael.md
+++ b/reference/vane-apis/jael.md
@@ -140,6 +140,8 @@ If the `source` is a `term`, Jael will `%pass` a `%deal` `task` to Gall asking t
 If the `source` is a `ship`, Jael will `%pass` a `%plea` `task` to Ames wrapping
 a `%public-keys` `task` intended for Jael on the `ship` specified by `source`.
 
+This `task` returns no `gift`s.
+
 ### `%meet`
 
 This `task` is deprecated and does not perform any actions.
@@ -157,26 +159,18 @@ This `task` returns no `gift`s.
 
 ### `%moon`
 
-Not sure what this one does.
-
-```hoon
-      %moon
-      ?.  =(%earl (clan:title ship.tac))
-        ~&  [%not-moon ship.tac]
-        +>.$
-      ?.  =(our (^sein:title ship.tac))
-        ~&  [%not-our-moon ship.tac]
-        +>.$
-      %-  curd  =<  abet
-      (~(new-event su hen our now pki etn) [ship udiff]:tac)
-   
-```
+This `task` sets the public keys of a moon. 
 
 #### Accepts
 
 ```hoon
 [=ship =udiff:point]
 ```
+
+The `ship` is the `@p` of the moon. The `task` will no-op if the `@p` is not that
+of a moon, or the moon does not belong to the ship.
+
+`udiff:point` is the 
 
 #### Returns
 

--- a/reference/vane-apis/jael.md
+++ b/reference/vane-apis/jael.md
@@ -26,11 +26,11 @@ information about Azimuth and the Ames network and booting other vanes for the f
 receipt of a `%dawn` `task`, Jael will:
  - record the Ethereum block the public key is registered to,
  - record the URL of the Ethereum node used,
- - save the signature of the parent planet (if the ship is a moon)
- - load the initial public and private keys for the ship
- - set the DNS suffix(es) used by the network (currently just `arvo.network`)
- - save the public keys of all galaxies
- - set Jael to subscribe to `%azimuth-tracker`
+ - save the signature of the parent planet (if the ship is a moon),
+ - load the initial public and private keys for the ship,
+ - set the DNS suffix(es) used by the network (currently just `arvo.network`),
+ - save the public keys of all galaxies,
+ - set Jael to subscribe to `%azimuth-tracker`,
  - `%slip` a `%init` `task` to Ames, Clay, Gall, Dill, and Eyre, and `%give` an `%init`
 `gift` to Arvo, which then informs Unix that the initialization process has concluded.
 

--- a/reference/vane-apis/jael.md
+++ b/reference/vane-apis/jael.md
@@ -32,7 +32,7 @@ receipt of a `%dawn` `task`, Jael will:
  - save the public keys of all galaxies
  - set Jael to subscribe to `%azimuth-tracker`
  - `%slip` a `%init` `task` to Ames, Clay, Gall, Dill, and Eyre, and `%give` an `%init`
-`gift` to Unix??. 
+`gift` to Arvo, which then informs Unix that the initialization process has concluded.
 
 #### Accepts
 
@@ -96,7 +96,7 @@ sponsorship chain and galaxy public keys are left at their bunted values.
 
 Like `%dawn`, `%fake` is used to initialize the other vanes. In response to a
 `%fake` `task`, Jael `%slip`s a `%init` `task` to each of Eyre, Dill, Gall,
-Clay, and Ames, and `%give`s a `%init` `gift` to Unix (?)
+Clay, and Ames, and `%give`s a `%init` `gift` to Arvo.
 
 
 ### `%listen`
@@ -191,7 +191,7 @@ This `task` returns no `gift`s.
 ### `%plea`
 
 This `task` is `%pass`ed to Jael from Ames. `%plea`s are wrappers for `task`s
-that (typically? always?) originate from a remote source, as the `%plea` pattern
+that originate from a remote source, as the `%plea` pattern
 is used to extend the `%pass`/`%give` semantics over the Ames network.
 
 Jael accepts two kinds of `%plea`s: [`%nuke`](#nuke) and
@@ -257,8 +257,8 @@ keys kept by Jael. This `task` can originate locally or remotely.
 [%public-keys =public-keys-result]
 ```
 If the `task` originated locally, Jael `%give`s a `%public-keys` `gift` in
-    response. If it originated remotely, Jael `%give`s a `%boon` `gift` to back
-    to Ames wrapping a `%public-keys` `gift`.
+response. If it originated remotely, Jael `%give`s a `%boon` `gift` to back
+to Ames wrapping a `%public-keys` `gift`.
     
 A `$public-keys-result` is the following.
 ```hoon
@@ -267,7 +267,12 @@ A `$public-keys-result` is the following.
           [%diff who=ship =diff:point]
           [%breach who=ship]
 ```
-
+The first time Jael receives a `%public-keys` `task` from a ship it will return
+a `[%public-keys-result %full]` `gift`, which contains all information about ships and
+their associated points that Jael knows. Subsequent updates will typically be
+`[%public-keys-result %diff]`, which tells the caller what has changed
+since last time they sent a `%public-keys` `task`, and `[%public-keys-result
+%breach]`, which informs the caller of ship breaches.
 
 
 ### `%rekey`

--- a/reference/vane-apis/jael.md
+++ b/reference/vane-apis/jael.md
@@ -96,12 +96,19 @@ sponsorship chain and galaxy public keys are left at their bunted values.
 
 Like `%dawn`, `%fake` is used to initialize the other vanes. In response to a
 `%fake` `task`, Jael `%slip`s a `%init` `task` to each of Eyre, Dill, Gall,
-Clay, and Ames, and `%give`s a `%init` `gift` to Arvo.
+Clay, and Ames, and `%give`s a `%init` `gift` to Unix.
 
 
 ### `%listen`
 
-set ethereum source?
+Sets the source that the public keys for a set of `ship`s should be obtained
+from. This can either be a Gall app that communicates with an Ethereum node such
+as `%azimuth-tracker`, as in the case for galaxies, stars,
+and planets, or a ship, as in the case of a moon or comet.
+
+After setting the source, Jael will then subscribe to the source for updates on
+public keys for the given ships.
+
 
 #### Accepts
 
@@ -109,73 +116,29 @@ set ethereum source?
 [whos=(set ship) =source]
 ```
 
-A `$source` is `(each ship term)`.
+`whos` is the set of ships whose key data source is to be altered. `source` is
+`(each ship term)`, where `term` will ultimately be treated as a handle for a
+Gall app.
 
-```
-++  each
-  |$  [this that]
-  ::    either {a} or {b}, defaulting to {a}.
-  ::
-  ::  mold generator: produces a discriminated fork between two types,
-  ::  defaulting to {a}.
-  ::
-  $%  [%| p=that]
-      [%& p=this]
-  ==
-```
-`term=@tas`
+A `%listen` `task` with empty `whos` will set the default source to `source`.
+This is the source used for all ships unless otherwise specified.
 
-```hoon
-        %listen
-      ~&  [%jael-listen whos source]:tac
-      %-  curd  =<  abet
-      (sources:~(feel su hen our now pki etn) [whos source]:tac)
-```
+When the `source` is a `term`, Jael looks into its state to find what source has
+been previously assigned to that `term` and will henceforth obtain public keys for
+ships in `(set ship)` from there. In practice, this is always
+`%azimuth-tracker`, but the ability to use other sources is present.
 
-```hoon
-++  su
-      ::  the ++su core handles all derived state,
-      ::  subscriptions, and actions.
-      ::
-      ::  ++feed:su registers subscriptions.
-      ::
-      ::  ++feel:su checks if a ++change should notify
-      ::  any subscribers.
-      ::
-```
-
-```hoon
-    ::  Change sources for ships
-    ::
-    ++  sources
-      |=  [whos=(set ship) =source]
-      ^+  ..feel
-      =^  =source-id  this-su  (get-source-id source)
-      =.  ..feed
-        ?~  whos
-          ..feed(default-source.etn source-id)
-        =/  whol=(list ship)  ~(tap in `(set ship)`whos)
-        =.  ship-sources.etn
-          |-  ^-  (map ship ^source-id)
-          ?~  whol
-            ship-sources.etn
-          (~(put by $(whol t.whol)) i.whol source-id)
-        =.  ship-sources-reverse.etn
-          %-  ~(gas ju ship-sources-reverse.etn)
-          (turn whol |=(=ship [source-id ship]))
-        ..feed
-      ::
-      ?:  ?=(%& -.source)
-        =/  send-message
-          |=  =message
-          [hen %pass /public-keys %a %plea p.source %j /public-keys message]
-        (emit (send-message %public-keys whos))
-      (peer p.source whos)
-    --
-```
+When the `source` is a ship, Jael will obtain public keys for ships in `(set ship)` from
+the given ship. By default, the `source` for a moon will be the planet that
+spawned that moon, and the `source` for a comet will be the comet itself.
 
 #### Returns
 
+If the `source` is a `term`, Jael will `%pass` a `%deal` `task` to Gall asking to
+`%watch` the app given by `source` at path `/`.
+
+If the `source` is a `ship`, Jael will `%pass` a `%plea` `task` to Ames wrapping
+a `%public-keys` `task` intended for Jael on the `ship` specified by `source`.
 
 ### `%meet`
 

--- a/reference/vane-apis/jael.md
+++ b/reference/vane-apis/jael.md
@@ -146,6 +146,21 @@ This `task` returns no `gift`s.
 
 ### `%moon`
 
+Not sure what this one does.
+
+```hoon
+      %moon
+      ?.  =(%earl (clan:title ship.tac))
+        ~&  [%not-moon ship.tac]
+        +>.$
+      ?.  =(our (^sein:title ship.tac))
+        ~&  [%not-our-moon ship.tac]
+        +>.$
+      %-  curd  =<  abet
+      (~(new-event su hen our now pki etn) [ship udiff]:tac)
+   
+```
+
 #### Accepts
 
 ```hoon
@@ -300,6 +315,9 @@ This task returns nothing.
 
 ### `%turf`
 
+This `task` is a request for Jael to provide its list of `turf`s, e.g. DNS
+suffixes for the Ames network. Currently `arvo.network` is the only `turf` in use.
+
 #### Accepts
 
 ```hoon
@@ -307,6 +325,13 @@ This task returns nothing.
 ```
 
 #### Returns
+
+```hoon
+[%turn tuf.own.pki]
+```
+
+Jael `%give`s a `%turf` `gift` in response to a `%turf` `task`. `tuf.own.pki` is
+a `(list turf)`, which is Jael's list of `turf`s.
 
 
 ### `%vega`

--- a/reference/vane-apis/jael.md
+++ b/reference/vane-apis/jael.md
@@ -70,8 +70,13 @@ with the Azimuth smart contract.
 
 #### Returns
 
-As mentioned above, this `task` `%slip`s `%init` `task`s to most other vanes and
-`%give`s an `%init` `gift` to Unix.
+Jael `%give`s an `%init` `gift` to Unix. This occurs after the Dill `%slip`
+init.
+
+#### Slips
+
+Jael `%slip`s `%init` `task`s to each of Eyre, Dill, Gall, Clay, and Ames, in
+that order.
 
 
 ### `%fake`
@@ -94,9 +99,12 @@ sponsorship chain and galaxy public keys are left at their bunted values.
 
 #### Returns
 
-Like `%dawn`, `%fake` is used to initialize the other vanes. In response to a
-`%fake` `task`, Jael `%slip`s a `%init` `task` to each of Eyre, Dill, Gall,
-Clay, and Ames, and `%give`s a `%init` `gift` to Unix.
+Jael `%give`s a `%init` `gift` to Unix.
+
+#### Slips
+
+In response to a `%fake` `task`, Jael `%slip`s a `%init` `task` to each of Eyre, Dill, Gall,
+Clay, and Ames, in that order.
 
 
 ### `%listen`
@@ -134,13 +142,16 @@ spawned that moon, and the `source` for a comet will be the comet itself.
 
 #### Returns
 
+This `task` returns no `gift`s.
+
+#### Passes
+
 If the `source` is a `term`, Jael will `%pass` a `%deal` `task` to Gall asking to
 `%watch` the app given by `source` at path `/`.
 
 If the `source` is a `ship`, Jael will `%pass` a `%plea` `task` to Ames wrapping
 a `%public-keys` `task` intended for Jael on the `ship` specified by `source`.
 
-This `task` returns no `gift`s.
 
 ### `%meet`
 
@@ -199,11 +210,12 @@ This `task` returns no `gift`s.
 
 This `task` is `%pass`ed to Jael from Ames. `%plea`s are wrappers for `task`s
 that originate from a remote source, as the `%plea` pattern
-is used to extend the `%pass`/`%give` semantics over the Ames network.
+is used to extend the `%pass`/`%give` semantics over the Ames network. Jael
+attempts to perform the `task` wrapped in the `%plea`.
 
 Jael accepts two kinds of `%plea`s: [`%nuke`](#nuke) and
-[`%public-keys`](#public-keys) and will crash if passed anything else. See the relevant entries to learn how Jael
-responds to these. 
+[`%public-keys`](#public-keys) and will crash if passed anything else. See the
+relevant entries to learn how Jael responds to these.
 
 #### Accepts
 
@@ -216,8 +228,11 @@ a `%public-keys` `task`.
 
 #### Returns
 
-Jael `%give`s a `%done` `gift` in response to a `%plea` `task`. It also
-`%pass`es itself the wrapped `task`.
+Jael `%give`s a `%done` `gift` in response to a `%plea` `task`. 
+
+#### Passes
+
+Jael `%pass`es itself the wrapped `task`.
 
 
 ### `%private-keys`
@@ -373,3 +388,8 @@ This `task` has no arguments.
 
 In response to this `task,` Jael `%give`s a `%mass` `gift` containing Ames'
 current memory usage.
+
+
+
+
+

--- a/reference/vane-apis/jael.md
+++ b/reference/vane-apis/jael.md
@@ -127,7 +127,11 @@ This `task` cancels all trackers from a given set of ships.
 
 #### Returns
 
-This `task` returns no `gift`s.
+```hoon
+[%done ~]
+```
+
+After a `%nuke` `task`, Jael `%give`s a `%done` `gift` in response. This is an acknowledgement that the task was completed successfully. 
 
 
 ### `%plea`
@@ -169,13 +173,20 @@ history of the ship.
 
 ### `%public-keys`
 
+This `task` creates a subscription for the callee to a selection of the public keys kept by Jael.
+
 #### Accepts
 
 ```hoon
 [ships=(set ship)]
 ```
+`ships` is the `set` of `ship`s whos' public keys are being subscribed to.
 
 #### Returns
+
+```hoon
+[%public-keys =public-keys-result]
+```
 
 
 ### `%rekey`

--- a/reference/vane-apis/jael.md
+++ b/reference/vane-apis/jael.md
@@ -63,9 +63,17 @@ know to their rift, life, and public key?
 
 ### `%meet`
 
+This `task` is a placeholder that currently does nothing.
+
 #### Accepts
 
+```hoon
+[=ship =life =pass]
+```
+
 #### Returns
+
+This `task` returns no `gift`s.
 
 
 ### `%moon`
@@ -112,9 +120,21 @@ know to their rift, life, and public key?
 
 ### `%trim`
 
+This `task` is sent by the interpreter in order to free up memory.
+ This `task` is empty for Jael, since it is not a good idea to forget your
+ private keys and other cryptographic data.
+
 #### Accepts
 
+```hoon
+[p=@ud]
+```
+This argument is unused by Jael.
+
 #### Returns
+
+This task returns nothing.
+
 
 
 ### `%turf`
@@ -126,13 +146,28 @@ know to their rift, life, and public key?
 
 ### `%vega`
 
+`%vega` is called whenever the kernel is updated. Jael currently does not do
+anything in response to this.
+
 #### Accepts
 
+`%vega` takes no arguments.
+
 #### Returns
+
+This `task` returns no `gift`s.
+
 
 
 ### `%wegh`
 
+This `task` is a request to Jael to produce a memory usage report.
+
 #### Accepts
 
+This `task` has no arguments.
+
 #### Returns
+
+In response to this `task,` Jael `%give`s a `%mass` `gift` containing Ames'
+current memory usage.

--- a/reference/vane-apis/jael.md
+++ b/reference/vane-apis/jael.md
@@ -76,13 +76,27 @@ As mentioned above, this `task` `%slip`s `%init` `task`s to most other vanes and
 
 ### `%fake`
 
+This `task` is used instead of `%dawn` when creating a fake ship via the `-F`
+flag when calling the Urbit binary. It performs a subset of the actions that
+`%dawn` performs, modified to accommodate the fake ship.
+
+`%fake` endows the ship with a private key and a public key deterministically derived from the
+ship's `@p`. It sets `fak.own.pki` to `%.y`, which is the bit that determines
+whether or not a ship is fake. Other parts of the Jael state, such as the
+sponsorship chain and galaxy public keys are left at their bunted values.
+
 #### Accepts
 
 ```hoon
 [=ship]
 ```
+`ship` is the `@p` of the fake ship being created.
 
 #### Returns
+
+Like `%dawn`, `%fake` is used to initialize the other vanes. In response to a
+`%fake` `task`, Jael `%slip`s a `%init` `task` to each of Eyre, Dill, Gall,
+Clay, and Ames, and `%give`s a `%init` `gift` to Unix (?)
 
 
 ### `%listen`

--- a/reference/vane-apis/jael.md
+++ b/reference/vane-apis/jael.md
@@ -131,7 +131,7 @@ A `$source` is `(each ship term)`.
 
 ### `%meet`
 
-This `task` is a placeholder that currently does nothing.
+This `task` is deprecated and does not perform any actions.
 
 #### Accepts
 
@@ -157,33 +157,44 @@ This `task` returns no `gift`s.
 
 ### `%nuke`
 
-This `task` cancels all trackers from a given set of ships.
+This `task` cancels subscriptions to Jael's state from a given set of `ship`s.
+This `task` works differently depending on whether the `task` originated locally
+or remotely.
 
 #### Accepts
 
 ```hoon
 [whos=(set ship)]
 ```
-`whos` is the `set` of `ship`s for which trackers are to be canceled.
+`whos` is the `set` of `ship`s from which subscriptions are to be canceled.
 
 #### Returns
 
-```hoon
-[%done ~]
-```
-
-After a `%nuke` `task`, Jael `%give`s a `%done` `gift` in response. This is an acknowledgement that the task was completed successfully. 
+This `task` returns no `gift`s.
 
 
 ### `%plea`
+
+This `task` is `%pass`ed to Jael from Ames. `%plea`s are wrappers for `task`s
+that (typically? always?) originate from a remote source, as the `%plea` pattern
+is used to extend the `%pass`/`%give` semantics over the Ames network.
+
+Jael accepts two kinds of `%plea`s: [`%nuke`](#nuke) and
+[`%public-keys`](#public-keys) and will crash if passed anything else. See the relevant entries to learn how Jael
+responds to these. 
 
 #### Accepts
 
 ```hoon
 [=ship =plea:ames]
 ```
+`ship` is the origin of the plea, and `plea:ames` is `[vane=@tas =path
+payload=*]`. Here, `vane=%j`, `path` is the internal route on the receiving ship, and `payload` is either a `%nuke` or
+a `%public-keys` `task`.
 
 #### Returns
+
+Jael `%give`s a `%done` `gift` in response to a `%plea` `task`.
 
 
 ### `%private-keys`

--- a/reference/vane-apis/jael.md
+++ b/reference/vane-apis/jael.md
@@ -138,6 +138,12 @@ This `task` returns no `gift`s.
 
 ### `%private-keys`
 
+This `task` creates a subscription to the private keys kept by Jael.
+
+We note that there are two `+private-keys` arms in Jael - one located in the
+`+feed` core and the other located in the `+feel` core. This `task` calls the
+arm in the `+feed` core.
+
 #### Accepts
 
 ```hoon
@@ -145,6 +151,15 @@ This `task` returns no `gift`s.
 ```
 
 #### Returns
+
+```hoon
+[%private-keys =life vein=(map life ring)]
+```
+
+In response to a `%private-keys` `task`, Jael `%give`s a `%private-keys` `gift`.
+`life=@ud` is the current `life` of the ship, and `vein` is a `map` from
+`life`s to `ring`s that keeps track of all `life`-`ring` pairs throughout the
+history of the ship.
 
 
 ### `%public-keys`

--- a/reference/vane-apis/jael.md
+++ b/reference/vane-apis/jael.md
@@ -116,13 +116,18 @@ This `task` returns no `gift`s.
 
 ### `%nuke`
 
+This `task` cancels all trackers from a given set of ships.
+
 #### Accepts
 
 ```hoon
 [whos=(set ship)]
 ```
+`whos` is the `set` of `ship`s for which trackers are to be canceled.
 
 #### Returns
+
+This `task` returns no `gift`s.
 
 
 ### `%plea`

--- a/reference/vane-apis/jael.md
+++ b/reference/vane-apis/jael.md
@@ -194,7 +194,8 @@ a `%public-keys` `task`.
 
 #### Returns
 
-Jael `%give`s a `%done` `gift` in response to a `%plea` `task`.
+Jael `%give`s a `%done` `gift` in response to a `%plea` `task`. It also
+`%pass`es itself the wrapped `task`.
 
 
 ### `%private-keys`

--- a/reference/vane-apis/jael.md
+++ b/reference/vane-apis/jael.md
@@ -51,12 +51,20 @@ know to their rift, life, and public key?
 
 #### Accepts
 
+```hoon
+[=ship]
+```
+
 #### Returns
 
 
 ### `%listen`
 
 #### Accepts
+
+```hoon
+[whos=(set ship) =source]
+```
 
 #### Returns
 
@@ -80,12 +88,20 @@ This `task` returns no `gift`s.
 
 #### Accepts
 
+```hoon
+[=ship =udiff:point]
+```
+
 #### Returns
 
 
 ### `%nuke`
 
 #### Accepts
+
+```hoon
+[whos=(set ship)]
+```
 
 #### Returns
 
@@ -94,12 +110,20 @@ This `task` returns no `gift`s.
 
 #### Accepts
 
+```hoon
+[=ship =plea:ames]
+```
+
 #### Returns
 
 
 ### `%private-keys`
 
 #### Accepts
+
+```hoon
+[~]
+```
 
 #### Returns
 
@@ -108,12 +132,20 @@ This `task` returns no `gift`s.
 
 #### Accepts
 
+```hoon
+[ships=(set ship)]
+```
+
 #### Returns
 
 
 ### `%rekey`
 
 #### Accepts
+
+```hoon
+[=life =ring]
+```
 
 #### Returns
 
@@ -140,6 +172,10 @@ This task returns nothing.
 ### `%turf`
 
 #### Accepts
+
+```hoon
+[~]
+```
 
 #### Returns
 

--- a/reference/vane-apis/jael.md
+++ b/reference/vane-apis/jael.md
@@ -226,7 +226,8 @@ history of the ship.
 
 ### `%public-keys`
 
-This `task` creates a subscription for the callee to a selection of the public keys kept by Jael.
+This `task` creates a subscription for the callee to a selection of the public
+keys kept by Jael. This `task` can originate locally or remotely.
 
 #### Accepts
 
@@ -240,6 +241,18 @@ This `task` creates a subscription for the callee to a selection of the public k
 ```hoon
 [%public-keys =public-keys-result]
 ```
+If the `task` originated locally, Jael `%give`s a `%public-keys` `gift` in
+    response. If it originated remotely, Jael `%give`s a `%boon` `gift` to back
+    to Ames wrapping a `%public-keys` `gift`.
+    
+A `$public-keys-result` is the following.
+```hoon
+    +$  public-keys-result
+      $%  [%full points=(map ship point)]
+          [%diff who=ship =diff:point]
+          [%breach who=ship]
+```
+
 
 
 ### `%rekey`
@@ -252,7 +265,7 @@ This `task` updates the ship's private keys.
 [=life =ring]
 ```
 
-`life` is a `@ud` that is the new ship key revision number. `ring` is an `@` that is the new private key.
+`life` is a `@ud` that is the new ship key revision number. `ring` is a `@` that is the new private key.
 
 #### Returns
 

--- a/reference/vane-apis/jael.md
+++ b/reference/vane-apis/jael.md
@@ -14,11 +14,25 @@ each `task` that Jael can be `%pass`ed, and which `gift`(s) Jael can `%give` in 
 
 ### `%dawn`
 
-This `task` is called only a single time per ship during the vane initialization
+This `task` is called once per ship during the vane initialization
 phase immediately following the beginning of the [adult
-stage](@/docs/tutorials/arvo/arvo.md#structural-interface-core) to load Azimuth information such as private keys and the sponsor into
-Jael. This `task` is `%pass`ed to Jael by Dill, as Dill is the first vane to be loaded for
-technical reasons, though we consider Jael to be the true "first" vane.
+stage](@/docs/tutorials/arvo/arvo.md#structural-interface-core). This `task` is `%pass`ed to Jael by Dill, as Dill is the first vane to be loaded for
+technical reasons, though we consider Jael to be the true "first" vane. This
+`task` is only used for ships that will join the Ames network - fake ships (i.e.
+made with `./urbit -F zod`) use the `%fake` `task` instead.
+
+`%dawn` is used to perform a sequence of initialization tasks related to saving
+information about Azimuth and the Ames network and booting other vanes for the first time. Upon
+receipt of a `%dawn` `task`, Jael will:
+ - record the Ethereum block the public key is registered to,
+ - record the URL of the Ethereum node used,
+ - save the signature of the parent planet (if the ship is a moon)
+ - load the initial public and private keys for the ship
+ - set the DNS suffix(es) used by the network (currently just `arvo.network`)
+ - save the public keys of all galaxies
+ - set Jael to subscribe to `%azimuth-tracker`
+ - `%slip` a `%init` `task` to Ames, Clay, Gall, Dill, and Eyre, and `%give` an `%init`
+`gift` to Unix??. 
 
 #### Accepts
 
@@ -36,15 +50,28 @@ technical reasons, though we consider Jael to be the true "first" vane.
 ```
 
 The `seed` is `[who=ship lyf=life key=ring sig=(unit oath:pki)]`. `who` is the
-`@p` of the ship running the `task`, `lyf` is the current ship key revision, `key`
+`@p` of the ship running the `task`, `lyf` is the current ship key revision,
+`key` is the ship's private key, and `sig` is the signature of the ship's parent
+planet if the ship is moon and `[~]` otherwise.
 
+`spon` is a `list` of ships and their `point`s in the ship's sponsorship chain,
+all the way to the galaxy level. `point:azimuth-types` contains all Azimuth
+related data and can be found in `zuse.hoon`.
 
-`spon` is a list (why?) of sponsors for the ship, `czar` is a map of ships you
-know to their rift, life, and public key? 
+`czar` is a map from each galaxy's `@p` to its `rift`, `life`, and public key (`pass`).
 
-`turf` is a `(list @t)` "::  domain, tld first" ?? something to do with DNS?
+`turf` is a `list` of DNS suffixes used by the Ames network, which for now is
+just `arvo.network`. 
+
+`bloq` is the number of the Ethereum block in which the ship registered its keys
+with the Azimuth smart contract.
+
+`node` is the URL of the Ethereum node used to register the ship's keys with Azimuth.
 
 #### Returns
+
+As mentioned above, this `task` `%slip`s `%init` `task`s to most other vanes and
+`%give`s an `%init` `gift` to Unix.
 
 
 ### `%fake`

--- a/reference/vane-apis/jael.md
+++ b/reference/vane-apis/jael.md
@@ -6,8 +6,8 @@ template = "doc.html"
 
 # Jael
 
-In this document we describe the public interface for Ames.  Namely, we describe
-each `task` that Jael can be `%pass`ed, and which `gift`(s) Ames can `%give` in return.
+In this document we describe the public interface for Jael.  Namely, we describe
+each `task` that Jael can be `%pass`ed, and which `gift`(s) Jael can `%give` in return.
 
 ## Tasks
 

--- a/reference/vane-apis/jael.md
+++ b/reference/vane-apis/jael.md
@@ -60,11 +60,30 @@ know to their rift, life, and public key?
 
 ### `%listen`
 
+set ethereum source?
+
 #### Accepts
 
 ```hoon
 [whos=(set ship) =source]
 ```
+
+A `$source` is `(each ship term)`.
+
+```
+++  each
+  |$  [this that]
+  ::    either {a} or {b}, defaulting to {a}.
+  ::
+  ::  mold generator: produces a discriminated fork between two types,
+  ::  defaulting to {a}.
+  ::
+  $%  [%| p=that]
+      [%& p=this]
+  ==
+```
+`term=@tas`
+
 
 #### Returns
 
@@ -141,13 +160,26 @@ This `task` returns no `gift`s.
 
 ### `%rekey`
 
+This `task` updates the ship's private keys.
+
 #### Accepts
 
 ```hoon
 [=life =ring]
 ```
 
+`life` is a `@ud` that is the new ship key revision number. `ring` is an `@` that is the new private key.
+
 #### Returns
+
+```hoon
+[%private-keys =life vein=(map life ring)]
+```
+
+In response to a `%rekey` `task`, Jael `%give`s a `%private-keys` `gift`. `life`
+is the new `life` given in the original `task`, and `vein` is a `map` from
+`life`s to `ring`s that keeps track of all `life`-`ring` pairs throughout the
+history of the ship.
 
 
 ### `%trim`

--- a/reference/vane-apis/jael.md
+++ b/reference/vane-apis/jael.md
@@ -1,0 +1,109 @@
++++
+title = "Jael Public API"
+weight = 5
+template = "doc.html"
++++
+
+# Jael
+
+In this document we describe the public interface for Ames.  Namely, we describe
+each `task` that Jael can be `%pass`ed, and which `gift`(s) Ames can `%give` in return.
+
+## Tasks
+
+### `%dawn`
+
+#### Accepts
+
+#### Returns
+
+
+### `%fake`
+
+#### Accepts
+
+#### Returns
+
+
+### `%listen`
+
+#### Accepts
+
+#### Returns
+
+
+### `%meet`
+
+#### Accepts
+
+#### Returns
+
+
+### `%moon`
+
+#### Accepts
+
+#### Returns
+
+
+### `%nuke`
+
+#### Accepts
+
+#### Returns
+
+
+### `%plea`
+
+#### Accepts
+
+#### Returns
+
+
+### `%private-keys`
+
+#### Accepts
+
+#### Returns
+
+
+### `%public-keys`
+
+#### Accepts
+
+#### Returns
+
+
+### `%rekey`
+
+#### Accepts
+
+#### Returns
+
+
+### `%trim`
+
+#### Accepts
+
+#### Returns
+
+
+### `%turf`
+
+#### Accepts
+
+#### Returns
+
+
+### `%vega`
+
+#### Accepts
+
+#### Returns
+
+
+### `%wegh`
+
+#### Accepts
+
+#### Returns

--- a/reference/vane-apis/jael.md
+++ b/reference/vane-apis/jael.md
@@ -125,6 +125,54 @@ A `$source` is `(each ship term)`.
 ```
 `term=@tas`
 
+```hoon
+        %listen
+      ~&  [%jael-listen whos source]:tac
+      %-  curd  =<  abet
+      (sources:~(feel su hen our now pki etn) [whos source]:tac)
+```
+
+```hoon
+++  su
+      ::  the ++su core handles all derived state,
+      ::  subscriptions, and actions.
+      ::
+      ::  ++feed:su registers subscriptions.
+      ::
+      ::  ++feel:su checks if a ++change should notify
+      ::  any subscribers.
+      ::
+```
+
+```hoon
+    ::  Change sources for ships
+    ::
+    ++  sources
+      |=  [whos=(set ship) =source]
+      ^+  ..feel
+      =^  =source-id  this-su  (get-source-id source)
+      =.  ..feed
+        ?~  whos
+          ..feed(default-source.etn source-id)
+        =/  whol=(list ship)  ~(tap in `(set ship)`whos)
+        =.  ship-sources.etn
+          |-  ^-  (map ship ^source-id)
+          ?~  whol
+            ship-sources.etn
+          (~(put by $(whol t.whol)) i.whol source-id)
+        =.  ship-sources-reverse.etn
+          %-  ~(gas ju ship-sources-reverse.etn)
+          (turn whol |=(=ship [source-id ship]))
+        ..feed
+      ::
+      ?:  ?=(%& -.source)
+        =/  send-message
+          |=  =message
+          [hen %pass /public-keys %a %plea p.source %j /public-keys message]
+        (emit (send-message %public-keys whos))
+      (peer p.source whos)
+    --
+```
 
 #### Returns
 


### PR DESCRIPTION
This PR adds `/docs/reference/vane-apis/jael.md`. It describes `task`s that can
be `%pass`ed to Jael and what `gift`s may be returned in response.

Edit 2020.12.03 - finally looped back to this! My only outstanding question is that the comment above the `%moon` task says its for changing private keys, but the code looks like it changes public keys. I ignored the comment, but I also don't know the details on how moon keys are stored, so perhaps it really does store private keys but uses the `+public-keys:feel` arm.

I also finally came to the conclusion that including `%pass`es that a `task` can trigger might be considered an implementation detail and thus doesn't necessarily belong in an API doc. I'm not really sure on this. I have chosen the worst path, the middle one, and so have a few tasks that say what `%slip`s and `%pass`es they might trigger and some that do not. I would appreciate another perspective on this.