### PR TITLE
global replace of odor with aura

### DIFF
--- a/reference/library/4b.md
+++ b/reference/library/4b.md
@@ -375,9 +375,9 @@ A `++tape`.
 ---
 ### `++sand`
 
-Soft-cast by odor
+Soft-cast by aura
 
-Soft-cast validity by odor.
+Soft-cast validity by aura.
 
 #### Accepts
 
@@ -412,9 +412,9 @@ A `(unit @)`.
 ---
 ### `++sane`
 
-Check odor validity
+Check aura validity
 
-Check validity by odor. Produces a gate.
+Check validity by aura. Produces a gate.
 
 #### Accepts
 

--- a/reference/library/4j.md
+++ b/reference/library/4j.md
@@ -63,7 +63,7 @@ A an atom. XX
 
 Parse phonetic pair
 
-Parsing `++rule`. Parses an atom of odor `@pE`, a phrase of two bytes
+Parsing `++rule`. Parses an atom of aura `@pE`, a phrase of two bytes
 encoded phonetically.
 
 #### Accepts
@@ -95,7 +95,7 @@ An atom.
 
 Parse two phonetic pairs
 
-Parsing `++rule`. Parses and unscrambles an atom of odor @pF, a phrase
+Parsing `++rule`. Parses and unscrambles an atom of aura @pF, a phrase
 of two two-byte pairs that are encoded (and scrambled) phonetically.
 
 #### Accepts
@@ -131,12 +131,12 @@ An atom. XX
 
 Parse 8 phonetic bytes
 
-Parsing `++rule`. Parses an atom of odor @pG, a phrase of eight of
+Parsing `++rule`. Parses an atom of aura @pG, a phrase of eight of
 phonetic bytes.
 
 #### Accepts
 
-An atom of odor `@pG`
+An atom of aura `@pG`
 
 #### Produces
 
@@ -922,7 +922,7 @@ Parsing `++rule`. Parses exactly three lowercase letters.
 
 Parse span characters
 
-Parsing rule. Parses characters from an atom of the span odor `@ta`.
+Parsing rule. Parses characters from an atom of the span aura `@ta`.
 
 #### Accepts
 
@@ -951,7 +951,7 @@ Parsing rule. Parses characters from an atom of the span odor `@ta`.
 
 Parse non-`_` span
 
-Parsing rule. Parses all characters of the span odor `@ta` except
+Parsing rule. Parses all characters of the span aura `@ta` except
 for cab, `_`.
 
 #### Accepts
@@ -1197,7 +1197,7 @@ Parsing rule. Parses a decmial number with leading zeroes.
 
 Parse phonetic base
 
-Parsing rule. Parses an atom of odor `@p`, the phonetic base.
+Parsing rule. Parses an atom of aura `@p`, the phonetic base.
 
 #### Accepts
 

--- a/reference/library/4l.md
+++ b/reference/library/4l.md
@@ -32,7 +32,7 @@ Core containing arms that parse `++coin`.
 
 ### `++bisk:so`
 
-Parse odor-atom pair
+Parse aura-atom pair
 
 Parsing rule. Parses an unsigned integer of any permitted base,
 producing a `++dime`.
@@ -74,7 +74,7 @@ producing a `++dime`.
 
 Parse `@da`, `@dr`, `@p`, `@t`
 
-Parsing rule. Parses any atom of any of the following odors after a
+Parsing rule. Parses any atom of any of the following auras after a
 leading sig, `~` into a `++dime`: `@da`, `@dr`, `@p`,
 and `@t`, producing a `++dime`.
 

--- a/reference/library/4m.md
+++ b/reference/library/4m.md
@@ -86,13 +86,13 @@ A `tape`.
 Curried slaw
 
 Produces a `gate` that parses a `term` `txt` to an atom of the
-odor specified by `mod`.
+aura specified by `mod`.
 
 #### Accepts
 
-`mod` is a term, an atom of odor `@tas`.
+`mod` is a term, an atom of aura `@tas`.
 
-`txt` is a cord, an atom of odor `@ta`.
+`txt` is a cord, an atom of aura `@ta`.
 
 #### Produces
 
