### PR TITLE
Add links to library docs 1a-2a

### DIFF
--- a/reference/library/1a.md
+++ b/reference/library/1a.md
@@ -12,13 +12,13 @@ Produces the sum of `a` and `b`.
 
 #### Accepts
 
-`a` is an [`atom`]('/docs/glossary/atom').
+`a` is an [`atom`](/docs/glossary/atom).
 
-`b` is an [`atom`]('/docs/glossary/atom').
+`b` is an [`atom`](/docs/glossary/atom).
 
 #### Produces
 
-An [`atom`]('/docs/glossary/atom').
+An [`atom`](/docs/glossary/atom).
 
 #### Source
 
@@ -65,11 +65,11 @@ Decrements `a` by `1`.
 
 #### Accepts
 
-`a` is an [`atom`]('/docs/glossary/atom').
+`a` is an [`atom`](/docs/glossary/atom).
 
 #### Produces
 
-An [`atom`]('/docs/glossary/atom').
+An [`atom`](/docs/glossary/atom).
 
 #### Source
 
@@ -116,13 +116,13 @@ Computes `a` divided by `b` without remainder.
 
 #### Accepts
 
-`a` is an [`atom`]('/docs/glossary/atom').
+`a` is an [`atom`](/docs/glossary/atom).
 
-`b` is an [`atom`]('/docs/glossary/atom').
+`b` is an [`atom`](/docs/glossary/atom).
 
 #### Produces
 
-An [`atom`]('/docs/glossary/atom').
+An [`atom`](/docs/glossary/atom).
 
 #### Source
 
@@ -171,13 +171,13 @@ Computes `a` divided by `b`, producing the quotient and the remainder.
 
 #### Accepts
 
-`a` is an [`atom`]('/docs/glossary/atom').
+`a` is an [`atom`](/docs/glossary/atom).
 
-`b` is an [`atom`]('/docs/glossary/atom').
+`b` is an [`atom`](/docs/glossary/atom).
 
 #### Produces
 
-A cell of [`atoms`]('/docs/glossary/atom').
+A cell of [`atoms`](/docs/glossary/atom).
 
 #### Source
 
@@ -221,9 +221,9 @@ Tests whether `a` is greater than or equal to `b`.
 
 #### Accepts
 
-`a` is an [`atom`]('/docs/glossary/atom').
+`a` is an [`atom`](/docs/glossary/atom).
 
-`b` is an [`atom`]('/docs/glossary/atom').
+`b` is an [`atom`](/docs/glossary/atom).
 
 #### Produces
 
@@ -261,9 +261,9 @@ Tests whether `a` is greater than `b`.
 
 #### Accepts
 
-`a` is an [`atom`]('/docs/glossary/atom').
+`a` is an [`atom`](/docs/glossary/atom).
 
-`b` is an [`atom`]('/docs/glossary/atom').
+`b` is an [`atom`](/docs/glossary/atom).
 
 #### Produces
 
@@ -302,9 +302,9 @@ Tests whether `a` is less than or equal to `b`.
 
 #### Accepts
 
-`a` is an [`atom`]('/docs/glossary/atom').
+`a` is an [`atom`](/docs/glossary/atom).
 
-`b` is an [`atom`]('/docs/glossary/atom').
+`b` is an [`atom`](/docs/glossary/atom).
 
 #### Produces
 
@@ -359,9 +359,9 @@ Tests whether `a` is less than `b`.
 
 #### Accepts
 
-`a` is an [`atom`]('/docs/glossary/atom').
+`a` is an [`atom`](/docs/glossary/atom).
 
-`b` is an [`atom`]('/docs/glossary/atom').
+`b` is an [`atom`](/docs/glossary/atom).
 
 #### Produces
 
@@ -417,13 +417,13 @@ Computes the greater of `a` and `b`.
 
 #### Accepts
 
-`a` is an [`atom`]('/docs/glossary/atom').
+`a` is an [`atom`](/docs/glossary/atom).
 
-`b` is an [`atom`]('/docs/glossary/atom').
+`b` is an [`atom`](/docs/glossary/atom).
 
 #### Produces
 
-An [`atom`]('/docs/glossary/atom').
+An [`atom`](/docs/glossary/atom).
 
 #### Source
 
@@ -473,13 +473,13 @@ Computes the lesser of `a` and `b`.
 
 #### Accepts
 
-`a` is an [`atom`]('/docs/glossary/atom').
+`a` is an [`atom`](/docs/glossary/atom).
 
-`b` is an [`atom`]('/docs/glossary/atom').
+`b` is an [`atom`](/docs/glossary/atom).
 
 #### Produces
 
-An [`atom`]('/docs/glossary/atom').
+An [`atom`](/docs/glossary/atom).
 
 #### Source
 
@@ -527,13 +527,13 @@ Computes the remainder of dividing `a` by `b`.
 
 #### Accepts
 
-`a` is an [`atom`]('/docs/glossary/atom').
+`a` is an [`atom`](/docs/glossary/atom).
 
-`b` is an [`atom`]('/docs/glossary/atom').
+`b` is an [`atom`](/docs/glossary/atom).
 
 #### Produces
 
-An [`atom`]('/docs/glossary/atom').
+An [`atom`](/docs/glossary/atom).
 
 #### Source
 
@@ -578,13 +578,13 @@ Multiplies `a` by `b`.
 
 #### Accepts
 
-`a` is an [`atom`]('/docs/glossary/atom').
+`a` is an [`atom`](/docs/glossary/atom).
 
-`b` is an [`atom`]('/docs/glossary/atom').
+`b` is an [`atom`](/docs/glossary/atom).
 
 #### Produces
 
-An [`atom`]('/docs/glossary/atom').
+An [`atom`](/docs/glossary/atom).
 
 #### Source
 
@@ -629,13 +629,13 @@ Subtracts `b` from `a`.
 
 #### Accepts
 
-`a` is an [`atom`]('/docs/glossary/atom').
+`a` is an [`atom`](/docs/glossary/atom).
 
-`b` is an [`atom`]('/docs/glossary/atom').
+`b` is an [`atom`](/docs/glossary/atom).
 
 #### Produces
 
-An [`atom`]('/docs/glossary/atom').
+An [`atom`](/docs/glossary/atom).
 
 #### Source
 

--- a/reference/library/1a.md
+++ b/reference/library/1a.md
@@ -12,13 +12,13 @@ Produces the sum of `a` and `b`.
 
 #### Accepts
 
-`a` is an atom.
+`a` is an [`atom`]('/docs/glossary/atom').
 
-`b` is an atom.
+`b` is an [`atom`]('/docs/glossary/atom').
 
 #### Produces
 
-An atom.
+An [`atom`]('/docs/glossary/atom').
 
 #### Source
 
@@ -65,11 +65,11 @@ Decrements `a` by `1`.
 
 #### Accepts
 
-`a` is an atom.
+`a` is an [`atom`]('/docs/glossary/atom').
 
 #### Produces
 
-An atom.
+An [`atom`]('/docs/glossary/atom').
 
 #### Source
 
@@ -116,13 +116,13 @@ Computes `a` divided by `b` without remainder.
 
 #### Accepts
 
-`a` is an atom.
+`a` is an [`atom`]('/docs/glossary/atom').
 
-`b` is an atom.
+`b` is an [`atom`]('/docs/glossary/atom').
 
 #### Produces
 
-An atom.
+An [`atom`]('/docs/glossary/atom').
 
 #### Source
 
@@ -171,13 +171,13 @@ Computes `a` divided by `b`, producing the quotient and the remainder.
 
 #### Accepts
 
-`a` is an atom.
+`a` is an [`atom`]('/docs/glossary/atom').
 
-`b` is an atom.
+`b` is an [`atom`]('/docs/glossary/atom').
 
 #### Produces
 
-A cell of atoms.
+A cell of [`atoms`]('/docs/glossary/atom').
 
 #### Source
 
@@ -221,9 +221,9 @@ Tests whether `a` is greater than or equal to `b`.
 
 #### Accepts
 
-`a` is an atom.
+`a` is an [`atom`]('/docs/glossary/atom').
 
-`b` is an atom.
+`b` is an [`atom`]('/docs/glossary/atom').
 
 #### Produces
 
@@ -261,9 +261,9 @@ Tests whether `a` is greater than `b`.
 
 #### Accepts
 
-`a` is an atom.
+`a` is an [`atom`]('/docs/glossary/atom').
 
-`b` is an atom.
+`b` is an [`atom`]('/docs/glossary/atom').
 
 #### Produces
 
@@ -302,9 +302,9 @@ Tests whether `a` is less than or equal to `b`.
 
 #### Accepts
 
-`a` is an atom.
+`a` is an [`atom`]('/docs/glossary/atom').
 
-`b` is an atom.
+`b` is an [`atom`]('/docs/glossary/atom').
 
 #### Produces
 
@@ -359,9 +359,9 @@ Tests whether `a` is less than `b`.
 
 #### Accepts
 
-`a` is an atom.
+`a` is an [`atom`]('/docs/glossary/atom').
 
-`b` is an atom.
+`b` is an [`atom`]('/docs/glossary/atom').
 
 #### Produces
 
@@ -417,13 +417,13 @@ Computes the greater of `a` and `b`.
 
 #### Accepts
 
-`a` is an atom.
+`a` is an [`atom`]('/docs/glossary/atom').
 
-`b` is an atom.
+`b` is an [`atom`]('/docs/glossary/atom').
 
 #### Produces
 
-An atom.
+An [`atom`]('/docs/glossary/atom').
 
 #### Source
 
@@ -473,13 +473,13 @@ Computes the lesser of `a` and `b`.
 
 #### Accepts
 
-`a` is an atom.
+`a` is an [`atom`]('/docs/glossary/atom').
 
-`b` is an atom.
+`b` is an [`atom`]('/docs/glossary/atom').
 
 #### Produces
 
-An atom.
+An [`atom`]('/docs/glossary/atom').
 
 #### Source
 
@@ -527,13 +527,13 @@ Computes the remainder of dividing `a` by `b`.
 
 #### Accepts
 
