### PR TITLE
Fixed description of signed integers

### DIFF
--- a/reference/library/3a.md
+++ b/reference/library/3a.md
@@ -372,12 +372,13 @@ Container core for signed integer functions.
 #### Discussion
 
 The signed-integer type is represented by the `@s` aura. Positive integers are
-represented with a two prepending `-`s, and negative integers are represented
-with two; `--1` and `-1`, respectively.
+prepended with a `--`, and negative integers are prepended with a `-`. For
+example, `--1` represents positive one, and `-1` represents negative one.
 
-Positive signed integers correspond to odd atoms of twice their absolute value,
-and negative signed integers correspond to atoms of twice their absolute value
-minus one. For example:
+Zig zag encoding is used to convert atoms to signed integers. Positive signed
+integers correspond to even atoms of twice their absolute value, and negative
+signed integers correspond to odd atoms of twice their absolute value minus
+one. For example:
 
 ```
     > `@`--4


### PR DESCRIPTION
The description of signed integers (the @s type) was previously incorrect.