### PR TITLE
adds reference to +curr and +cury in Hoon school

### DIFF
--- a/reference/library/2n.md
+++ b/reference/library/2n.md
@@ -67,7 +67,7 @@ Build `f` such that
 ```
 
 ---
-### `++curr`
+### `++curr` {#curry}
 
 Right curry
 

--- a/tutorials/hoon/doors.md
+++ b/tutorials/hoon/doors.md
@@ -355,6 +355,10 @@ Readers with some mathematical background may notice that `~( )` expressions all
 
 Thus, you may think of the `c` door as a function for making functions.  Use the `~(arm c arg)` syntax -- `arm` defines which kind of gate is produced (i.e., which arm of the door is used to create the gate), and `arg` defines the value of `b` in that gate, which in turn affects the product value of the gate produced.
 
+The standard library provides [currying
+functionality](@/docs/reference/library/2n.md#curry) outside of the context of
+doors - see `+curr` and `+cury`.
+
 #### Creating Doors with a Modified Sample
 
 In the above example we created a door `c` with sample `b=@` and found that the initial value of `b` was `0`, the bunt value of `@`. We then created new door from `c` by modifying the value of `b`. But what if we wish to define a door with a chosen sample value directly? We make use of the `$_` rune, whose irregular form is simply `_`. To create the door `c` with the sample `b=@` set to have the value `7` in the dojo, we would write


### PR DESCRIPTION
Up until this point, I was under the impression that currying in Hoon was only
possible using doors and `%~`, which always seemed rather restrictive. I just
found `+cury` and `+curr`, and so have added a brief reference to them in the
lesson on doors, which is the only place in the Hoon tutorial that mentions
currying at the moment.

----

#