### PR TITLE
remove references to factories

### DIFF
--- a/reference/hoon-expressions/rune/buc.md
+++ b/reference/hoon-expressions/rune/buc.md
@@ -7,9 +7,9 @@ aliases = ["docs/reference/hoon-expressions/rune/buc/"]
 The `$` family of runes is used for defining custom types.  Strictly speaking,
 these runes are used to produce 'structures'.  A structure is a compile-time
 value that at runtime can be converted to either an example value (sometimes
-called a 'bunt' value) for its corresponding type, or to a 'factory' (sometimes
-called a 'mold').  An example value is used as a placeholder for sample values,
-among other things.  A factory/mold is used as a data validator.
+called a 'bunt' value) for its corresponding type, or to a 'mold'.  An example
+value is used as a placeholder for sample values, among other things.  A
+mold is an idempotent function used as a data validator.
 
 ## Overview
 

--- a/reference/hoon-expressions/rune/ket.md
+++ b/reference/hoon-expressions/rune/ket.md
@@ -51,7 +51,7 @@ The prettyprinter shows the core metal (`.` gold, `|` iron):
 
 ### ^: "ketcol"
 
-`[%ktcl p=spec]`: 'factory' gate for type `p`.
+`[%ktcl p=spec]`: mold gate for type `p`.
 
 ##### Produces
 

--- a/reference/hoon-expressions/rune/ket.md
+++ b/reference/hoon-expressions/rune/ket.md
@@ -63,7 +63,7 @@ Regular: **1-fixed**.
 
 ##### Discussion
 
-In older versions of Hoon, a 'mold' was an idempotent gate that was guaranteed to produce a noun of that type.  If an input value wasn't of the correct type, the bunt value of that type was returned.  (See `^*`.)
+A mold is an idempotent gate that is guaranteed to produce a noun of that type.  If an input value isn't of the correct type, the bunt value of that type is returned.  (See `^*`.)
 
 `^:` is used to produce a gate that is much like a mold, except that instead of producing a bunt value when the input value is of the wrong type, it crashes.
 


### PR DESCRIPTION
This is a small PR that removes two references to "factories", which seems to be
an old name for molds. I asked in the infrastructure channel if this terminology
was still used and a couple people commented that it is not.

----

#