### PR TITLE
Fix mint-vain error in wutlus

### DIFF
--- a/reference/hoon-expressions/rune/wut.md
+++ b/reference/hoon-expressions/rune/wut.md
@@ -366,7 +366,7 @@ If there is a case that is never taken you'll get a `mint-vain` error.
 ##### Examples
 
 ```
-~zod:dojo> =cor  |=  vat=?(%a %b)
+~zod:dojo> =cor  |=  vat=@tas
                  ?+  vat  240
                    %a  20
                    %b  42


### PR DESCRIPTION
wutlus was incorrectly listed as allowing a default with a constrained sample e.g.:
|=  vas=?(%a %b)  ?+(vas 240 %a 20 %b 42)

Corrected to have a @tas for type of vas.