-`a` is an atom.
+`a` is an [`atom`]('/docs/glossary/atom').
 
-`b` is an atom.
+`b` is an [`atom`]('/docs/glossary/atom').
 
 #### Produces
 
-An atom.
+An [`atom`]('/docs/glossary/atom').
 
 #### Source
 
@@ -578,13 +578,13 @@ Multiplies `a` by `b`.
 
 #### Accepts
 
-`a` is an atom.
+`a` is an [`atom`]('/docs/glossary/atom').
 
-`b` is an atom.
+`b` is an [`atom`]('/docs/glossary/atom').
 
 #### Produces
 
-An atom.
+An [`atom`]('/docs/glossary/atom').
 
 #### Source
 
@@ -629,13 +629,13 @@ Subtracts `b` from `a`.
 
 #### Accepts
 
-`a` is an atom.
+`a` is an [`atom`]('/docs/glossary/atom').
 
-`b` is an atom.
+`b` is an [`atom`]('/docs/glossary/atom').
 
 #### Produces
 
-An atom.
+An [`atom`]('/docs/glossary/atom').
 
 #### Source
 

--- a/reference/library/1a.md
+++ b/reference/library/1a.md
@@ -12,13 +12,13 @@ Produces the sum of `a` and `b`.
 
 #### Accepts
 
-`a` is an [`atom`](/docs/glossary/atom).
+`a` is an [`atom`](@/docs/glossary/atom.md).
 
-`b` is an [`atom`](/docs/glossary/atom).
+`b` is an [`atom`](@/docs/glossary/atom.md).
 
 #### Produces
 
-An [`atom`](/docs/glossary/atom).
+An [`atom`](@/docs/glossary/atom.md).
 
 #### Source
 
@@ -65,11 +65,11 @@ Decrements `a` by `1`.
 
 #### Accepts
 
-`a` is an [`atom`](/docs/glossary/atom).
+`a` is an [`atom`](@/docs/glossary/atom.md).
 
 #### Produces
 
-An [`atom`](/docs/glossary/atom).
+An [`atom`](@/docs/glossary/atom.md).
 
 #### Source
 
@@ -116,13 +116,13 @@ Computes `a` divided by `b` without remainder.
 
 #### Accepts
 
-`a` is an [`atom`](/docs/glossary/atom).
+`a` is an [`atom`](@/docs/glossary/atom.md).
 
-`b` is an [`atom`](/docs/glossary/atom).
+`b` is an [`atom`](@/docs/glossary/atom.md).
 
 #### Produces
 
-An [`atom`](/docs/glossary/atom).
+An [`atom`](@/docs/glossary/atom.md).
 
 #### Source
 
@@ -171,13 +171,13 @@ Computes `a` divided by `b`, producing the quotient and the remainder.
 
 #### Accepts
 
-`a` is an [`atom`](/docs/glossary/atom).
+`a` is an [`atom`](@/docs/glossary/atom.md).
 
-`b` is an [`atom`](/docs/glossary/atom).
+`b` is an [`atom`](@/docs/glossary/atom.md).
 
 #### Produces
 
-A cell of [`atoms`](/docs/glossary/atom).
+A cell of [`atoms`](@/docs/glossary/atom.md).
 
 #### Source
 
@@ -221,9 +221,9 @@ Tests whether `a` is greater than or equal to `b`.
 
 #### Accepts
 
-`a` is an [`atom`](/docs/glossary/atom).
+`a` is an [`atom`](@/docs/glossary/atom.md).
 
-`b` is an [`atom`](/docs/glossary/atom).
+`b` is an [`atom`](@/docs/glossary/atom.md).
 
 #### Produces
 
@@ -261,9 +261,9 @@ Tests whether `a` is greater than `b`.
 
 #### Accepts
 
-`a` is an [`atom`](/docs/glossary/atom).
+`a` is an [`atom`](@/docs/glossary/atom.md).
 
-`b` is an [`atom`](/docs/glossary/atom).
+`b` is an [`atom`](@/docs/glossary/atom.md).
 
 #### Produces
 
@@ -302,9 +302,9 @@ Tests whether `a` is less than or equal to `b`.
 
 #### Accepts
 
-`a` is an [`atom`](/docs/glossary/atom).
+`a` is an [`atom`](@/docs/glossary/atom.md).
 
-`b` is an [`atom`](/docs/glossary/atom).
+`b` is an [`atom`](@/docs/glossary/atom.md).
 
 #### Produces
 
@@ -359,9 +359,9 @@ Tests whether `a` is less than `b`.
 
 #### Accepts
 
-`a` is an [`atom`](/docs/glossary/atom).
+`a` is an [`atom`](@/docs/glossary/atom.md).
 
-`b` is an [`atom`](/docs/glossary/atom).
+`b` is an [`atom`](@/docs/glossary/atom.md).
 
 #### Produces
 
@@ -417,13 +417,13 @@ Computes the greater of `a` and `b`.
 
 #### Accepts
 
-`a` is an [`atom`](/docs/glossary/atom).
+`a` is an [`atom`](@/docs/glossary/atom.md).
 
-`b` is an [`atom`](/docs/glossary/atom).
+`b` is an [`atom`](@/docs/glossary/atom.md).
 
 #### Produces
 
-An [`atom`](/docs/glossary/atom).
+An [`atom`](@/docs/glossary/atom.md).
 
 #### Source
 
@@ -473,13 +473,13 @@ Computes the lesser of `a` and `b`.
 
 #### Accepts
 
-`a` is an [`atom`](/docs/glossary/atom).
+`a` is an [`atom`](@/docs/glossary/atom.md).
 
-`b` is an [`atom`](/docs/glossary/atom).
+`b` is an [`atom`](@/docs/glossary/atom.md).
 
 #### Produces
 
-An [`atom`](/docs/glossary/atom).
+An [`atom`](@/docs/glossary/atom.md).
 
 #### Source
 
@@ -527,13 +527,13 @@ Computes the remainder of dividing `a` by `b`.
 
 #### Accepts
 
-`a` is an [`atom`](/docs/glossary/atom).
+`a` is an [`atom`](@/docs/glossary/atom.md).
 
-`b` is an [`atom`](/docs/glossary/atom).
+`b` is an [`atom`](@/docs/glossary/atom.md).
 
 #### Produces
 
-An [`atom`](/docs/glossary/atom).
+An [`atom`](@/docs/glossary/atom.md).
 
 #### Source
 
@@ -578,13 +578,13 @@ Multiplies `a` by `b`.
 
 #### Accepts
 
-`a` is an [`atom`](/docs/glossary/atom).
+`a` is an [`atom`](@/docs/glossary/atom.md).
 
-`b` is an [`atom`](/docs/glossary/atom).
+`b` is an [`atom`](@/docs/glossary/atom.md).
 
 #### Produces
 
-An [`atom`](/docs/glossary/atom).
+An [`atom`](@/docs/glossary/atom.md).
 
 #### Source
 
@@ -629,13 +629,13 @@ Subtracts `b` from `a`.
 
 #### Accepts
 
-`a` is an [`atom`](/docs/glossary/atom).
+`a` is an [`atom`](@/docs/glossary/atom.md).
 
-`b` is an [`atom`](/docs/glossary/atom).
+`b` is an [`atom`](@/docs/glossary/atom.md).
 
 #### Produces
 
-An [`atom`](/docs/glossary/atom).
+An [`atom`](@/docs/glossary/atom.md).
 
 #### Source
 

--- a/reference/library/1b.md
+++ b/reference/library/1b.md
@@ -11,18 +11,18 @@ information on the tree-addressing system.
 
 Tree head
 
-Tests whether the tree address `a` is in the head or the tail of a [`noun`](/docs/glossary/noun).
-Produces the constant [`atom`](/docs/glossary/atom) `%2` if it is within the head (subtree `+2`), or
-the constant [`atom`](/docs/glossary/atom) `%3` if it is within the tail (subtree `+3`).
+Tests whether the tree address `a` is in the head or the tail of a [`noun`](@/docs/glossary/noun.md).
+Produces the constant [`atom`](@/docs/glossary/atom.md) `%2` if it is within the head (subtree `+2`), or
+the constant [`atom`](@/docs/glossary/atom.md) `%3` if it is within the tail (subtree `+3`).
 
 
 #### Accepts
 
-`a` is an [`atom`](/docs/glossary/atom).
+`a` is an [`atom`](@/docs/glossary/atom.md).
 
 #### Produces
 
-A constant [`atom`](/docs/glossary/atom).
+A constant [`atom`](@/docs/glossary/atom.md).
 
 #### Source
 
@@ -70,16 +70,16 @@ A constant [`atom`](/docs/glossary/atom).
 
 Address within head/tail
 
-Computes the tree address of [`atom`](/docs/glossary/atom) `a` within either the head (`+2`) or tail
-(`+3`) of a [`noun`](/docs/glossary/noun).
+Computes the tree address of [`atom`](@/docs/glossary/atom.md) `a` within either the head (`+2`) or tail
+(`+3`) of a [`noun`](@/docs/glossary/noun.md).
 
 #### Accepts
 
-`a` is an [`atom`](/docs/glossary/atom).
+`a` is an [`atom`](@/docs/glossary/atom.md).
 
 #### Produces
 
-An [`atom`](/docs/glossary/atom).
+An [`atom`](@/docs/glossary/atom.md).
 
 #### Source
 
