### PR TITLE
Removes stray ser from gall tutorial

### DIFF
--- a/reference/hoon-expressions/rune/tis.md
+++ b/reference/hoon-expressions/rune/tis.md
@@ -423,11 +423,11 @@ Regular: **running**.
 
 ### =* "tistar"
 
-`[%tstr p=term q=hoon r=hoon]`: define an alias.
+`[%tstr p=term q=hoon r=hoon]`: define a macro.
 
 ##### Produces
 
-`r`, compiled with a subject in which `p` is aliased to `q`.
+`r`, compiled with a subject in which `p` is a macro for `q`.
 
 ##### Syntax
 
@@ -435,7 +435,7 @@ Regular: **3-fixed**.
 
 ##### Discussion
 
-The difference between aliasing and pinning is that pinning changes the subject, but for aliasing the subject noun stays the same.  The aliased expression, `q`, is recorded in the type information of `p`. `q` is calculated every time you use the `p` alias.
+The difference between macroing and pinning is that pinning changes the subject, but for macroing the subject noun stays the same.  The macro'd expression, `q`, is recorded in the type information of `p`. `q` is calculated every time you use the `p` macro.
 
 ##### Examples
 

--- a/tutorials/arvo/gall.md
+++ b/tutorials/arvo/gall.md
@@ -162,8 +162,8 @@ Here's a skeleton example of an implementation:
 ::
 ++  on-poke
   |=  [=mark =vase]
-  ~&  state=state
-  ~&  got-poked-with-data=mark]
+  ~&  >  state=state
+  ~&  got-poked-with-data=mark
   =.  state  +(state)
   `this
 ::

--- a/tutorials/hoon/nouns.md
+++ b/tutorials/hoon/nouns.md
@@ -422,7 +422,7 @@ Let's do a few more examples:
 %six
 ```
 
-For those who prefer to think in terms of binary numbers and binary trees, there is another (equivalent) way to understand noun addressing.  When the noun address is expressed as a binary number, you can think of the the number as indicating a tree path from the top node.
+For those who prefer to think in terms of binary numbers and binary trees, there is another (equivalent) way to understand noun addressing.  When the noun address is expressed as a binary number, you can think of the number as indicating a tree path from the top node.
 
 As before, the root of the binary tree (i.e., the whole noun) is at address `1`. For the node of a tree at any address `b`, where `b` is a binary number, you get the address of its head by concatenating a `0` to the end of `b`; and to get its tail, concatenate a `1` to the end. For example, the head of the node at binary address `111` is at `1110`, and the tail is at `1111`.
 


### PR DESCRIPTION
I also noticed in the two  `++on-poke` arms `state` is `~&`'d slightly differently: `~&  state=state` vs `~&  >  state=state`.  The second one apparently is not  a syntax error.  It prints as `>   state=42` (gar with three aces) in _green_.  Wild.  Questions is, do we want both versions to be the same for consistency? 