### PR TITLE
Clarify wing resolution part of bank-account.md explanation

### DIFF
--- a/tutorials/hoon/bank-account.md
+++ b/tutorials/hoon/bank-account.md
@@ -75,6 +75,6 @@ Each of these arms produces a gate which takes an `@ud` argument. Each of these 
 +>.$(balance (add balance amount))
 ```
 
-`+>` is [wing syntax](@/docs/reference/hoon-expressions/limb/wing.md). This particularly wing construction looks for the the tail of the tail (the third element) in `$`, the subject of the gate we are in, which is the entire `new-account` door. We change `balance` to be the result of adding `balance` and `amount` and produce the door as the result. `withdraw` functions the same way only doing subtraction instead of addition.
+`+>` is [wing syntax](@/docs/reference/hoon-expressions/limb/wing.md). This particular wing construction looks for the tail of the tail (the third element) in `$`, the subject of the gate we are in. The `withdraw` and `deposit` arms create gates with the entire `new-account` door as the context in their cores' `[battery sample context]`, in the "tail of the tail" slot. We change `balance` to be the result of adding `balance` and `amount` and produce the door as the result. `withdraw` functions the same way only doing subtraction instead of addition.
 
 It's important to notice that the sample, `balance`, is stored as part of the door rather than existing outside of it.


### PR DESCRIPTION
- fixed some grammar
- clarified the sentence about wing resolution and the fact that the arms create gates, which have the door as their subject at the time of creation.