### PR TITLE
Ames packet structure

### DIFF
--- a/tutorials/arvo/ames.md
+++ b/tutorials/arvo/ames.md
@@ -132,8 +132,7 @@ The 32-bit header is given by the following data:
  - 1 bit: whether the packet is encrypted or not,
  - 4 bits: unused.
  
- Every packet between Azimuth addresses are encrypted. The only unencrypted
- packets are self-signed attestation packets from 128-bit comets.
+ Every packet sent between `@p`'s is encrypted except for self-signed attestation packets from 128-bit comets.
  
 ### Body
 

--- a/tutorials/arvo/ames.md
+++ b/tutorials/arvo/ames.md
@@ -111,3 +111,42 @@ ducts as unique keys.  Stop tracking a peer by sending Ames a
 `%jilt` `$task`.
 
 Debug output can be adjusted using `%sift` and `%spew` `$task`'s.
+
+## Packet structure
+
+Ames datagram packets are handled as nouns internally by Arvo but as serial data
+by Unix. Here we document their serial structure.
+For further information, see `+encode-packet` and `+decode-packet` in `ames.hoon`.
+
+There is a 32-bit header followed by a variable width body.
+
+### Header
+
+The 32-bit header is given by the following data:
+
+ - 3 bits: Ames `protocol-version`,
+ - 20 bits: a checksum as a truncated insecure hash of the body, done with
+   `+mug`,
+ - 2 bits: the bit width of the sender address encoded as a 2-bit enum,
+ - 2 bits: the bit width of the receiver address encoded as a 2-bit enum,
+ - 1 bit: whether the packet is encrypted or not,
+ - 4 bits: unused.
+ 
+ Every packet between Azimuth addresses are encrypted. The only unencrypted
+ packets are self-signed attestation packets from 128-bit comets.
+ 
+### Body
+
+The body is of variable length and consists of three parts:
+
+ - The `@p` of the sender,
+ - The `@p` of the receiver,
+ - The payload, which is the `+jam` (i.e. serialization) of the noun `[origin content]`.
+ 
+ `origin` is the IP and port of the original sender if the packet was proxied
+ through a relay and null otherwise. `content` is a noun that is either an encrypted ack or an
+ encrypted message fragment, unless it is a comet attestation packet in which
+ case it is unencrypted.
+ 
+ The sender and receiver live outside of the jammed data section to simplify
+ packet filtering for the interpreter.

--- a/tutorials/arvo/ames.md
+++ b/tutorials/arvo/ames.md
@@ -122,7 +122,7 @@ There is a 32-bit header followed by a variable width body.
 
 ### Header
 
-The 32-bit header is given by the following data:
+The 32-bit header is given by the following data, presented in order:
 
  - 3 bits: Ames `protocol-version`,
  - 20 bits: a checksum as a truncated insecure hash of the body, done with
@@ -132,14 +132,14 @@ The 32-bit header is given by the following data:
  - 1 bit: whether the packet is encrypted or not,
  - 4 bits: unused.
  
- Every packet sent between `@p`'s is encrypted except for self-signed attestation packets from 128-bit comets.
+ Every packet sent between ships is encrypted except for self-signed attestation packets from 128-bit comets.
  
 ### Body
 
-The body is of variable length and consists of three parts:
+The body is of variable length and consists of three parts in this order:
 
- - The `@p` of the sender,
- - The `@p` of the receiver,
+ - The `@p` of the sending ship,
+ - The `@p` of the receiving ship,
  - The payload, which is the `+jam` (i.e. serialization) of the noun `[origin content]`.
  
  `origin` is the IP and port of the original sender if the packet was proxied


### PR DESCRIPTION
Just a short section on how Ames packets are structured as serial data. I will
be adding more to the Ames section over the next few weeks and this is
just a start.

I'll be focusing on information useful to the security auditors, which will
probably end up being close to having a story of the "journey of a packet" here,
which I think is what the Ames page used to have before that was made out of date.

----

#