### PR TITLE
Correct language re jetting.

### DIFF
--- a/tutorials/vere/jetting.md
+++ b/tutorials/vere/jetting.md
@@ -600,7 +600,7 @@ ending your C code with
    return(123);
 ```
 
-is wrong and will result in a dojo error because you are returning a single atom, instead of a list of three atoms.
+is wrong and will result in a dojo error because you are returning a single atom, instead of a cell containing three atoms.
 
 Instead do one of these:
 
@@ -610,7 +610,7 @@ Instead do one of these:
      return(u3nq(a, b, c, d));  // for four atoms
 ```
 
-If you need to return a longer list, you can compose your own.  Look
+If you need to return a longer collection, you can compose your own.  Look
 at the definitions of these three functions and you will see that they
 are just recursive calls to the cell constructor `u3i_cell()` e.g.
 

--- a/tutorials/vere/jetting.md
+++ b/tutorials/vere/jetting.md
@@ -602,7 +602,7 @@ ending your C code with
    return(123);
 ```
 
-is wrong and will result in a dojo error because you are returning a single atom, instead of a cell containing three atoms.
+is wrong and will result in a dojo error because you are returning a single atom, instead of a tuple containing three atoms.
 
 Instead do one of these:
 
@@ -612,7 +612,7 @@ Instead do one of these:
      return(u3nq(a, b, c, d));  // for four atoms
 ```
 
-If you need to return a longer collection, you can compose your own.  Look
+If you need to return a longer tuple, you can compose your own.  Look
 at the definitions of these three functions and you will see that they
 are just recursive calls to the cell constructor `u3i_cell()` e.g.
 

--- a/tutorials/vere/jetting.md
+++ b/tutorials/vere/jetting.md
@@ -534,6 +534,8 @@ If you need to get the size
    u3r_met(3, a);
 ```
 
+Cells have their own set of characteristic functions for accessing interior nouns:  `u3r_cell`, `u3r_trel`, `u3r_qual`, `u3h`, `u3t`, and the like.
+
 The actual meat of the function is up to you.  What is it supposed to do?
 
 Now we move on to return semantics.

--- a/tutorials/vere/jetting.md
+++ b/tutorials/vere/jetting.md
@@ -618,6 +618,13 @@ are just recursive calls to the cell constructor `u3i_cell()` e.g.
      u3i_cell(a, u3i_cell(b, u3i_cell(c, d));
 ```
 
+This implies that, to create a list instead of a cell, you will need to append
+`u3_nul` to the appropriately-sized tuple constructor:
+
+```c
+     return(u3nt(a, b, u3_nul));    // for two atoms as a list
+```
+
 Understanding the memory model, allocation, freeing, and ownership ('transfer' vs 'retain' semantics) is important. Some info is available at [Nouns](@/docs/tutorials/vere/nouns.md).
 
 ## Compile the C code


### PR DESCRIPTION
Cell composition, not list composition, is referred to by `u3nc` _y amigos_.

`u3nc` simply composes two bare atoms:  it does not actually form a list from them.

To form a list, you have to append `u3_nul` as appropriate.