### PR TITLE
Corrects ++on-load example code in gall tutorial

### DIFF
--- a/tutorials/arvo/gall.md
+++ b/tutorials/arvo/gall.md
@@ -158,7 +158,7 @@ Here's a skeleton example of an implementation:
     ~&  %prep-lost
     `this
   ~&  %prep-found
-  `this(state u.old-state)
+  `this(state old-state)
 ::
 ++  on-poke
   |=  [=mark =vase]


### PR DESCRIPTION
I would call `old-state` `saved-state` and use "old" only for state _type_ stuff, like `old-state-types`.  But since all the existing apps use "old" instead of "saved" this is probably not worth pursuing.