### PR TITLE
Parsing tutorial

### DIFF
--- a/reference/library/4f.md
+++ b/reference/library/4f.md
@@ -853,7 +853,7 @@ A `++rule`.
 
 
 ---
-### `++slug`
+### `++slug` {#slug}
 
 Use gate to parse delimited list
 

--- a/tutorials/arvo/parsing.md
+++ b/tutorials/arvo/parsing.md
@@ -378,7 +378,7 @@ syntax error
 
 
     
-### Parsing atoms
+## Parsing atoms
 
 [Recall](@/docs/tutorials/hoon/lists.md) that `cord`s are atoms with the aura
 `@t` and are typically used to represent strings internally as data, as atoms
@@ -388,10 +388,50 @@ analogous to `+scan` and `+rush` being analogous to `rust`. Under the hood, `+ra
 calls `+scan` after converting the input atom to a `tape`, and `+rush` does
 similary for `+rust`.
 
+## Parsing numbers
+
+Functions for parsing numbers are documented in [4j: Parsing (Bases and Base
+Digits)](@/docs/reference/library/4j.md). In particualr, `dem` is a `rule`
+for parsing decimal numbers.
+
+```
+> (scan "42" dem)
+42
+> (add 1 (scan "42" dem))
+43
+```
+
+## Other parsing tidbits
+
+Need to mention `cold`
 
 ## Parsing arithmetic expressions
 
-Functions for parsing numbers are documented in [4j: Parsing (Bases and Base
-Digits)](@/docs/reference/library/4j.md). `dim:ag` is for parsing decimal
-numbers.
+In this section we will be applying what we have learned to write a parser for
+arithmetic expressions in Hoon. That is, we will make a `rule` that takes in
+`tape`s of the form `"(2+3)*4*"` and returns `20` as a `@ud`.
 
+We call a `tape` consisting of some consistent arithmetic string of numbers,
+`+,*`, `(`, and `)` an _expression_.
+
+I probably need to figure out how to break this into a tree and do all the
+adding and multiplying at the end
+
+### Parsing expressions
+
+An expression is either a term plus an expression or a term.
+
+### Parsing terms
+
+A term is either a factor times a term or a factor.
+
+### Parsing factors
+
+A factor is either an expression surrounded by parentheses or an integer. To parse
+a factor, we first check if it is a number and apply `dem` if so, otherwise
+we strip the parentheses and apply the `rule` for parsing expressions.
+
+```
+> (scan "(5)" ;~(pose dem (ifix [lit rit] dem)))
+5
+```

--- a/tutorials/arvo/parsing.md
+++ b/tutorials/arvo/parsing.md
@@ -339,9 +339,45 @@ The syntax to combine parsers (chain them together) is
 ```
 The `rule`s are composed together using the combinator as an
 intermediate function, which takes product of a `rule` (an `edge`) and a `rule` and turns
-it into a sample (a `nail`) for the next `rule`.
+it into a sample (a `nail`) for the next `rule` to handle.
+
+### `+plug`
+
+`+plug` simply takes the `nail` in the `edge` produced by one rule and passes it
+to the next `rule`, forming a cell of the results as it proceeds.
+
+```
+> (scan "starship" ;~(plug (jest 'star') (jest 'ship')))
+['star' 'ship']
+```
+
+### `+pose`
+
+`+pose` tries each `rule` you hand it successively until it finds one that
+works.
+
+```
+> (scan "a" ;~(pose (just 'a') (just 'b')))
+'a'
+> (scan "b" ;~(pose (just 'a') (just 'b')))
+'b'
+```
+
+### `+glue`
+
+`+glue` parses a delimiter in between each `rule` and forms a cell of the
+results of each `rule`.
+
+```
+> (scan "a,b" ;~((glue com) (just 'a') (just 'b')))
+['a' 'b']
+> (scan "a,b,a" ;~((glue com) (just 'a') (just 'b')))
+{1 4}
+syntax error
+```
 
 
+    
 ### Parsing atoms
 
 [Recall](@/docs/tutorials/hoon/lists.md) that `cord`s are atoms with the aura

