### PR TITLE
gall: remove stray ser and unify ++on-poke examples in gall tutorial

### DIFF
--- a/tutorials/arvo/gall.md
+++ b/tutorials/arvo/gall.md
@@ -162,8 +162,8 @@ Here's a skeleton example of an implementation:
 ::
 ++  on-poke
   |=  [=mark =vase]
-  ~&  state=state
-  ~&  got-poked-with-data=mark]
+  ~&  >  state=state
+  ~&  got-poked-with-data=mark
   =.  state  +(state)
   `this
 ::


### PR DESCRIPTION
Redo of https://github.com/urbit/docs/pull/846.