### PR TITLE
Updated egg-timer.md to static Gall

### DIFF
--- a/tutorials/hoon/egg-timer.md
+++ b/tutorials/hoon/egg-timer.md
@@ -8,7 +8,7 @@ aliases = ["/docs/learn/hoon/hoon-tutorial/egg-timer/"]
 The Arvo operating system is divided up into modules called vanes.  Gall is the vane responsible for providing an API for building stateful applications in Urbit.  Gall is a complex system that takes a lot of getting used to, so let's dip our toes in with a simple egg-timer app.
 
 The following code sample should be saved as `/home/app/egg-timer.hoon`
-After committing: `|start egg-timer` and poke with `:egg-timer ~s10`
+After committing: `|start %egg-timer` and poke with `:egg-timer ~s10`
 
 ```hoon
 /+  default-agent

--- a/tutorials/hoon/egg-timer.md
+++ b/tutorials/hoon/egg-timer.md
@@ -5,115 +5,155 @@ template = "doc.html"
 aliases = ["/docs/learn/hoon/hoon-tutorial/egg-timer/"]
 +++
 
-The Arvo operating system is divided up into modules called vanes. Gall is the vane responsible for providing an API for building stateful applications in Urbit. Gall is a complex system that takes a lot of getting used to, so let's dip our toes in with a simple egg-timer app.
+The Arvo operating system is divided up into modules called vanes.  Gall is the vane responsible for providing an API for building stateful applications in Urbit.  Gall is a complex system that takes a lot of getting used to, so let's dip our toes in with a simple egg-timer app.
 
+The following code sample should be saved as `/home/app/egg-timer.hoon`
+After committing: `|start egg-timer` and poke with `:egg-timer ~s10`
 
 ```hoon
+/+  default-agent
 |%
-+$  move  (pair bone card)
-+$  card  [%wait path @da]
++$  card  card:agent:gall
 --
-|_  [bowl:gall ~]
-++  poke-noun
-  |=  t=@dr
-  ^+  [*(list move) +>.$]
-  :_  +>.$  :_  ~
-  [ost %wait /egg-timer (add now t)]
-++  wake
-  |=  [=wire error=(unit tang)]
-  ^+  [*(list move) +>.$]
+::
+^-  agent:gall
+|_  =bowl:gall
++*  this  .
+    def   ~(. (default-agent this %.n) bowl)
+::
+++  on-poke
+  |=  [=mark =vase]
+  ^-  (quip card _this)
+  =/   t   !<(@dr vase)
+  :_  this
+  [%pass /egg-timer %arvo %b %wait (add now.bowl t)]~
+::
+++  on-arvo
+  ^+  on-arvo:*agent:gall
+  |=  [=wire =sign-arvo]
+  ^-  (quip card _this)
   ~&  "Timer went off!"
-  [~ +>.$]
+  [~ this]
+::
+++  on-init   on-init:def
+++  on-save   on-save:def
+++  on-load   on-load:def
+++  on-watch  on-watch:def
+++  on-leave  on-leave:def
+++  on-peek   on-peek:def
+++  on-agent  on-agent:def
+++  on-fail   on-fail:def
 --
 ```
 
-The first thing to notice is that we are creating a `core` (`|%`) and a `door` (`|_`). This is a typical style of Gall programming where your types are defined in the first `core` and your application is defined in the following `door`.
+The first thing to notice is that we are creating a core (`|%`) and a door (`|_`).  This is a typical style for Gall programming wherein types are defined in the first core and your application is defined in the following door.
+Our door will have type `agent:gall` as specified in `sys/zuse.hoon`
 
 ```hoon
 |%
-+$  move  (pair bone card)
-+$  card  [%wait path @da]
++$  card  card:agent:gall
 --
 ```
 
-The `core` here defines two types: `move` and `card`. A `move` is a `pair` of `bone` and `card`. A `bone` is a Gall-only type that identifies app event chains by mapping atoms to them. We define `card` to be a request to Arvo to do something for us. In this case, the only valid `card` will be `%wait` which we'll discuss in a bit.
+The core here defines only one type: `card`. 
+A `card` is a request to Arvo to do something for us.  In this case, the only card used will be a `%wait` request to Behn which we'll discuss later.
 
-It's important to note that the names `move` and `card` are technically arbitrary; you can call them whatever you'd like. By convention, however, you will see them called `move` and `card` practically everywhere.
+It's important to note that the name `card` is technically arbitrary.  By convention, however, you will see it called `card` practically everywhere.
 
-The sample of the `door` is:
+The sample of the door(`|_`) is:
 
 ```hoon
