### PR TITLE
removes hall.md

### DIFF
--- a/glossary/hall.md
+++ b/glossary/hall.md
@@ -1,9 +1,0 @@
-+++
-title = "Hall"
-
-template = "doc.html"
-[extra]
-category = "arvo"
-+++
-
-**Hall** is the former backend of [Talk](../talk), which originally combined the messaging protocol with a simple user experience. It is no longer used.


### PR DESCRIPTION
Generally we've removed pages that refer to things that don't exist anymore. I
remember writing this entry when I had just started at Tlon and since it was on
the list of articles to write I didn't question why I was writing it.

----

#