@@ -144,7 +144,7 @@ An [`atom`](/docs/glossary/atom).
      (continues...)
 ```
 
-Running `(mas 7)` in the [`Dojo`](/docs/glossary/dojo) will return `3`, because address `+3` is what
+Running `(mas 7)` in the [`Dojo`](@/docs/glossary/dojo.md) will return `3`, because address `+3` is what
 `+7` now occupies. The tree below helps illustrate the relationship. With
 parentheses are `a` values (if `a` is in subtree `+3`), and without parentheses
 are the values returned with `(mas a)`.
@@ -175,13 +175,13 @@ Computes the absolute address of `b`, a relative address within the subtree
 
 #### Accepts
 
-`a` is an [`atom`](/docs/glossary/atom).
+`a` is an [`atom`](@/docs/glossary/atom.md).
 
-`b` is an [`atom`](/docs/glossary/atom).
+`b` is an [`atom`](@/docs/glossary/atom.md).
 
 #### Produces
 
-An [`atom`](/docs/glossary/atom).
+An [`atom`](@/docs/glossary/atom.md).
 
 #### Source
 
@@ -232,7 +232,7 @@ right (starting with root `+1`, head `+2`, and tail `+3`). Relative address
 `b` is found with respect to `a`, and then its absolute address, within the
 greater tree, is returned.
 
-Running `(peg 3 4)` in the [`Dojo`](/docs/glossary/dojo), for example, will return `12`. Looking at
+Running `(peg 3 4)` in the [`Dojo`](@/docs/glossary/dojo.md), for example, will return `12`. Looking at
 a tree diagram makes it easy to see why.
 
 ```

--- a/reference/library/1b.md
+++ b/reference/library/1b.md
@@ -11,18 +11,18 @@ information on the tree-addressing system.
 
 Tree head
 
-Tests whether the tree address `a` is in the head or the tail of a noun.
-Produces the constant atom `%2` if it is within the head (subtree `+2`), or
-the constant atom `%3` if it is within the tail (subtree `+3`).
+Tests whether the tree address `a` is in the head or the tail of a [`noun`]('/docs/glossary/noun').
+Produces the constant [`atom`]('/docs/glossary/atom') `%2` if it is within the head (subtree `+2`), or
+the constant [`atom`]('/docs/glossary/atom') `%3` if it is within the tail (subtree `+3`).
 
 
 #### Accepts
 
-`a` is an atom.
+`a` is an [`atom`]('/docs/glossary/atom').
 
 #### Produces
 
-A constant atom.
+A constant [`atom`]('/docs/glossary/atom').
 
 #### Source
 
@@ -70,16 +70,16 @@ A constant atom.
 
 Address within head/tail
 
-Computes the tree address of atom `a` within either the head (`+2`) or tail
-(`+3`) of a noun.
+Computes the tree address of [`atom`]('/docs/glossary/atom') `a` within either the head (`+2`) or tail
+(`+3`) of a [`noun`]('/docs/glossary/noun').
 
 #### Accepts
 
-`a` is an atom.
+`a` is an [`atom`]('/docs/glossary/atom').
 
 #### Produces
 
-An atom.
+An [`atom`]('/docs/glossary/atom').
 
 #### Source
 
@@ -144,7 +144,7 @@ An atom.
      (continues...)
 ```
 
-Running `(mas 7)` in the Dojo will return `3`, because address `+3` is what
+Running `(mas 7)` in the [`Dojo`]('/docs/glossary/dojo') will return `3`, because address `+3` is what
 `+7` now occupies. The tree below helps illustrate the relationship. With
 parentheses are `a` values (if `a` is in subtree `+3`), and without parentheses
 are the values returned with `(mas a)`.
@@ -175,13 +175,13 @@ Computes the absolute address of `b`, a relative address within the subtree
 
 #### Accepts
 
-`a` is an atom.
+`a` is an [`atom`]('/docs/glossary/atom').
 
-`b` is an atom.
+`b` is an [`atom`]('/docs/glossary/atom').
 
 #### Produces
 
-An atom.
+An [`atom`]('/docs/glossary/atom').
 
 #### Source
 
@@ -232,7 +232,7 @@ right (starting with root `+1`, head `+2`, and tail `+3`). Relative address
 `b` is found with respect to `a`, and then its absolute address, within the
 greater tree, is returned.
 
-Running `(peg 3 4)` in the Dojo, for example, will return `12`. Looking at
+Running `(peg 3 4)` in the [`Dojo`]('/docs/glossary/dojo'), for example, will return `12`. Looking at
 a tree diagram makes it easy to see why.
 
 ```

--- a/reference/library/1b.md
+++ b/reference/library/1b.md
@@ -11,7 +11,7 @@ information on the tree-addressing system.
 
 Tree head
 
-Tests whether the tree address `a` is in the head or the tail of a [`noun`]('/docs/glossary/noun').
+Tests whether the tree address `a` is in the head or the tail of a [`noun`](/docs/glossary/noun).
 Produces the constant [`atom`](/docs/glossary/atom) `%2` if it is within the head (subtree `+2`), or
 the constant [`atom`](/docs/glossary/atom) `%3` if it is within the tail (subtree `+3`).
 

--- a/reference/library/1b.md
+++ b/reference/library/1b.md
@@ -12,17 +12,17 @@ information on the tree-addressing system.
 Tree head
 
 Tests whether the tree address `a` is in the head or the tail of a [`noun`]('/docs/glossary/noun').
-Produces the constant [`atom`]('/docs/glossary/atom') `%2` if it is within the head (subtree `+2`), or
-the constant [`atom`]('/docs/glossary/atom') `%3` if it is within the tail (subtree `+3`).
+Produces the constant [`atom`](/docs/glossary/atom) `%2` if it is within the head (subtree `+2`), or
+the constant [`atom`](/docs/glossary/atom) `%3` if it is within the tail (subtree `+3`).
 
 
 #### Accepts
 
-`a` is an [`atom`]('/docs/glossary/atom').
+`a` is an [`atom`](/docs/glossary/atom).
 
 #### Produces
 
-A constant [`atom`]('/docs/glossary/atom').
+A constant [`atom`](/docs/glossary/atom).
 
 #### Source
 
@@ -70,16 +70,16 @@ A constant [`atom`]('/docs/glossary/atom').
 
 Address within head/tail
 
-Computes the tree address of [`atom`]('/docs/glossary/atom') `a` within either the head (`+2`) or tail
-(`+3`) of a [`noun`]('/docs/glossary/noun').
+Computes the tree address of [`atom`](/docs/glossary/atom) `a` within either the head (`+2`) or tail
+(`+3`) of a [`noun`](/docs/glossary/noun).
 
 #### Accepts
 
-`a` is an [`atom`]('/docs/glossary/atom').
+`a` is an [`atom`](/docs/glossary/atom).
 
 #### Produces
 
-An [`atom`]('/docs/glossary/atom').
+An [`atom`](/docs/glossary/atom).
 
 #### Source
 
@@ -144,7 +144,7 @@ An [`atom`]('/docs/glossary/atom').
      (continues...)
 ```
 
-Running `(mas 7)` in the [`Dojo`]('/docs/glossary/dojo') will return `3`, because address `+3` is what
+Running `(mas 7)` in the [`Dojo`](/docs/glossary/dojo) will return `3`, because address `+3` is what
 `+7` now occupies. The tree below helps illustrate the relationship. With
 parentheses are `a` values (if `a` is in subtree `+3`), and without parentheses
 are the values returned with `(mas a)`.
@@ -175,13 +175,13 @@ Computes the absolute address of `b`, a relative address within the subtree
 
 #### Accepts
 
-`a` is an [`atom`]('/docs/glossary/atom').
+`a` is an [`atom`](/docs/glossary/atom).
 
-`b` is an [`atom`]('/docs/glossary/atom').
+`b` is an [`atom`](/docs/glossary/atom).
 
 #### Produces
 
-An [`atom`]('/docs/glossary/atom').
+An [`atom`](/docs/glossary/atom).
 
 #### Source
 
@@ -232,7 +232,7 @@ right (starting with root `+1`, head `+2`, and tail `+3`). Relative address
 `b` is found with respect to `a`, and then its absolute address, within the
 greater tree, is returned.
 
-Running `(peg 3 4)` in the [`Dojo`]('/docs/glossary/dojo'), for example, will return `12`. Looking at
+Running `(peg 3 4)` in the [`Dojo`](/docs/glossary/dojo), for example, will return `12`. Looking at
 a tree diagram makes it easy to see why.
 
 ```

--- a/reference/library/1c.md
+++ b/reference/library/1c.md
@@ -8,7 +8,7 @@ template = "doc.html"
 
 Blocksize
 
-Atom representing block size. A block of size `a` has a bitwidth of `2^a`.
+[`Atom`]('/docs/glossary/atom') representing block size. A block of size `a` has a bitwidth of `2^a`.
 
 #### Source
 
@@ -97,7 +97,7 @@ A mold generator. Produces a discriminated fork between two types, defaulting to
 
 Function
 
-A core with one arm, `$`--the empty name--which transforms a sample noun into a
+A [`core`]('/docs/glossary/core') with one arm, `$`--the empty name--which transforms a sample noun into a
 product noun. If used dryly as a type, the subject must have a sample type of
 `*`.
 
@@ -130,7 +130,7 @@ A `gate` is analogous to a function in other programming languages. We created
 this new jargon because other constructs in Urbit are "functions" in the
 mathematical sense. Any `gate` normalizes to an iron `gate`.
 