-[bowl:gall ~]
+=bowl:gall
 ```
 
-You can find the full definition of `bowl` in `sys/zuse.hoon`, but for now it's enough to know that this is the default app state and includes various faces for information. Below are some important such faces:
+You can find the full definition of `bowl` in `sys/zuse.hoon`, but for now it's enough to know that includes contextual data used by Gall with particular faces.  Below are some important such faces:
 
 - `our`  The ship this code is running on
 - `src`  The ship the current event originated from
-- `ost`  A reference to the current chain of events
 - `eny`  Guaranteed-fresh entropy
 - `now`  The current time
 
-The `door` we've made has two [arms](/docs/glossary/arm/) `poke-noun` and `wake`. Gall is capable of dispatching `pokes`, or requests, to an app based on the mark of the data given along with that poke. These are sent to the [arm](/docs/glossary/arm/) with the name that matches the mark of the data. Here we use the generic `noun` mark:
+We give `bowl:gall` the face `bowl`.
+Additionally, we use `+*` to create two structures for future use:
 
 ```hoon
-++  poke-noun
-  |=  t=@dr
-  ^+  [*(list move) +>.$]
-  :_  +>.$  :_  ~
-  [ost %wait /egg-timer (add now t)]
++*  this  .
+    def   ~(. (default-agent this %.n) bowl)
 ```
+`this` is our current context(the door).
+`def` uses `default-agent` to produce a standard `gall:agent` door, from which we will instance default definitions for our unused arms.
 
-In the above code, we create a [gate](/docs/glossary/gate/) that takes a single `@dr` argument. `@dr` is an aura for a 128-bit relative date. Here are a few examples.
-
-- `~s17`  17 seconds
-- `~m20`  20 minutes
-- `~d42`  42 days
-
-As a matter of good type hygiene, we explicitly cast the output of this gate with `^+` to ensure we are producing the correct thing for Gall to handle. `^+` is the rune for casting by example. Our example is a cell: `list` of `move`, which we `bunt` with `*`, is the head; `+>.$`, the enclosing [core](/docs/glossary/core/) which is our `door`, is the tail.
-
-Next we're going to use the `:_` rune which is just the inverted form a `:-` the cell construction rune. We use it twice so the actual data will end up looking something like:
+All Gall agents have a fixed set of 10 arms.  In this trivial case, we will specify only two and use the default definitions from `default-agent` for the remaining arms.
 
 ```hoon
-[[[ost %wait /egg-timer (add now t)] ~] +>.$]
+++  on-poke
+  |=  [=mark =vase]
+  ^-  (quip card _this)
+  =/   t   !<(@dr vase)
+  :_  this
+  [%pass /egg-timer %arvo %b %wait (add now.bowl t)]~
 ```
 
-`ost` is the `bone`, the opaque reference to a chain of events, that comes from `bowl`, so we're going to continue to use it here. `%wait` is the name of the `move`, in this case a request to the Behn vain to start a timer for us.
+The `++on-poke` arm evaluates to a gate which takes a sample `[mark vase]`.  `mark` is a type specification and `vase` is a cell of `[specification  value]`
+Note: since `++on-poke` may take many different samples, it would be prudent to add a `%noun` mark check here.
+In this example, we assume that our sample will contain a `@dr` and pull it from the `vase` with `=/   t   !<(@dr vase)`
+`@dr` is an aura for a 128-bit relative date. Here are a few examples.
 
-After `%wait`, we have the `path`, a `list` of `cords` that serves as the unique identifier for this `move`:
+- `~s17`    17 seconds
+- `~m20`    20 minutes
+- `~m13s37` 13 minutes, 37 seconds
+- `~d42`    42 days
 
-```
-/egg-timer
-```
+As a matter of good type hygiene, we explicitly cast the output of this gate with `^-` to ensure we are producing the correct structure for Gall to handle.
+Our specification is `(quip card _this)` which produces a type,  `[(list card) _this]`.  Note that `_this` is irregular form of `$_(this)` which normalizes to the type of `this`, our door.
 
-The `/` here is an irregular syntax to make a `path`.
-
-The final part of this `move` is:
-
-```
-(add now t)
-```
-
-`now` is the current time of type `@da`, and `t` was declared as `@dr`. Because they are both atoms, we can add `now` and `t` these two to get an atom that is `t` units of time into the future from `now`. That produced atom can be interpreted as a `@da`.
-
-That's all for our `poke-noun` arm. But what about when the timer goes off? Behn will create a `gift`, a similar construct to how we created a `card`, only this time it will end up being dispatched back to us via Gall in the `++wake` arm. Any app that wants to use a timer trigger needs to have an arm called `++wake`.
+Next we use the `:_` rune which is the inverted form of `:-`, the cell construction rune. 
 
 ```hoon