@@ -121,16 +121,16 @@ A `gate`.
 ---
 ### `++slav`
 
-Demand: parse cord with input odor
+Demand: parse cord with input aura
 
-Parses a cord `txt` to an atom of the odor specificed by `mod`.
+Parses a cord `txt` to an atom of the aura specificed by `mod`.
 Crashes if it fails to parse.
 
 #### Accepts
 
-`mod` is a term, an atom of odor `@tas`.
+`mod` is a term, an atom of aura `@tas`.
 
-`txt` is a cord, an atom of odor `@ta`.
+`txt` is a cord, an atom of aura `@ta`.
 
 #### Produces
 
@@ -166,15 +166,15 @@ The atom of a `(unit @)` from `++slaw`, or crash.
 ---
 ### `++slaw`
 
-Parse cord to input odor
+Parse cord to input aura
 
-Parses a cord `txt` to an atom of the odor specified by `mod`.
+Parses a cord `txt` to an atom of the aura specified by `mod`.
 
 #### Accepts
 
-`mod` is a term, an atom of odor `@tas`.
+`mod` is a term, an atom of aura `@tas`.
 
-`txt` is a cord, an atom of odor `@ta`.
+`txt` is a cord, an atom of aura `@ta`.
 
 #### Produces
 

--- a/reference/library/4o.md
+++ b/reference/library/4o.md
@@ -81,12 +81,12 @@ right and `0` left.
 Base type
 
 A base type that nouns are built from. A `++base` is either a noun, cell,
-boolean or null labelled with an odor.
+boolean or null labelled with an aura.
 
 #### Source
 
 ```hoon
-    ++  base  ?([%atom p=odor] %noun %cell %bean %null)     ::  axils, @ * ^ ? ~
+    ++  base  ?([%atom p=aura] %noun %cell %bean %null)     ::  axils, @ * ^ ? ~
 ```
 
 #### Examples
@@ -293,7 +293,7 @@ XX move to `++ut`
 #### Source
 
 ```hoon
-    ++  line  ,[p=[%leaf p=odor q=@] q=tile]                ::  %kelp case
+    ++  line  ,[p=[%leaf p=aura q=@] q=tile]                ::  %kelp case
 ```
 
 #### Examples

--- a/reference/library/5f.md
+++ b/reference/library/5f.md
@@ -155,7 +155,7 @@ Used primarily in crypto.
 
 Absolute date
 
-The `@da` odor designates an absolute date atom.
+The `@da` aura designates an absolute date atom.
 
 #### Source
 
@@ -165,7 +165,7 @@ The `@da` odor designates an absolute date atom.
 
 #### Examples
 
