### PR TITLE
remove superfluous headers

### DIFF
--- a/reference/vane-apis/airlock.md
+++ b/reference/vane-apis/airlock.md
@@ -4,8 +4,6 @@ weight = 1
 template = "doc.html"
 +++
 
-# Airlock
-
 Airlock is the term to describe the set of APIs for interacting with a running Urbit ship from outside of the Urbit network.
 
 ## Urlock-py

--- a/reference/vane-apis/ames.md
+++ b/reference/vane-apis/ames.md
@@ -4,8 +4,6 @@ weight = 2
 template = "doc.html"
 +++
 
-# Ames
-
 In this document we describe the public interface for Ames.  Namely, we describe
 each `task` that Ames can be `%pass`ed, and which `gift`(s) Ames can `%give` in return.
 

--- a/reference/vane-apis/behn.md
+++ b/reference/vane-apis/behn.md
@@ -4,8 +4,6 @@ weight = 3
 template = "doc.html"
 +++
 
-# Behn
-
 In this document we describe the public interface for Behn. Namely, we describe
 each `task` that Behn can be `pass`ed, and which `gift`(s) Behn can `give` in return.
 

--- a/reference/vane-apis/dill.md
+++ b/reference/vane-apis/dill.md
@@ -4,8 +4,6 @@ weight = 4
 template = "doc.html"
 +++
 
-# Dill
-
 In this document we describe the public interface for Dill. Namely, we describe
 each `task` that Dill can be `pass`ed, and which `gift`(s) Dill can `give` in return.
 

--- a/reference/vane-apis/gall.md
+++ b/reference/vane-apis/gall.md
@@ -4,8 +4,6 @@ weight = 5
 template = "doc.html"
 +++
 
-# Gall
-
 ## Reference Agent
 
 This app stores a number for each user. You can increment your number, increment

--- a/reference/vane-apis/iris.md
+++ b/reference/vane-apis/iris.md
@@ -4,8 +4,6 @@ weight = 6
 template = "doc.html"
 +++
 
-# Iris
-
 In this document we describe the public interface for Iris. Namely, we describe
 each `task` that Iris can be `%pass`ed, and which `gift`(s) Iris can `%give` in
 return.

--- a/tutorials/arvo/cli-tutorial.md
+++ b/tutorials/arvo/cli-tutorial.md
@@ -1,10 +1,8 @@
 +++
-title = "Command line interface apps"
+title = "CLI apps"
 weight = 13
 template = "doc.html"
 +++
-
-# Command line interface apps
 
 ## Introduction
 

--- a/tutorials/arvo/move-trace.md
+++ b/tutorials/arvo/move-trace.md
@@ -4,15 +4,12 @@ weight = 12
 template = "doc.html"
 +++
 
-
-## Move trace tutorial
-
 In this tutorial we will run a simple "move trace" and use the output to get a
 picture of what the Arvo kernel proper does during the routine task of setting a
 timer. Some level of familiarity with the kernel is required for this section,
 which can be obtained in our [Arvo kernel tutorial](@/docs/tutorials/arvo/arvo.md#the-kernel).
 
-### Running a move trace
+## Running a move trace
 
 Ultimately, everything that happens in Arvo is reduced to Unix events, and the
 Arvo kernel acts as a sort of traffic cop for vanes and apps to talk to one
@@ -84,7 +81,7 @@ another `move` to perform and the loop begins again. Thus this move trace does
 not display information about what is going on inside of the vane or app such as
 private function calls, only what the kernel itself sees.
 
-### Interpreting the move trace
+## Interpreting the move trace
 
 In this section we will go over the move trace line-by-line, explaining how the
 move trace is printed, what each line means (including some things not found in
@@ -93,7 +90,7 @@ first few lines that should equip you well enough to unravel the rest of the
 move trace in as much detail as you desire.
 
 
-#### The call
+### The call
 
 Let's put the first part of the move trace into a diagram to make following
 along a little easier.
@@ -310,7 +307,7 @@ Gall's spider's thread with id `~.dojo_0v6.210tt.1sme1.ev3qm.qgv2e.a754u` asks B
 Behn `%give`s a `%doze` `card` to Unix, asking it to set a timer [for one second from
 now]. At this point Arvo may rest.
 
-#### The return
+### The return
 
 Now Unix sets a timer for one second, waits one second, and then informs Behn that a second has
 passed, leading to a chain of `%give` `move`s that ultimately prints


### PR DESCRIPTION
Since the title in the preamble of a document renders a header at the top of the
document, all of these listed the title twice once rendered on the site.

----

#