-++  wake
-  |=  [=wire error=(unit tang)]
-  ^+  [*(list move) +>.$]
+:_  this
+  [%pass /egg-timer %arvo %b %wait (add now.bowl t)]~
+```
+Our card should follow the basic form `[%pass /my/wire a-note]`
+In this case, our card will ask Arvo to `%pass` a note along the wire `/egg-timer` to Behn(`%b`) containing a `%wait` request.
+Behn will start a timer for us, and will respond along our wire, `/egg-timer`.
+
+`now.bowl` is the current time of type `@da`, and `t` was declared as `@dr`.  Because they are both atoms, we can add `now` and `t` to produce an atom that is `t` units of time into the future from `now`.  That produced atom can be interpreted as a `@da`.
+The calculated time will be passed via Arvo to Behn with instruction to `%wait @da`, i.e., to set a timer.
+
+That's all for our `++on-poke` arm.  But what about when the timer goes off?  Behn will create a `gift`, a similar construct to our `card` which will be dispatched back to us via Gall in the `++on-arvo` arm.
+
+```hoon
+++  on-arvo
+  ^+  on-arvo:*agent:gall
+  |=  [=wire =sign-arvo]
+  ^-  (quip card _this)
   ~&  "Timer went off!"
-  [~ +>.$]
+  [~ this]
 ```
+`++on-arvo` evaluates to a gate whose sample is a cell of `wire` and `sign-arvo` here given default faces.  The syntax of `=wire` is a shortcut for `wire=wire`; it's a common pattern to shadow the name of a type when you only have one instance of the type and are not going to refer to the type itself.
+A `wire` is an alias for a path.  Our `wire` will be the path  we provided in our `++on-poke` card.  If we needed to do something particular depending on which request triggered this Arvo card, we could use the wire to do so.
 
-`wake` is a `gate` that has two arguments: a `wire`, and a `(unit tang)` with the face `error`. The syntax of `=wire` is a shortcut for `wire=wire`; it's a common pattern to shadow the name of a type when you only have one instance of the type and are not going to refer to the type itself. A `wire` is just an alias for `path`. Our `wire` will be the `path` that we gave original `move`. If we needed to do something based on which request caused this gate to be called, we could use the wire to do so. In this case, we don't do perform such a dispatch.
+Note: since multiple vanes can send many sorts of cards via `++on-arvo`, it would be prudent to check if `sign-arvo` is `[%b %wake *]`.  Since our trivial example assumes the card is `%wake` from Behn, we will forgo that better practice here.
 
-Next we have the same cast we used in `++poke-noun` to make sure we are producing the correct thing for Gall. These casts are not strictly necessary, as the type system can infer what the type will be, but they can be very useful both for debugging our own code and for someone else trying to determine what our code should be producing.
-
+Next we have the same cast we used in `++on-poke` to make sure we produce the correct type for Gall.  `(quip card _this)` resolves to a type `[(list card) _this]`
 ```
 ~&  "Timer went off!"
 ```
 
-`~&` is the debugging printf rune. Here we're using it to output a message. We could, however, modify this line of code to do any other computation we would want to happen when `++wait` gets called.
+`~&` is the debugging printf rune.  Here we're using it to output a message.  We could, however, modify this line of code to do any other computation when `++on-arvo` is called.
 
-Finally, we need to produce our `move`. Here the effect is simply `[~ +>.$]`, since we have no `move` to make and we are not changing the state of our app. We just use the `door` without changing its sample.
+We need to produce a noun of type `(quip card _this)` i.e., `[(list card) _this]`.
+In this case, we will not produce any card or change application state.  Therefore we simply produce a cell of a null list and our original context, `[~ this]`.
+
+```hoon
+++  on-init   on-init:def
+++  on-save   on-save:def
+++  on-load   on-load:def
+++  on-watch  on-watch:def
+++  on-leave  on-leave:def
+++  on-peek   on-peek:def
+++  on-agent  on-agent:def
+++  on-fail   on-fail:def
+--
+```
+Finally, we define the remaining 8 unused but required Gall Agent armsas instances of the default arms provided in `/lib/default-agent.hoon`.


### PR DESCRIPTION
Complete rewrite of egg-timer.hoon example code and walkthrough, to work with static Gall.

Thanks to ~hastuc for walking me through this and ~palfun for helping with style/standards and my own understanding.

Regarding the tutorial itself, I tried to be consistent with other documentation, however I had to make best guesses in some cases. e.g., should we say `++on-poke` or `++  on poke`? Should we capitalize Core, Door, Arm?

Will require review both for style and content.