-See also: [`++lift`](../2a), [`++cork`](../2n)
+See also: [`++lift`](../2a#lift), [`++cork`](../2n#cork)
 
 ---
 ### `++list`
@@ -166,7 +166,7 @@ homogenous type.
 ```
 #### Discussion
 
-See also: [`++turn`](../2b), [`++snag`](../2b)
+See also: [`++turn`](../2b#turn), [`++snag`](../2b#snag)
 
 ---
 ### `++lone`
@@ -229,9 +229,9 @@ A mold generator. Produces a tuple of two of the types passed in.
 ---
 ### `++pole`
 
-Faceless list
+Faceless [`list`]('../1c#list')
 
-A mold generator. A `list` without the faces `i` and `t`.
+A mold generator. A [`list`]('../1c#list') without the faces `i` and `t`.
 
 #### Source
 
@@ -280,9 +280,9 @@ A mold generator. Produces a tuple of four of the types passed in.
 ---
 ### `++quip`
 
-Mold of pair of `list` and type
+Mold of pair of [`list`]('../1c#list') and type
 
-A mold generator. Produces a tuple of a `list` of `a` and the mold of `b`.
+A mold generator. Produces a tuple of a [`list`]('../1c#list') of `a` and the mold of `b`.
 
 #### Source
 
@@ -309,9 +309,9 @@ new state. You'll often see `quip` used in Gall apps.
 ---
 ### `++trap`
 
-Core with one arm `$`
+[`Core`]('/docs/glossary/core') with one arm `$`
 
-A trap is a core with one arm `$`.
+A trap is a [`core`]('/docs/glossary/core') with one arm `$`.
 
 #### Source
 
@@ -416,6 +416,6 @@ type that was passed in.
 
 Using a `unit` allows you to specify something that may not be there.
 
-See also: [`++bind`](../2b)
+See also: [`++bind`](../2b#bind)
 
 ---

--- a/reference/library/1c.md
+++ b/reference/library/1c.md
@@ -8,7 +8,7 @@ template = "doc.html"
 
 Blocksize
 
-[`Atom`](/docs/glossary/atom) representing block size. A block of size `a` has a bitwidth of `2^a`.
+[`Atom`](@/docs/glossary/atom.md) representing block size. A block of size `a` has a bitwidth of `2^a`.
 
 #### Source
 
@@ -97,7 +97,7 @@ A mold generator. Produces a discriminated fork between two types, defaulting to
 
 Function
 
-A [`core`](/docs/glossary/core) with one arm, `$`--the empty name--which transforms a sample noun into a
+A [`core`](@/docs/glossary/core) with one arm, `$`--the empty name--which transforms a sample noun into a
 product noun. If used dryly as a type, the subject must have a sample type of
 `*`.
 
@@ -130,7 +130,7 @@ A `gate` is analogous to a function in other programming languages. We created
 this new jargon because other constructs in Urbit are "functions" in the
 mathematical sense. Any `gate` normalizes to an iron `gate`.
 
-See also: [`++lift`](../2a#lift), [`++cork`](../2n#cork)
+See also: [`++lift`](@/docs/reference/library/2a.md#lift), [`++cork`](@/docs/reference/library/2n.md#cork)
 
 ---
 ### `++list`
@@ -166,7 +166,7 @@ homogenous type.
 ```
 #### Discussion
 
-See also: [`++turn`](../2b#turn), [`++snag`](../2b#snag)
+See also: [`++turn`](@/docs/reference/library/2b.md#turn), [`++snag`](@/docs/reference/library/2b.md#snag)
 
 ---
 ### `++lone`

--- a/reference/library/1c.md
+++ b/reference/library/1c.md
@@ -229,9 +229,9 @@ A mold generator. Produces a tuple of two of the types passed in.
 ---
 ### `++pole`
 
-Faceless [`list`](../1c#list)
+Faceless [`list`](@/docs/reference/library/1c#list)
 
-A mold generator. A [`list`](../1c#list) without the faces `i` and `t`.
+A mold generator. A [`list`](@/docs/reference/library/1c#list) without the faces `i` and `t`.
 
 #### Source
 
@@ -280,9 +280,9 @@ A mold generator. Produces a tuple of four of the types passed in.
 ---
 ### `++quip`
 
-Mold of pair of [`list`](../1c#list) and type
+Mold of pair of [`list`](@/docs/reference/library/1c#list) and type
 
-A mold generator. Produces a tuple of a [`list`](../1c#list) of `a` and the mold of `b`.
+A mold generator. Produces a tuple of a [`list`](@/docs/reference/library/1c#list) of `a` and the mold of `b`.
 
 #### Source
 
@@ -309,9 +309,9 @@ new state. You'll often see `quip` used in Gall apps.
 ---
 ### `++trap`
 
-[`Core`](/docs/glossary/core) with one arm `$`
+[`Core`](@/docs/glossary/core) with one arm `$`
 
-A trap is a [`core`](/docs/glossary/core) with one arm `$`.
+A trap is a [`core`](@/docs/glossary/core) with one arm `$`.
 
 #### Source
 
@@ -416,6 +416,6 @@ type that was passed in.
 
 Using a `unit` allows you to specify something that may not be there.
 
-See also: [`++bind`](../2b#bind)
+See also: [`++bind`](@/docs/reference/library/2b#bind)
 
 ---

--- a/reference/library/1c.md
+++ b/reference/library/1c.md
@@ -8,7 +8,7 @@ template = "doc.html"
 
 Blocksize
 
-[`Atom`]('/docs/glossary/atom') representing block size. A block of size `a` has a bitwidth of `2^a`.
+[`Atom`](/docs/glossary/atom) representing block size. A block of size `a` has a bitwidth of `2^a`.
 
 #### Source
 
@@ -97,7 +97,7 @@ A mold generator. Produces a discriminated fork between two types, defaulting to
 
 Function
 
-A [`core`]('/docs/glossary/core') with one arm, `$`--the empty name--which transforms a sample noun into a
+A [`core`](/docs/glossary/core) with one arm, `$`--the empty name--which transforms a sample noun into a
 product noun. If used dryly as a type, the subject must have a sample type of
 `*`.
 
@@ -229,9 +229,9 @@ A mold generator. Produces a tuple of two of the types passed in.
 ---
 ### `++pole`
 
-Faceless [`list`]('../1c#list')
+Faceless [`list`](../1c#list)
 
-A mold generator. A [`list`]('../1c#list') without the faces `i` and `t`.
+A mold generator. A [`list`](../1c#list) without the faces `i` and `t`.
 
 #### Source
 
@@ -280,9 +280,9 @@ A mold generator. Produces a tuple of four of the types passed in.
 ---
 ### `++quip`
 
-Mold of pair of [`list`]('../1c#list') and type
+Mold of pair of [`list`](../1c#list) and type
 
-A mold generator. Produces a tuple of a [`list`]('../1c#list') of `a` and the mold of `b`.
+A mold generator. Produces a tuple of a [`list`](../1c#list) of `a` and the mold of `b`.
 
 #### Source
 
@@ -309,9 +309,9 @@ new state. You'll often see `quip` used in Gall apps.
 ---
 ### `++trap`
 
-[`Core`]('/docs/glossary/core') with one arm `$`
+[`Core`](/docs/glossary/core) with one arm `$`
 
-A trap is a [`core`]('/docs/glossary/core') with one arm `$`.
+A trap is a [`core`](/docs/glossary/core) with one arm `$`.
 
 #### Source
 

--- a/reference/library/2a.md
+++ b/reference/library/2a.md
@@ -6,20 +6,20 @@ template = "doc.html"
 
 ### `++biff`
 
-[`Unit`](../1c#unit) as argument
+[`Unit`](@/docs/glossary/library/1c.md#unit) as argument
 
-Applies a function `b` that produces a [`unit`](../1c#unit) to the unwrapped value of [`unit`](../1c#unit)
+Applies a function `b` that produces a [`unit`](@/docs/glossary/library/1c.md#unit) to the unwrapped value of [`unit`](@/docs/glossary/library/1c.md#unit)
 `a` (`u.a`). If `a` is empty, `~` is produced.
 
 #### Accepts
 
-`a` is a [`unit`](../1c#unit).
+`a` is a [`unit`](@/docs/glossary/library/1c.md#unit).
 
-`b` is a function that accepts a [`noun`](/docs/glossary/noun) and produces a [`unit`](../1c#unit).
+`b` is a function that accepts a [`noun`](@/docs/glossary/noun.md) and produces a [`unit`](@/docs/glossary/library/1c.md#unit).
 
 #### Produces
 
-A [`unit`](../1c#unit).
+A [`unit`](@/docs/glossary/library/1c.md#unit).
 
 #### Source
 
@@ -44,21 +44,21 @@ A [`unit`](../1c#unit).
 ---
 ### `++bind`
 
-Non-unit function to [`unit`](../1c#unit), producing [`unit`](../1c#unit)
+Non-unit function to [`unit`](@/docs/glossary/library/1c.md#unit), producing [`unit`](@/docs/glossary/library/1c.md#unit)
 
-Applies a function `b` to the value (`u.a`) of a [`unit`](../1c#unit) `a`, producing
-a [`unit`](../1c#unit). Used when you want a function that does not accept or produce a
-[`unit`](../1c#unit) to both accept and produce a [`unit`](../1c#unit).
+Applies a function `b` to the value (`u.a`) of a [`unit`](@/docs/glossary/library/1c.md#unit) `a`, producing
+a [`unit`](@/docs/glossary/library/1c.md#unit). Used when you want a function that does not accept or produce a
+[`unit`](@/docs/glossary/library/1c.md#unit) to both accept and produce a [`unit`](@/docs/glossary/library/1c.md#unit).
 
 #### Accepts
 
-`a` is a [`unit`](../1c#unit).
+`a` is a [`unit`](@/docs/glossary/library/1c.md#unit).
 
 `b` is a function.
 
 #### Produces
 
-A [`unit`](../1c#unit).
+A [`unit`](@/docs/glossary/library/1c.md#unit).
 
 #### Source
 
@@ -87,18 +87,18 @@ A [`unit`](../1c#unit).
 
 Replace null
 
-Replaces an empty [`unit`](../1c#unit) `b` with the product of a called [`trap`](/docs/glossary/trap)
-`a`. If the [`unit`](../1c#unit) is not empty, then the original [`unit`](../1c#unit) is produced.
+Replaces an empty [`unit`](@/docs/glossary/library/1c.md#unit) `b` with the product of a called [`trap`](@/docs/glossary/trap.md)
+`a`. If the [`unit`](@/docs/glossary/library/1c.md#unit) is not empty, then the original [`unit`](@/docs/glossary/library/1c.md#unit) is produced.
 
 #### Accepts
 
-`a` is a [`trap`](/docs/glossary/trap).
+`a` is a [`trap`](@/docs/glossary/trap.md).
 
-`b` is a [`unit`](../1c#unit).
+`b` is a [`unit`](@/docs/glossary/library/1c.md#unit).
 
 #### Produces
 
-Either the product of `a` or the value inside of [`unit`](../1c#unit) `b`.
+Either the product of `a` or the value inside of [`unit`](@/docs/glossary/library/1c.md#unit) `b`.
 
 #### Source
 
@@ -126,21 +126,21 @@ Either the product of `a` or the value inside of [`unit`](../1c#unit) `b`.
 ---
 ### `++both`
 
-Group [`unit`](../1c#unit) values into pair
+Group [`unit`](@/docs/glossary/library/1c.md#unit) values into pair
 
 Produces `~` if either `a` or `b` are empty. Otherwise, produces a
-[`unit`](../1c#unit) whose value is a cell of the values of two input [`units`](../1c#unit) `a` and
+[`unit`](@/docs/glossary/library/1c.md#unit) whose value is a cell of the values of two input [`units`](@/docs/glossary/library/1c.md#unit) `a` and
 `b`.
 
 #### Accepts
 
-`a` is a [`unit`](../1c#unit).
+`a` is a [`unit`](@/docs/glossary/library/1c.md#unit).
 
-`b` is a [`unit`](../1c#unit).
+`b` is a [`unit`](@/docs/glossary/library/1c.md#unit).
 
 #### Produces
 
-A [`unit`](../1c#unit) of the two initial values.
+A [`unit`](@/docs/glossary/library/1c.md#unit) of the two initial values.
 
 #### Source
 
@@ -165,22 +165,22 @@ A [`unit`](../1c#unit) of the two initial values.
 ---
 ### `++clap`
 
-Apply function to two [`units`](../1c#unit)
+Apply function to two [`units`](@/docs/glossary/library/1c.md#unit)
 
 Applies a binary function `c`--which does not usually accept or produce a
-[`unit`](../1c#unit)-- to the values of two [`units`](../1c#unit), `a` and `b`, producing a [`unit`](../1c#unit).
+[`unit`](@/docs/glossary/library/1c.md#unit)-- to the values of two [`units`](@/docs/glossary/library/1c.md#unit), `a` and `b`, producing a [`unit`](@/docs/glossary/library/1c.md#unit).
 
 #### Accepts
 
-`a` is a [`unit`](../1c#unit).
+`a` is a [`unit`](@/docs/glossary/library/1c.md#unit).
 
-`b` is a [`unit`](../1c#unit).
+`b` is a [`unit`](@/docs/glossary/library/1c.md#unit).
 
 `c` is a function that performs a binary operation.
 
 #### Produces
 
-A [`unit`](../1c#unit).
+A [`unit`](@/docs/glossary/library/1c.md#unit).
 
 #### Source
 
@@ -212,13 +212,13 @@ A [`unit`](../1c#unit).
 ---
 ### `++drop`
 
-[`Unit`](../1c#unit) to list
+[`Unit`](@/docs/glossary/library/1c.md#unit) to list
 
-Makes a [`++list`](../1c#list) of the unwrapped value (`u.a`) of a [`unit`](../1c#unit) `a`.
+Makes a [`++list`](@/docs/glossary/library/1c.md#list) of the unwrapped value (`u.a`) of a [`unit`](@/docs/glossary/library/1c.md#unit) `a`.
 
 #### Accepts
 
-`a` is a [`unit`](../1c#unit).
+`a` is a [`unit`](@/docs/glossary/library/1c.md#unit).
 
 #### Produces
 
@@ -249,19 +249,19 @@ A list.
 ---
 ### `++fall`
 
-Give [`unit`](../1c#unit) a default value
+Give [`unit`](@/docs/glossary/library/1c.md#unit) a default value
 
-Produces a default value `b` for a [`unit`](../1c#unit) `a` in cases where `a` is null.
+Produces a default value `b` for a [`unit`](@/docs/glossary/library/1c.md#unit) `a` in cases where `a` is null.
 
 #### Accepts
 
-`a` is a [`unit`](../1c#unit).
+`a` is a [`unit`](@/docs/glossary/library/1c.md#unit).
 
-`b` is a [`noun`](/docs/glossary/noun) that's used as the default value.
+`b` is a [`noun`](@/docs/glossary/noun.md) that's used as the default value.
 
 #### Produces
 
-Either a [`noun`](/docs/glossary/noun) `b` or the unwrapped value of [`unit`](../1c#unit) `a`.
+Either a [`noun`](@/docs/glossary/noun.md) `b` or the unwrapped value of [`unit`](@/docs/glossary/library/1c.md#unit) `a`.
 
 #### Source
 
@@ -285,19 +285,19 @@ Either a [`noun`](/docs/glossary/noun) `b` or the unwrapped value of [`unit`](..
 
 Curried bind
 
-Accepts a `++gate` `a` and produces a function that accepts [`unit`](../1c#unit)
+Accepts a `++gate` `a` and produces a function that accepts [`unit`](@/docs/glossary/library/1c.md#unit)
 `b` to which it applies `a`. Used when you want a function that does not accept
-or produce a [`unit`](../1c#unit) to both accept and produce a [`unit`](../1c#unit).
+or produce a [`unit`](@/docs/glossary/library/1c.md#unit) to both accept and produce a [`unit`](@/docs/glossary/library/1c.md#unit).
 
 #### Accepts
 
 `a` is a gate.
 
-`b` is a [`unit`](../1c#unit).
+`b` is a [`unit`](@/docs/glossary/library/1c.md#unit).
 
 #### Produces
 
-A [`unit`](../1c#unit).
+A [`unit`](@/docs/glossary/library/1c.md#unit).
 
 #### Source
 
@@ -324,7 +324,7 @@ A [`unit`](../1c#unit).
 
 Choose
 
-Accepts two [`units`](../1c#unit) `a` and `b` whose values are expected to be
+Accepts two [`units`](@/docs/glossary/library/1c.md#unit) `a` and `b` whose values are expected to be
 equivalent. If either is empty, then the value of the other is produced.
 If neither are empty, it asserts that both values are the same and
 produces that value. If the assertion fails, `++mate` crashes with
@@ -332,13 +332,13 @@ produces that value. If the assertion fails, `++mate` crashes with
 
 #### Accepts
 
-`a` is a [`unit`](../1c#unit).
+`a` is a [`unit`](@/docs/glossary/library/1c.md#unit).
 
-`b` is a [`unit`](../1c#unit).
+`b` is a [`unit`](@/docs/glossary/library/1c.md#unit).
 
 #### Produces
 
-A [`unit`](../1c#unit) or crash.
+A [`unit`](@/docs/glossary/library/1c.md#unit) or crash.
 
 #### Source
 
@@ -374,13 +374,13 @@ A [`unit`](../1c#unit) or crash.
 ---
 ### `++need`
 
-Unwrap [`unit`](../1c#unit)
+Unwrap [`unit`](@/docs/glossary/library/1c.md#unit)
 
-Retrieve the value from a [`unit`](../1c#unit) and crash if the [`unit`](../1c#unit) is null.
+Retrieve the value from a [`unit`](@/docs/glossary/library/1c.md#unit) and crash if the [`unit`](@/docs/glossary/library/1c.md#unit) is null.
 
 #### Accepts
 
-`a` is a [`unit`](../1c#unit).
+`a` is a [`unit`](@/docs/glossary/library/1c.md#unit).
 
 #### Produces
 
@@ -415,17 +415,17 @@ Either the unwrapped value of `a` (`u.a`), or crash.
 ---
 ### `++some`
 
-Wrap value in a [`unit`](../1c#unit)
+Wrap value in a [`unit`](@/docs/glossary/library/1c.md#unit)
 
-Takes any [`noun`](/docs/glossary/noun) `a` and produces a [`unit`](../1c#unit) with the value set to `a`.
+Takes any [`noun`](@/docs/glossary/noun.md) `a` and produces a [`unit`](@/docs/glossary/library/1c.md#unit) with the value set to `a`.
 
 #### Accepts
 
-`a` is a [`noun`](/docs/glossary/noun).
+`a` is a [`noun`](@/docs/glossary/noun.md).
 
 #### Produces
 
-A [`unit`](../1c#unit).
+A [`unit`](@/docs/glossary/library/1c.md#unit).
 
 #### Source
 

--- a/reference/library/2a.md
+++ b/reference/library/2a.md
@@ -6,20 +6,20 @@ template = "doc.html"
 
 ### `++biff`
 
-Unit as argument
+[`Unit`]('../1c#unit') as argument
 
-Applies a function `b` that produces a unit to the unwrapped value of ++unit
+Applies a function `b` that produces a [`unit`]('../1c#unit') to the unwrapped value of [`unit`]('../1c#unit')
 `a` (`u.a`). If `a` is empty, `~` is produced.
 
 #### Accepts
 
-`a` is a unit.
+`a` is a [`unit`]('../1c#unit').
 
-`b` is a function that accepts a noun and produces a unit.
+`b` is a function that accepts a [`noun`]('/docs/glossary/noun') and produces a [`unit`]('../1c#unit').
 
 #### Produces
 
-A unit.
+A [`unit`]('../1c#unit').
 
 #### Source
 
@@ -44,21 +44,21 @@ A unit.
 ---
 ### `++bind`
 
-Non-unit function to unit, producing unit
+Non-unit function to [`unit`]('../1c#unit'), producing [`unit`]('../1c#unit')
 
-Applies a function `b` to the value (`u.a`) of a ++unit `a`, producing
-a unit. Used when you want a function that does not accept or produce a
-unit to both accept and produce a unit.
+Applies a function `b` to the value (`u.a`) of a [`unit`]('../1c#unit') `a`, producing
+a [`unit`]('../1c#unit'). Used when you want a function that does not accept or produce a
+[`unit`]('../1c#unit') to both accept and produce a [`unit`]('../1c#unit').
 
 #### Accepts
 
-`a` is a unit.
+`a` is a [`unit`]('../1c#unit').
 
 `b` is a function.
 
 #### Produces
 
-A unit.
+A [`unit`]('../1c#unit').
 
 #### Source
 
@@ -87,18 +87,18 @@ A unit.
 
 Replace null
 
-Replaces an empty ++unit `b` with the product of a called trap
-`a`. If the unit is not empty, then the original unit is produced.
+Replaces an empty [`unit`]('../1c#unit') `b` with the product of a called [`trap`]('/docs/glossary/trap')
+`a`. If the [`unit`]('../1c#unit') is not empty, then the original [`unit`]('../1c#unit') is produced.
 
 #### Accepts
 
-`a` is a trap.
+`a` is a [`trap`]('/docs/glossary/trap').
 
-`b` is a unit.
+`b` is a [`unit`]('../1c#unit').
 
 #### Produces
 
-Either the product of `a` or the value inside of unit `b`.
+Either the product of `a` or the value inside of [`unit`]('../1c#unit') `b`.
 
 #### Source
 
@@ -126,21 +126,21 @@ Either the product of `a` or the value inside of unit `b`.
 ---
 ### `++both`
 
-Group unit values into pair
+Group [`unit`]('../1c#unit') values into pair
 
 Produces `~` if either `a` or `b` are empty. Otherwise, produces a
-++unit whose value is a cell of the values of two input units `a` and
+[`unit`]('../1c#unit') whose value is a cell of the values of two input [`units`]('../1c#unit') `a` and
 `b`.
 
 #### Accepts
 
-`a` is a unit.
+`a` is a [`unit`]('../1c#unit').
 
-`b` is a unit.
+`b` is a [`unit`]('../1c#unit').
 
 #### Produces
 
-A unit of the two initial values.
+A [`unit`]('../1c#unit') of the two initial values.
 
 #### Source
 
@@ -165,22 +165,22 @@ A unit of the two initial values.
 ---
 ### `++clap`
 
-Apply function to two units
+Apply function to two [`units`]('../1c#unit')
 
 Applies a binary function `c`--which does not usually accept or produce a
-`++unit`-- to the values of two units, `a` and `b`, producing a unit.
+[`unit`]('../1c#unit')-- to the values of two [`units`]('../1c#unit'), `a` and `b`, producing a [`unit`]('../1c#unit').
 
 #### Accepts
 
-`a` is a unit.
+`a` is a [`unit`]('../1c#unit').
 
-`b` is a unit.
+`b` is a [`unit`]('../1c#unit').
 
 `c` is a function that performs a binary operation.
 
 #### Produces
 
-A unit.
+A [`unit`]('../1c#unit').
 
 #### Source
 
@@ -212,13 +212,13 @@ A unit.
 ---
 ### `++drop`
 
-Unit to list
+[`Unit`]('../1c#unit') to list
 
-Makes a ++list of the unwrapped value (`u.a`) of a `++unit` `a`.
+Makes a [`++list`]('../1c#list) of the unwrapped value (`u.a`) of a [`unit`]('../1c#unit') `a`.
 
 #### Accepts
 
-`a` is a unit.
+`a` is a [`unit`]('../1c#unit').
 
 #### Produces
 
@@ -249,19 +249,19 @@ A list.
 ---
 ### `++fall`
 
-Give unit a default value
+Give [`unit`]('../1c#unit') a default value
 
-Produces a default value `b` for a `++unit` `a` in cases where `a` is null.
+Produces a default value `b` for a [`unit`]('../1c#unit') `a` in cases where `a` is null.
 
 #### Accepts
 
-`a` is a unit.
+`a` is a [`unit`]('../1c#unit').
 
-`b` is a noun that's used as the default value.
+`b` is a [`noun`]('/docs/glossary/noun') that's used as the default value.
 
 #### Produces
 
-Either a noun `b` or the unwrapped value of unit `a`.
+Either a [`noun`]('/docs/glossary/noun') `b` or the unwrapped value of [`unit`]('../1c#unit') `a`.
 
 #### Source
 
@@ -285,19 +285,19 @@ Either a noun `b` or the unwrapped value of unit `a`.
 
 Curried bind
 
-Accepts a `++gate` `a` and produces a function that accepts `++unit`
+Accepts a `++gate` `a` and produces a function that accepts [`unit`]('../1c#unit')
 `b` to which it applies `a`. Used when you want a function that does not accept
-or produce a unit to both accept and produce a unit.
+or produce a [`unit`]('../1c#unit') to both accept and produce a [`unit`]('../1c#unit').
 
 #### Accepts
 
 `a` is a gate.
 
-`b` is a unit.
+`b` is a [`unit`]('../1c#unit').
 
 #### Produces
 
-A unit.
+A [`unit`]('../1c#unit').
 
 #### Source
 
@@ -324,7 +324,7 @@ A unit.
 
 Choose
 
-Accepts two units `a` and `b` whose values are expected to be
+Accepts two [`units`]('../1c#unit') `a` and `b` whose values are expected to be
 equivalent. If either is empty, then the value of the other is produced.
 If neither are empty, it asserts that both values are the same and
 produces that value. If the assertion fails, `++mate` crashes with
@@ -332,13 +332,13 @@ produces that value. If the assertion fails, `++mate` crashes with
 
 #### Accepts
 
-`a` is a unit.
+`a` is a [`unit`]('../1c#unit').
 
-`b` is a unit.
+`b` is a [`unit`]('../1c#unit').
 
 #### Produces
 
-A unit or crash.
+A [`unit`]('../1c#unit') or crash.
 
 #### Source
 
@@ -374,13 +374,13 @@ A unit or crash.
 ---
 ### `++need`
 
-Unwrap unit
+Unwrap [`unit`]('../1c#unit')
 
-Retrieve the value from a `++unit` and crash if the unit is null.
+Retrieve the value from a [`unit`]('../1c#unit') and crash if the [`unit`]('../1c#unit') is null.
 
 #### Accepts
 
-`a` is a unit.
+`a` is a [`unit`]('../1c#unit').
 
 #### Produces
 
@@ -415,17 +415,17 @@ Either the unwrapped value of `a` (`u.a`), or crash.
 ---
 ### `++some`
 
-Wrap value in a unit
+Wrap value in a [`unit`]('../1c#unit')
 
-Takes any noun `a` and produces a `++unit` with the value set to `a`.
+Takes any [`noun`]('/docs/glossary/noun') `a` and produces a [`unit`]('../1c#unit') with the value set to `a`.
 
 #### Accepts
 
-`a` is a noun.
+`a` is a [`noun`]('/docs/glossary/noun').
 
 #### Produces
 
-A unit.
+A [`unit`]('../1c#unit').
 
 #### Source
 

--- a/reference/library/2a.md
+++ b/reference/library/2a.md
@@ -6,20 +6,20 @@ template = "doc.html"
 
 ### `++biff`
 
-[`Unit`]('../1c#unit') as argument
+[`Unit`](../1c#unit) as argument
 
-Applies a function `b` that produces a [`unit`]('../1c#unit') to the unwrapped value of [`unit`]('../1c#unit')
+Applies a function `b` that produces a [`unit`](../1c#unit) to the unwrapped value of [`unit`](../1c#unit)
 `a` (`u.a`). If `a` is empty, `~` is produced.
 
 #### Accepts
 
-`a` is a [`unit`]('../1c#unit').
+`a` is a [`unit`](../1c#unit).
 
-`b` is a function that accepts a [`noun`]('/docs/glossary/noun') and produces a [`unit`]('../1c#unit').
+`b` is a function that accepts a [`noun`](/docs/glossary/noun) and produces a [`unit`](../1c#unit).
 
 #### Produces
 
-A [`unit`]('../1c#unit').
+A [`unit`](../1c#unit).
 
 #### Source
 
@@ -44,21 +44,21 @@ A [`unit`]('../1c#unit').
 ---
 ### `++bind`
 
-Non-unit function to [`unit`]('../1c#unit'), producing [`unit`]('../1c#unit')
+Non-unit function to [`unit`](../1c#unit), producing [`unit`](../1c#unit)
 
-Applies a function `b` to the value (`u.a`) of a [`unit`]('../1c#unit') `a`, producing
-a [`unit`]('../1c#unit'). Used when you want a function that does not accept or produce a
-[`unit`]('../1c#unit') to both accept and produce a [`unit`]('../1c#unit').
+Applies a function `b` to the value (`u.a`) of a [`unit`](../1c#unit) `a`, producing
+a [`unit`](../1c#unit). Used when you want a function that does not accept or produce a
+[`unit`](../1c#unit) to both accept and produce a [`unit`](../1c#unit).
 
 #### Accepts
 
-`a` is a [`unit`]('../1c#unit').
+`a` is a [`unit`](../1c#unit).
 
 `b` is a function.
 
 #### Produces
 
-A [`unit`]('../1c#unit').
+A [`unit`](../1c#unit).
 
 #### Source
 
@@ -87,18 +87,18 @@ A [`unit`]('../1c#unit').
 
 Replace null
 
-Replaces an empty [`unit`]('../1c#unit') `b` with the product of a called [`trap`]('/docs/glossary/trap')
-`a`. If the [`unit`]('../1c#unit') is not empty, then the original [`unit`]('../1c#unit') is produced.
+Replaces an empty [`unit`](../1c#unit) `b` with the product of a called [`trap`](/docs/glossary/trap)
+`a`. If the [`unit`](../1c#unit) is not empty, then the original [`unit`](../1c#unit) is produced.
 
 #### Accepts
 
-`a` is a [`trap`]('/docs/glossary/trap').
+`a` is a [`trap`](/docs/glossary/trap).
 
-`b` is a [`unit`]('../1c#unit').
+`b` is a [`unit`](../1c#unit).
 
 #### Produces
 
-Either the product of `a` or the value inside of [`unit`]('../1c#unit') `b`.
+Either the product of `a` or the value inside of [`unit`](../1c#unit) `b`.
 
 #### Source
 
@@ -126,21 +126,21 @@ Either the product of `a` or the value inside of [`unit`]('../1c#unit') `b`.
 ---
 ### `++both`
 
-Group [`unit`]('../1c#unit') values into pair
+Group [`unit`](../1c#unit) values into pair
 
 Produces `~` if either `a` or `b` are empty. Otherwise, produces a
-[`unit`]('../1c#unit') whose value is a cell of the values of two input [`units`]('../1c#unit') `a` and
+[`unit`](../1c#unit) whose value is a cell of the values of two input [`units`](../1c#unit) `a` and
 `b`.
 
 #### Accepts
 
-`a` is a [`unit`]('../1c#unit').
+`a` is a [`unit`](../1c#unit).
 
-`b` is a [`unit`]('../1c#unit').
+`b` is a [`unit`](../1c#unit).
 
 #### Produces
 
-A [`unit`]('../1c#unit') of the two initial values.
+A [`unit`](../1c#unit) of the two initial values.
 
 #### Source
 
@@ -165,22 +165,22 @@ A [`unit`]('../1c#unit') of the two initial values.
 ---
 ### `++clap`
 
-Apply function to two [`units`]('../1c#unit')
+Apply function to two [`units`](../1c#unit)
 
 Applies a binary function `c`--which does not usually accept or produce a
-[`unit`]('../1c#unit')-- to the values of two [`units`]('../1c#unit'), `a` and `b`, producing a [`unit`]('../1c#unit').
+[`unit`](../1c#unit)-- to the values of two [`units`](../1c#unit), `a` and `b`, producing a [`unit`](../1c#unit).
 
 #### Accepts
 
-`a` is a [`unit`]('../1c#unit').
+`a` is a [`unit`](../1c#unit).
 
-`b` is a [`unit`]('../1c#unit').
+`b` is a [`unit`](../1c#unit).
 
 `c` is a function that performs a binary operation.
 
 #### Produces
 
-A [`unit`]('../1c#unit').
+A [`unit`](../1c#unit).
 
 #### Source
 
@@ -212,13 +212,13 @@ A [`unit`]('../1c#unit').
 ---
 ### `++drop`
 
-[`Unit`]('../1c#unit') to list
+[`Unit`](../1c#unit) to list
 
-Makes a [`++list`]('../1c#list) of the unwrapped value (`u.a`) of a [`unit`]('../1c#unit') `a`.
+Makes a [`++list`](../1c#list) of the unwrapped value (`u.a`) of a [`unit`](../1c#unit) `a`.
 
 #### Accepts
 
-`a` is a [`unit`]('../1c#unit').
+`a` is a [`unit`](../1c#unit).
 
 #### Produces
 
@@ -249,19 +249,19 @@ A list.
 ---
 ### `++fall`
 
-Give [`unit`]('../1c#unit') a default value
+Give [`unit`](../1c#unit) a default value
 
-Produces a default value `b` for a [`unit`]('../1c#unit') `a` in cases where `a` is null.
+Produces a default value `b` for a [`unit`](../1c#unit) `a` in cases where `a` is null.
 
 #### Accepts
 
-`a` is a [`unit`]('../1c#unit').
+`a` is a [`unit`](../1c#unit).
 
-`b` is a [`noun`]('/docs/glossary/noun') that's used as the default value.
+`b` is a [`noun`](/docs/glossary/noun) that's used as the default value.
 
 #### Produces
 
-Either a [`noun`]('/docs/glossary/noun') `b` or the unwrapped value of [`unit`]('../1c#unit') `a`.
+Either a [`noun`](/docs/glossary/noun) `b` or the unwrapped value of [`unit`](../1c#unit) `a`.
 
 #### Source
 
@@ -285,19 +285,19 @@ Either a [`noun`]('/docs/glossary/noun') `b` or the unwrapped value of [`unit`](
 
 Curried bind
 
-Accepts a `++gate` `a` and produces a function that accepts [`unit`]('../1c#unit')
+Accepts a `++gate` `a` and produces a function that accepts [`unit`](../1c#unit)
 `b` to which it applies `a`. Used when you want a function that does not accept
-or produce a [`unit`]('../1c#unit') to both accept and produce a [`unit`]('../1c#unit').
+or produce a [`unit`](../1c#unit) to both accept and produce a [`unit`](../1c#unit).
 
 #### Accepts
 
 `a` is a gate.
 
-`b` is a [`unit`]('../1c#unit').
+`b` is a [`unit`](../1c#unit).
 
 #### Produces
 
-A [`unit`]('../1c#unit').
+A [`unit`](../1c#unit).
 
 #### Source
 
@@ -324,7 +324,7 @@ A [`unit`]('../1c#unit').
 
 Choose
 
-Accepts two [`units`]('../1c#unit') `a` and `b` whose values are expected to be
+Accepts two [`units`](../1c#unit) `a` and `b` whose values are expected to be
 equivalent. If either is empty, then the value of the other is produced.
 If neither are empty, it asserts that both values are the same and
 produces that value. If the assertion fails, `++mate` crashes with
@@ -332,13 +332,13 @@ produces that value. If the assertion fails, `++mate` crashes with
 
 #### Accepts
 
-`a` is a [`unit`]('../1c#unit').
+`a` is a [`unit`](../1c#unit).
 
-`b` is a [`unit`]('../1c#unit').
+`b` is a [`unit`](../1c#unit).
 
 #### Produces
 
-A [`unit`]('../1c#unit') or crash.
+A [`unit`](../1c#unit) or crash.
 
 #### Source
 
@@ -374,13 +374,13 @@ A [`unit`]('../1c#unit') or crash.
 ---
 ### `++need`
 
-Unwrap [`unit`]('../1c#unit')
+Unwrap [`unit`](../1c#unit)
 
-Retrieve the value from a [`unit`]('../1c#unit') and crash if the [`unit`]('../1c#unit') is null.
+Retrieve the value from a [`unit`](../1c#unit) and crash if the [`unit`](../1c#unit) is null.
 
 #### Accepts
 
-`a` is a [`unit`]('../1c#unit').
+`a` is a [`unit`](../1c#unit).
 
 #### Produces
 
@@ -415,17 +415,17 @@ Either the unwrapped value of `a` (`u.a`), or crash.
 ---
 ### `++some`
 
-Wrap value in a [`unit`]('../1c#unit')
+Wrap value in a [`unit`](../1c#unit)
 
-Takes any [`noun`]('/docs/glossary/noun') `a` and produces a [`unit`]('../1c#unit') with the value set to `a`.
+Takes any [`noun`](/docs/glossary/noun) `a` and produces a [`unit`](../1c#unit) with the value set to `a`.
 
 #### Accepts
 
-`a` is a [`noun`]('/docs/glossary/noun').
+`a` is a [`noun`](/docs/glossary/noun).
 
 #### Produces
 
-A [`unit`]('../1c#unit').
+A [`unit`](../1c#unit).
 
 #### Source
 

--- a/reference/library/2a.md
+++ b/reference/library/2a.md
@@ -6,20 +6,20 @@ template = "doc.html"
 
 ### `++biff`
 
-[`Unit`](@/docs/glossary/library/1c.md#unit) as argument
+[`Unit`](@/docs/reference/library/1c.md#unit) as argument
 
-Applies a function `b` that produces a [`unit`](@/docs/glossary/library/1c.md#unit) to the unwrapped value of [`unit`](@/docs/glossary/library/1c.md#unit)
+Applies a function `b` that produces a [`unit`](@/docs/reference/library/1c.md#unit) to the unwrapped value of [`unit`](@/docs/reference/library/1c.md#unit)
 `a` (`u.a`). If `a` is empty, `~` is produced.
 
 #### Accepts
 
-`a` is a [`unit`](@/docs/glossary/library/1c.md#unit).
+`a` is a [`unit`](@/docs/reference/library/1c.md#unit).
 
-`b` is a function that accepts a [`noun`](@/docs/glossary/noun.md) and produces a [`unit`](@/docs/glossary/library/1c.md#unit).
+`b` is a function that accepts a [`noun`](@/docs/glossary/noun.md) and produces a [`unit`](@/docs/reference/library/1c.md#unit).
 
 #### Produces
 
-A [`unit`](@/docs/glossary/library/1c.md#unit).
+A [`unit`](@/docs/reference/library/1c.md#unit).
 
 #### Source
 
@@ -44,21 +44,21 @@ A [`unit`](@/docs/glossary/library/1c.md#unit).
 ---
 ### `++bind`
 
-Non-unit function to [`unit`](@/docs/glossary/library/1c.md#unit), producing [`unit`](@/docs/glossary/library/1c.md#unit)
+Non-unit function to [`unit`](@/docs/reference/library/1c.md#unit), producing [`unit`](@/docs/reference/library/1c.md#unit)
 
-Applies a function `b` to the value (`u.a`) of a [`unit`](@/docs/glossary/library/1c.md#unit) `a`, producing
-a [`unit`](@/docs/glossary/library/1c.md#unit). Used when you want a function that does not accept or produce a
-[`unit`](@/docs/glossary/library/1c.md#unit) to both accept and produce a [`unit`](@/docs/glossary/library/1c.md#unit).
+Applies a function `b` to the value (`u.a`) of a [`unit`](@/docs/reference/library/1c.md#unit) `a`, producing
+a [`unit`](@/docs/reference/library/1c.md#unit). Used when you want a function that does not accept or produce a
+[`unit`](@/docs/reference/library/1c.md#unit) to both accept and produce a [`unit`](@/docs/reference/library/1c.md#unit).
 
 #### Accepts
 
-`a` is a [`unit`](@/docs/glossary/library/1c.md#unit).
+`a` is a [`unit`](@/docs/reference/library/1c.md#unit).
 
 `b` is a function.
 
 #### Produces
 
-A [`unit`](@/docs/glossary/library/1c.md#unit).
+A [`unit`](@/docs/reference/library/1c.md#unit).
 
 #### Source
 
@@ -87,18 +87,18 @@ A [`unit`](@/docs/glossary/library/1c.md#unit).
 
 Replace null
 
-Replaces an empty [`unit`](@/docs/glossary/library/1c.md#unit) `b` with the product of a called [`trap`](@/docs/glossary/trap.md)
-`a`. If the [`unit`](@/docs/glossary/library/1c.md#unit) is not empty, then the original [`unit`](@/docs/glossary/library/1c.md#unit) is produced.
+Replaces an empty [`unit`](@/docs/reference/library/1c.md#unit) `b` with the product of a called [`trap`](@/docs/glossary/trap.md)
+`a`. If the [`unit`](@/docs/reference/library/1c.md#unit) is not empty, then the original [`unit`](@/docs/reference/library/1c.md#unit) is produced.
 
 #### Accepts
 
 `a` is a [`trap`](@/docs/glossary/trap.md).
 
-`b` is a [`unit`](@/docs/glossary/library/1c.md#unit).
+`b` is a [`unit`](@/docs/reference/library/1c.md#unit).
 
 #### Produces
 
-Either the product of `a` or the value inside of [`unit`](@/docs/glossary/library/1c.md#unit) `b`.
+Either the product of `a` or the value inside of [`unit`](@/docs/reference/library/1c.md#unit) `b`.
 
 #### Source
 
@@ -126,21 +126,21 @@ Either the product of `a` or the value inside of [`unit`](@/docs/glossary/librar
 ---
 ### `++both`
 
-Group [`unit`](@/docs/glossary/library/1c.md#unit) values into pair
+Group [`unit`](@/docs/reference/library/1c.md#unit) values into pair
 
 Produces `~` if either `a` or `b` are empty. Otherwise, produces a
-[`unit`](@/docs/glossary/library/1c.md#unit) whose value is a cell of the values of two input [`units`](@/docs/glossary/library/1c.md#unit) `a` and
+[`unit`](@/docs/reference/library/1c.md#unit) whose value is a cell of the values of two input [`units`](@/docs/reference/library/1c.md#unit) `a` and
 `b`.
 
 #### Accepts
 
-`a` is a [`unit`](@/docs/glossary/library/1c.md#unit).
+`a` is a [`unit`](@/docs/reference/library/1c.md#unit).
 
-`b` is a [`unit`](@/docs/glossary/library/1c.md#unit).
+`b` is a [`unit`](@/docs/reference/library/1c.md#unit).
 
 #### Produces
 
-A [`unit`](@/docs/glossary/library/1c.md#unit) of the two initial values.
+A [`unit`](@/docs/reference/library/1c.md#unit) of the two initial values.
 
 #### Source
 
@@ -165,22 +165,22 @@ A [`unit`](@/docs/glossary/library/1c.md#unit) of the two initial values.
 ---
 ### `++clap`
 
-Apply function to two [`units`](@/docs/glossary/library/1c.md#unit)
+Apply function to two [`units`](@/docs/reference/library/1c.md#unit)
 
 Applies a binary function `c`--which does not usually accept or produce a
-[`unit`](@/docs/glossary/library/1c.md#unit)-- to the values of two [`units`](@/docs/glossary/library/1c.md#unit), `a` and `b`, producing a [`unit`](@/docs/glossary/library/1c.md#unit).
+[`unit`](@/docs/reference/library/1c.md#unit)-- to the values of two [`units`](@/docs/reference/library/1c.md#unit), `a` and `b`, producing a [`unit`](@/docs/reference/library/1c.md#unit).
 
 #### Accepts
 
-`a` is a [`unit`](@/docs/glossary/library/1c.md#unit).
+`a` is a [`unit`](@/docs/reference/library/1c.md#unit).
 
-`b` is a [`unit`](@/docs/glossary/library/1c.md#unit).
+`b` is a [`unit`](@/docs/reference/library/1c.md#unit).
 
 `c` is a function that performs a binary operation.
 
 #### Produces
 
-A [`unit`](@/docs/glossary/library/1c.md#unit).
+A [`unit`](@/docs/reference/library/1c.md#unit).
 
 #### Source
 
@@ -212,13 +212,13 @@ A [`unit`](@/docs/glossary/library/1c.md#unit).
 ---
 ### `++drop`
 
-[`Unit`](@/docs/glossary/library/1c.md#unit) to list
+[`Unit`](@/docs/reference/library/1c.md#unit) to list
 
-Makes a [`++list`](@/docs/glossary/library/1c.md#list) of the unwrapped value (`u.a`) of a [`unit`](@/docs/glossary/library/1c.md#unit) `a`.
+Makes a [`++list`](@/docs/reference/library/1c.md#list1c.md#list) of the unwrapped value (`u.a`) of a [`unit`](@/docs/reference/library/1c.md#unit) `a`.
 
 #### Accepts
 
-`a` is a [`unit`](@/docs/glossary/library/1c.md#unit).
+`a` is a [`unit`](@/docs/reference/library/1c.md#unit).
 
 #### Produces
 
@@ -249,19 +249,19 @@ A list.
 ---
 ### `++fall`
 
-Give [`unit`](@/docs/glossary/library/1c.md#unit) a default value
+Give [`unit`](@/docs/reference/library/1c.md#unit) a default value
 
-Produces a default value `b` for a [`unit`](@/docs/glossary/library/1c.md#unit) `a` in cases where `a` is null.
+Produces a default value `b` for a [`unit`](@/docs/reference/library/1c.md#unit) `a` in cases where `a` is null.
 
 #### Accepts
 
-`a` is a [`unit`](@/docs/glossary/library/1c.md#unit).
+`a` is a [`unit`](@/docs/reference/library/1c.md#unit).
 
 `b` is a [`noun`](@/docs/glossary/noun.md) that's used as the default value.
 
 #### Produces
 
-Either a [`noun`](@/docs/glossary/noun.md) `b` or the unwrapped value of [`unit`](@/docs/glossary/library/1c.md#unit) `a`.
+Either a [`noun`](@/docs/glossary/noun.md) `b` or the unwrapped value of [`unit`](@/docs/reference/library/1c.md#unit) `a`.
 
 #### Source
 
@@ -285,19 +285,19 @@ Either a [`noun`](@/docs/glossary/noun.md) `b` or the unwrapped value of [`unit`
 
 Curried bind
 
-Accepts a `++gate` `a` and produces a function that accepts [`unit`](@/docs/glossary/library/1c.md#unit)
+Accepts a `++gate` `a` and produces a function that accepts [`unit`](@/docs/reference/library/1c.md#unit)
 `b` to which it applies `a`. Used when you want a function that does not accept
-or produce a [`unit`](@/docs/glossary/library/1c.md#unit) to both accept and produce a [`unit`](@/docs/glossary/library/1c.md#unit).
+or produce a [`unit`](@/docs/reference/library/1c.md#unit) to both accept and produce a [`unit`](@/docs/reference/library/1c.md#unit).
 
 #### Accepts
 
 `a` is a gate.
 
-`b` is a [`unit`](@/docs/glossary/library/1c.md#unit).
+`b` is a [`unit`](@/docs/reference/library/1c.md#unit).
 
 #### Produces
 
-A [`unit`](@/docs/glossary/library/1c.md#unit).
+A [`unit`](@/docs/reference/library/1c.md#unit).
 
 #### Source
 
@@ -324,7 +324,7 @@ A [`unit`](@/docs/glossary/library/1c.md#unit).
 
 Choose
 
-Accepts two [`units`](@/docs/glossary/library/1c.md#unit) `a` and `b` whose values are expected to be
+Accepts two [`units`](@/docs/reference/library/1c.md#unit) `a` and `b` whose values are expected to be
 equivalent. If either is empty, then the value of the other is produced.
 If neither are empty, it asserts that both values are the same and
 produces that value. If the assertion fails, `++mate` crashes with
@@ -332,13 +332,13 @@ produces that value. If the assertion fails, `++mate` crashes with
 
 #### Accepts
 
-`a` is a [`unit`](@/docs/glossary/library/1c.md#unit).
+`a` is a [`unit`](@/docs/reference/library/1c.md#unit).
 
-`b` is a [`unit`](@/docs/glossary/library/1c.md#unit).
+`b` is a [`unit`](@/docs/reference/library/1c.md#unit).
 
 #### Produces
 
-A [`unit`](@/docs/glossary/library/1c.md#unit) or crash.
+A [`unit`](@/docs/reference/library/1c.md#unit) or crash.
 
 #### Source
 
@@ -374,13 +374,13 @@ A [`unit`](@/docs/glossary/library/1c.md#unit) or crash.
 ---
 ### `++need`
 
-Unwrap [`unit`](@/docs/glossary/library/1c.md#unit)
+Unwrap [`unit`](@/docs/reference/library/1c.md#unit)
 
-Retrieve the value from a [`unit`](@/docs/glossary/library/1c.md#unit) and crash if the [`unit`](@/docs/glossary/library/1c.md#unit) is null.
+Retrieve the value from a [`unit`](@/docs/reference/library/1c.md#unit) and crash if the [`unit`](@/docs/reference/library/1c.md#unit) is null.
 
 #### Accepts
 
-`a` is a [`unit`](@/docs/glossary/library/1c.md#unit).
+`a` is a [`unit`](@/docs/reference/library/1c.md#unit).
 
 #### Produces
 
@@ -415,9 +415,9 @@ Either the unwrapped value of `a` (`u.a`), or crash.
 ---
 ### `++some`
 
-Wrap value in a [`unit`](@/docs/glossary/library/1c.md#unit)
+Wrap value in a [`unit`](@/docs/reference/library/1c.md#unit)
 
-Takes any [`noun`](@/docs/glossary/noun.md) `a` and produces a [`unit`](@/docs/glossary/library/1c.md#unit) with the value set to `a`.
+Takes any [`noun`](@/docs/glossary/noun.md) `a` and produces a [`unit`](@/docs/reference/library/1c.md#unit) with the value set to `a`.
 
 #### Accepts
 
@@ -425,7 +425,7 @@ Takes any [`noun`](@/docs/glossary/noun.md) `a` and produces a [`unit`](@/docs/g
 
 #### Produces
 
-A [`unit`](@/docs/glossary/library/1c.md#unit).
+A [`unit`](@/docs/reference/library/1c.md#unit).
 
 #### Source
 


### PR DESCRIPTION
I've felt that the standard library docs are lacking in links between doc pages, so I've added some.

Let me know if we should standardize on whether we should be including `++` when linking within the standard library, or whether or not these links should be in `this font` or not.