### PR TITLE
Fix typos in the libraries tutorial

### DIFF
--- a/tutorials/hoon/libraries.md
+++ b/tutorials/hoon/libraries.md
@@ -103,9 +103,9 @@ The `?+` rune is the rune to switch against a value with a default.  The default
   |-
   ?:  (gth i 4)
     mydeck
-  =/  j  1
+  =/  j  2
   |-
-  ?.  (lte j 13)
+  ?.  (lte j 14)
     ^$(i +(i))
   %=  $
     j       +(j)
@@ -153,9 +153,9 @@ Next, with `=/  random  ~(. og entropy)`, we feed the `og` core the entropy it n
 
 `?:  =(remaining 1)` checks if have only one card remaining. If that's true, we produce a cell of `shuffled` and the one card left in `unshuffled`. We use the `:_` rune here, so that the "heavier" hoon is at the bottom of the expression.
 
-If the above conditional evaluates to false, we are going to do a little work.  `=^` is a rune that pins the head of a pair and changes the leg with a tail. It's useful for interacting with the `og` core arms, as many of them produce a pair of a random numbers and the next state of the core. We're going to put the random number in the subject with the face `index` and change `random` to be the next core.
+If the above conditional evaluates to false, we are going to do a little work.  `=^` is a rune that pins the head of a pair and changes a leg in the subject with the tail. It's useful for interacting with the `og` core arms, as many of them produce a pair of a random numbers and the next state of the core. We're going to put the random number in the subject with the face `index` and change `random` to be the next core.
 
-With completed, we use `%^` to call `$` to recurse back up to `|-` with a few changes.
+With completed, we use `%=` to call `$` to recurse back up to `|-` with a few changes.
 
 `shuffled` gets the `darc` from `unshuffled` at `index` added to the front of it.
 


### PR DESCRIPTION
- In the `make-deck` walkthrough, I changed `j` to loop from 2 to 14 to correctly reflect the original code.
- In the `shuffle-deck` walkthrough, I changed the description of `=^` to be more clear. Originally, it said "changes the leg with a tail", which doesn't make much sense. I changed this to say "changes a leg in the subject with the tail".
- The `shuffle-deck` walkthrough also said that the code used the `%^` rune for recursion. I changed this to `%=` to match the code.