### PR TITLE
fixes +edge in std library reference

### DIFF
--- a/reference/library/3g.md
+++ b/reference/library/3g.md
@@ -73,8 +73,7 @@ to parse atoms of specific auras.
 ---
 ### `++edge`
 
-Parsing output. `p` is the location of the parser, `p.q` is an obtained result
-of the parser, and `q.q` is the remainder of the `tape` to be parsed.
+Parsing location metadata. Parsing location input `p` and optional result `p.q` and parsing continuation `q.q`.
 
 #### Source
 
@@ -94,7 +93,7 @@ of the parser, and `q.q` is the remainder of the `tape` to be parsed.
 
 #### Discussion
 
-See also: [Section 2e](@/docs/reference/library/2e.md), `++rule`
+See also: [Section 3g](@/docs/reference/library/3g.md#rule), `++rule`
 
 
 ---

--- a/reference/library/3g.md
+++ b/reference/library/3g.md
@@ -73,14 +73,13 @@ to parse atoms of specific auras.
 ---
 ### `++edge`
 
-Parsing location metadata
-
-Optional result `p` and parsing continuation `q`.
+Parsing output. `p` is the location of the parser, `p.q` is an obtained result
+of the parser, and `q.q` is the remainder of the `tape` to be parsed.
 
 #### Source
 
 ```hoon
-    ++  hair  [p=@ud q=@ud]
+  ++  edge  [p=hair q=(unit [p=* q=nail])]                ::  parsing output
 ```
 
 #### Examples


### PR DESCRIPTION
It previosly had the source for `++hair` and the defintion looked wrong. I fixed
the source and rewrote what it does, though I am still not 100% certain why an
`+edge` has two `+hair`s.

Also fixed a link.

----

#