-See also: `++date`, odor reference
+See also: `++date`, aura reference
 
 ```
     > `time`~2014.1.1

--- a/reference/library/_index.md
+++ b/reference/library/_index.md
@@ -69,7 +69,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/3b/#bit-rs' title="fn to single-precision float"><code>++bit:rs</code></a>
 <a class="tooltip" href='/docs/reference/library/3b/#bit-rq' title="fn to quad-precision float"><code>++bit:rq</code></a>
 <a class="tooltip" href='/docs/reference/library/4j/#bix-ab' title="Parse hex pair"><code>++bix:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4l/#bisk-so' title="Parse odor-atom pair"><code>++bisk:so</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#bisk-so' title="Parse aura-atom pair"><code>++bisk:so</code></a>
 <a class="tooltip" href='/docs/reference/library/1c/#bloq' title="Blocksize"><code>++bloq</code></a>
 <a class="tooltip" href='/docs/reference/library/2a/#bond' title="Replace null"><code>++bond</code></a>
 <a class="tooltip" href='/docs/reference/library/4f/#boss' title="Parser modifier: LSB"><code>++boss</code></a>
@@ -546,8 +546,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/3b/#san-rh' title="Signed integer to @rh"><code>++san:rh</code></a>
 <a class="tooltip" href='/docs/reference/library/3b/#san-rs' title="Signed integer to @rs"><code>++san:rs</code></a>
 <a class="tooltip" href='/docs/reference/library/3b/#san-rq' title="Signed integer to @rq"><code>++san:rq</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#sand' title="Soft-cast by odor"><code>++sand</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#sane' title="Check odor validity"><code>++sane</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#sand' title="Soft-cast by aura"><code>++sand</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#sane' title="Check aura validity"><code>++sane</code></a>
 <a class="tooltip" href='/docs/reference/library/3b/#sb-ff' title="Sign bit"><code>++sb:ff</code></a>
 <a class="tooltip" href='/docs/reference/library/2b/#scag' title="Prefix (produce front of list)"><code>++scag</code></a>
 <a class="tooltip" href='/docs/reference/library/4g/#scan' title="Parse tape or crash"><code>++scan</code></a>
@@ -606,8 +606,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/2b/#skip' title="Produce list of elements failing boolean gate"><code>++skip</code></a>
 <a class="tooltip" href='/docs/reference/library/2b/#slag' title="Produce all elements from index in list"><code>++slag</code></a>
 <a class="tooltip" href='/docs/reference/library/4m/#slat' title="Curried slaw"><code>++slat</code></a>
-<a class="tooltip" href='/docs/reference/library/4m/#slav' title="Demand: parse cord with input odor"><code>++slav</code></a>
-<a class="tooltip" href='/docs/reference/library/4m/#slaw' title="Parse cord to input odor"><code>++slaw</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#slav' title="Demand: parse cord with input aura"><code>++slav</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#slaw' title="Parse cord to input aura"><code>++slaw</code></a>
 <a class="tooltip" href='/docs/reference/library/4m/#slay' title="Parse cord to coin"><code>++slay</code></a>
 <a class="tooltip" href='/docs/reference/library/2n/#slog' title="Deify printf"><code>++slog</code></a>
 <a class="tooltip" href='/docs/reference/library/4f/#slug' title="Use gate to parse delimited list"><code>++slug</code></a>
@@ -1402,8 +1402,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/4b/#cuss' title="To uppercase"><code>++cuss</code></a>
 <a class="tooltip" href='/docs/reference/library/4b/#mesc' title="Escape special characters"><code>++mesc</code></a>
 <a class="tooltip" href='/docs/reference/library/4b/#runt' title="Prepend n times"><code>++runt</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#sand' title="Soft-cast by odor"><code>++sand</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#sane' title="Check odor validity"><code>++sane</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#sand' title="Soft-cast by aura"><code>++sand</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#sane' title="Check aura validity"><code>++sane</code></a>
 <a class="tooltip" href='/docs/reference/library/4b/#teff' title="UTF-8 length"><code>++teff</code></a>
 <a class="tooltip" href='/docs/reference/library/4b/#trim' title="Tape split"><code>++trim</code></a>
 <a class="tooltip" href='/docs/reference/library/4b/#trip' title="Cord to tape"><code>++trip</code></a>
@@ -1631,7 +1631,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### 4l: parsing (atom parsing)
 
 <a class="tooltip" href='/docs/reference/library/4l/#so' title="Coin parser engine"><code>++so</code></a>
-<a class="tooltip" href='/docs/reference/library/4l/#bisk-so' title="Parse odor-atom pair"><code>++bisk:so</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#bisk-so' title="Parse aura-atom pair"><code>++bisk:so</code></a>
 <a class="tooltip" href='/docs/reference/library/4l/#crub-so' title="Parse @da, @dr, @p, @t"><code>++crub:so</code></a>
 <a class="tooltip" href='/docs/reference/library/4l/#nuck-so' title="Top-level coin parser"><code>++nuck:so</code></a>
 <a class="tooltip" href='/docs/reference/library/4l/#nusk-so' title="Parse coin literal with escapes"><code>++nusk:so</code></a>
@@ -1647,8 +1647,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/4m/#scot' title="Render dime as cord"><code>++scot</code></a>
 <a class="tooltip" href='/docs/reference/library/4m/#scow' title="Render dime as tape"><code>++scow</code></a>
 <a class="tooltip" href='/docs/reference/library/4m/#slat' title="Curried slaw"><code>++slat</code></a>
-<a class="tooltip" href='/docs/reference/library/4m/#slav' title="Demand: parse cord with input odor"><code>++slav</code></a>
-<a class="tooltip" href='/docs/reference/library/4m/#slaw' title="Parse cord to input odor"><code>++slaw</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#slav' title="Demand: parse cord with input aura"><code>++slav</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#slaw' title="Parse cord to input aura"><code>++slaw</code></a>
 <a class="tooltip" href='/docs/reference/library/4m/#slay' title="Parse cord to coin"><code>++slay</code></a>
 <a class="tooltip" href='/docs/reference/library/4m/#smyt' title="Render path as tank"><code>++smyt</code></a>
 <a class="tooltip" href='/docs/reference/library/4m/#spat' title="Render path as cord"><code>++spat</code></a>

--- a/reference/library/table-of-contents.md
+++ b/reference/library/table-of-contents.md
@@ -69,7 +69,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/3b/#bit-rs' title="fn to single-precision float"><code>++bit:rs</code></a>
 <a class="tooltip" href='/docs/reference/library/3b/#bit-rq' title="fn to quad-precision float"><code>++bit:rq</code></a>
 <a class="tooltip" href='/docs/reference/library/4j/#bix-ab' title="Parse hex pair"><code>++bix:ab</code></a>
-<a class="tooltip" href='/docs/reference/library/4l/#bisk-so' title="Parse odor-atom pair"><code>++bisk:so</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#bisk-so' title="Parse aura-atom pair"><code>++bisk:so</code></a>
 <a class="tooltip" href='/docs/reference/library/1c/#bloq' title="Blocksize"><code>++bloq</code></a>
 <a class="tooltip" href='/docs/reference/library/2a/#bond' title="Replace null"><code>++bond</code></a>
 <a class="tooltip" href='/docs/reference/library/4f/#boss' title="Parser modifier: LSB"><code>++boss</code></a>
@@ -547,8 +547,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/3b/#san-rh' title="Signed integer to @rh"><code>++san:rh</code></a>
 <a class="tooltip" href='/docs/reference/library/3b/#san-rs' title="Signed integer to @rs"><code>++san:rs</code></a>
 <a class="tooltip" href='/docs/reference/library/3b/#san-rq' title="Signed integer to @rq"><code>++san:rq</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#sand' title="Soft-cast by odor"><code>++sand</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#sane' title="Check odor validity"><code>++sane</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#sand' title="Soft-cast by aura"><code>++sand</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#sane' title="Check aura validity"><code>++sane</code></a>
 <a class="tooltip" href='/docs/reference/library/3b/#sb-ff' title="Sign bit"><code>++sb:ff</code></a>
 <a class="tooltip" href='/docs/reference/library/2b/#scag' title="Prefix (produce front of list)"><code>++scag</code></a>
 <a class="tooltip" href='/docs/reference/library/4g/#scan' title="Parse tape or crash"><code>++scan</code></a>
@@ -607,8 +607,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/2b/#skip' title="Produce list of elements failing boolean gate"><code>++skip</code></a>
 <a class="tooltip" href='/docs/reference/library/2b/#slag' title="Produce all elements from index in list"><code>++slag</code></a>
 <a class="tooltip" href='/docs/reference/library/4m/#slat' title="Curried slaw"><code>++slat</code></a>
-<a class="tooltip" href='/docs/reference/library/4m/#slav' title="Demand: parse cord with input odor"><code>++slav</code></a>
-<a class="tooltip" href='/docs/reference/library/4m/#slaw' title="Parse cord to input odor"><code>++slaw</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#slav' title="Demand: parse cord with input aura"><code>++slav</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#slaw' title="Parse cord to input aura"><code>++slaw</code></a>
 <a class="tooltip" href='/docs/reference/library/4m/#slay' title="Parse cord to coin"><code>++slay</code></a>
 <a class="tooltip" href='/docs/reference/library/2n/#slog' title="Deify printf"><code>++slog</code></a>
 <a class="tooltip" href='/docs/reference/library/4f/#slug' title="Use gate to parse delimited list"><code>++slug</code></a>
@@ -1401,8 +1401,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/4b/#cuss' title="To uppercase"><code>++cuss</code></a>
 <a class="tooltip" href='/docs/reference/library/4b/#mesc' title="Escape special characters"><code>++mesc</code></a>
 <a class="tooltip" href='/docs/reference/library/4b/#runt' title="Prepend n times"><code>++runt</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#sand' title="Soft-cast by odor"><code>++sand</code></a>
-<a class="tooltip" href='/docs/reference/library/4b/#sane' title="Check odor validity"><code>++sane</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#sand' title="Soft-cast by aura"><code>++sand</code></a>
+<a class="tooltip" href='/docs/reference/library/4b/#sane' title="Check aura validity"><code>++sane</code></a>
 <a class="tooltip" href='/docs/reference/library/4b/#teff' title="UTF-8 length"><code>++teff</code></a>
 <a class="tooltip" href='/docs/reference/library/4b/#trim' title="Tape split"><code>++trim</code></a>
 <a class="tooltip" href='/docs/reference/library/4b/#trip' title="Cord to tape"><code>++trip</code></a>
@@ -1630,7 +1630,7 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 ### 4l: parsing (atom parsing)
 
 <a class="tooltip" href='/docs/reference/library/4l/#so' title="Coin parser engine"><code>++so</code></a>
-<a class="tooltip" href='/docs/reference/library/4l/#bisk-so' title="Parse odor-atom pair"><code>++bisk:so</code></a>
+<a class="tooltip" href='/docs/reference/library/4l/#bisk-so' title="Parse aura-atom pair"><code>++bisk:so</code></a>
 <a class="tooltip" href='/docs/reference/library/4l/#crub-so' title="Parse @da, @dr, @p, @t"><code>++crub:so</code></a>
 <a class="tooltip" href='/docs/reference/library/4l/#nuck-so' title="Top-level coin parser"><code>++nuck:so</code></a>
 <a class="tooltip" href='/docs/reference/library/4l/#nusk-so' title="Parse coin literal with escapes"><code>++nusk:so</code></a>
@@ -1646,8 +1646,8 @@ Can be navigated [alphabetically](#alphabetical) or [by section](#by-section).
 <a class="tooltip" href='/docs/reference/library/4m/#scot' title="Render dime as cord"><code>++scot</code></a>
 <a class="tooltip" href='/docs/reference/library/4m/#scow' title="Render dime as tape"><code>++scow</code></a>
 <a class="tooltip" href='/docs/reference/library/4m/#slat' title="Curried slaw"><code>++slat</code></a>
-<a class="tooltip" href='/docs/reference/library/4m/#slav' title="Demand: parse cord with input odor"><code>++slav</code></a>
-<a class="tooltip" href='/docs/reference/library/4m/#slaw' title="Parse cord to input odor"><code>++slaw</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#slav' title="Demand: parse cord with input aura"><code>++slav</code></a>
+<a class="tooltip" href='/docs/reference/library/4m/#slaw' title="Parse cord to input aura"><code>++slaw</code></a>
 <a class="tooltip" href='/docs/reference/library/4m/#slay' title="Parse cord to coin"><code>++slay</code></a>
 <a class="tooltip" href='/docs/reference/library/4m/#smyt' title="Render path as tank"><code>++smyt</code></a>
 <a class="tooltip" href='/docs/reference/library/4m/#spat' title="Render path as cord"><code>++spat</code></a>

--- a/tutorials/arvo/eyre.md
+++ b/tutorials/arvo/eyre.md
@@ -409,7 +409,7 @@ To this object, `/main/lib/urb.js` adds helpers:
 - `send({data,mark?='json',app?=urb.app,ship?}, cb?)` delivers messages
 - `bind({path,app?=urb.app}, cb)` subscribes by path
 - `drop({path,app?=urb.app}, cb?)` pulls the subscription
-- `util` is an object containing methods for converting between JavaScript types and Hoon [atom](/docs/glossary/atom/) odors.
+- `util` is an object containing methods for converting between JavaScript types and Hoon [atom](/docs/glossary/atom/) auras.
 
 ## 3. Requests
 


### PR DESCRIPTION
This old terminology was all over the place in the standard library docs, and in
one spot on the Eyre doc. I just did a find-and-replace and didn't check
anything closely, hopefully we weren't using odor as some colorful language somewhere.

----

#