### PR TITLE
Fix weld example output

### DIFF
--- a/reference/library/2b.md
+++ b/reference/library/2b.md
@@ -1262,7 +1262,7 @@ Concatenate two `++list`s `a` and `b`.
 
 ```
     > (weld "urb" "it")
-    ~[~~u ~~r ~~b ~~i ~~t]
+    "urbit"
 
     > (weld (limo [1 2 ~]) (limo [3 4 ~]))
     ~[1 2 3 4]


### PR DESCRIPTION
The output of `(weld "urb" "it")` is incorrect.