--- a/tutorials/arvo/parsing.md
+++ b/tutorials/arvo/parsing.md
@@ -1,0 +1,79 @@
++++
+title = "Parsing tutorial"
+weight = 12
+template = "doc.html"
++++
+
+# Parsing Tutorial
+
+This document serves as an introduction to parsing text with Hoon. No prior
+knowledge of parsing is required, and we will explain the basic structure of how
+parsing works in a purely functional language such as Hoon before moving on to
+how it is implemented in Hoon.
+
+## What is parsing?
+
+A program which takes a raw sequence of characters as an input and produces a data
+structure as an output is known as a _parser_. The data structure produced
+depends on the use case, but often it may be represented as a tree, and the
+output is thought of as a structural representation of the input. Parsers are ubiquitous in
+computing, commonly used in applications such as reading files, compiling
+source code, or understanding commands input in a command line interface.
+
+Parsing a string is rarely done all at once. Instead, it is usually done
+character-by-character, and the return contains the data structure representing
+what has been parsed thus far as well as the remainder of the string to be
+parsed. They also need to be able to fail in case the input is improperly formed.
+
+## Functional parsers
+
+How parsers are built varies greatly depending on what sort of programming
+language it is written in. As Hoon is a functional programming language, we will
+be focused on understanding _functional parsers_, also known as _combinator
+parsers_.
+
+Functional parsers are built piece by piece from simple irreducible components
+that are plugged into one another in various ways to form more complex
+parsers.
+
+The basic building blocks, or primitives, are parsers that read only a
+single character. There are frequently a few types of possible input characters,
+such as letters, numbers, and symbols. For example, `parse(integer, "1")` calls
+the parsing routine on the string `"1"` and looks for an integer, and so it
+returns the integer `1`. However, taking into account what was said above about
+parsers returning the unparsed portion of the string as well, we should
+represent this return as a tuple. So we should expect something like this:
+```
+> parse(integer, "1")
+(1, "")
+> parse(integer, "123")
+(1, "23")
+```
+What if we wish to parse the rest of the string? We would need to apply the
+`parse(integer, -)` function again:
+```
+> parse(integer, parse(integer, "123"))
+(12, "3")
+> parse(integer, parse(integer, parse(integer, "123")))
+(123, "")
+```
+So we see that we can parse strings larger than one character by stringing
+together parsing functions for single characters. Thus in addition to parsing
+functions for single input characters, we want _parser combinators_ that
+allow you to combine two or more simple parsers to form more complex ones.
+Combinators come in a few shapes and sizes, and typical operations they may
+perform would be to repeat the same parsing operation until the string is
+consumed, try a few different parsing operations until one of them works,
+or perform a sequence of parsing operations. We will see how all of this is done
+with Hoon in the [Parsing in Hoon](#parsing-in-hoon) section.
+
+# Parsing in Hoon
+
+In this section we will cover the basic types and functions that are utilized for parsing in
+Hoon, and then build some simple parsers.
+
+## Basic types
+
+hair, edge, etc
+
+## Parsing arithmetic expressions


### PR DESCRIPTION
This PR is an elaboration on @Fang- 's parser notes (https://github.com/urbit/fora-posts/blob/0535da6992f9a81c89858b6598eda4bb41da7b26/archive/posts/~2016.12.21..21.54.21..cfd1~.md)

The overall goal of this document is both to familarize developers with how parsing works in
a functional programming language and how to write parsers for Hoon in
particular.

I've attempted to write for the reader who knows Hoon but has never written a
parser before (which was my own starting point).

There are three main parts:
1.  A short section describing what a parser does and how they are implemented in
   functional programming languages.
2. A much longer section describing the particulars of writing parsers with
   Hoon.
3. A walkthrough implementing a parser that parses arithmetic expressions and
   returns what they evaluate to.

Comments on each:
1. I currently am using some (very simple) pseudocode to give an idea of how functional parsers
   work. Actually it is Haskell, but shhh. I think including some code here
   helps to illuminate how parsers are chained together, and there is chicken
   and egg problem if I did this with Hoon. That being said, the pseudocode I've
   written here feels a bit ugly to me, and I wonder if there are other things I
   could put here that would be more enlightening.

   I'm also uncertain whether I've discussed the most important things to know
   about functional parsers. Since I learned about the topic specifically to
   write this, I might have missed some totally basic things.
2. First I introduce the basic types: `hair`, `nail`, `egde`, and `rule`. Are
   there any other types worthy of inclusion here?

   Next I cover a wide variety of standard library functions. I focus in
   particular on any functions used in the arithmetic expression parser that
   follows in the third section, as well as a few others of the most commonly
   used ones. All functions introduced in Mark's parser notes are included.

   I'm consider removing the entry for `+cold`. It is used relatively frequently, but
   all I really do here for it is gesture vaguely in the direction of the CLI app
   tutorial. Its not used in the example parser at the end so I think there is an
   argument to not include it for the sake of conciseness.

   There's quite a few parser-related functions in the standard library and I
   still know relatively little about parsing, so I'd
   appreciate it if you pointed out any important ones that I may have omitted
   due to ignorance.

3. Please check that my Hoon for the parser is tastefully arranged. The way it
   is written now violates the practice of putting heavier things towards the
   bottom right now. I'd like `factor` to go above `((slug mul)...` in `+turm`
   and for `turm` to go above `((slug add)..." as well, but my code breaks when
   I do this. Given that `+pose` is supposed to try each rule until one works, I
   find this puzzling. What's going on here? Is it worth explaining?

   The "Try it out" section might be unnecessary. Thoughts?

 Should monads be mentioned?
  Given the relevance of `;~` to parsing, monads are afoot, but the
   pre-existing pattern in the documentation for monads has been to mention that
   they are there, but not elaborate any further on it. I've continued that tradition here,
   but would like some perspective on whether its useful to think about Hoon
   parsers in monadic terms before I leave it out completely.

 Lastly, the placement of the page under the Arvo folder is bad. It's not an
   Arvo-specific thing at all - this is a Hoon topic. Our issue is that the Hoon folder is reserved for
   Hoon school. So I will talk with @baudtack about this - I propose that we
   make a new folder under Hoon for Hoon school, and another folder for Hoon
   tutorials, under which this would fall. This should go in a separate PR though.


----

#