### PR TITLE
%plea triggers %send which are in response to %born

### DIFF
--- a/reference/vane-apis/ames.md
+++ b/reference/vane-apis/ames.md
@@ -124,6 +124,11 @@ Ames also `pass`es a `%plea` `note` to another vane when it receives a message o
 "forward flow" from a peer, originally passed from one of the peer's vanes to the
 peer's Ames.
 
+Ultimately `%plea` causes `%send` `gift`(s) to be sent to Unix, which tells
+Unix to send packets. In terms of `%pass`/`%give` semantics, this is in
+response to the `%born` `task`, which came along the Unix `duct`, rather than a
+response to the `%plea`.
+
 #### Accepts
 
 ```hoon
@@ -141,8 +146,7 @@ route on the receiving ship, and `payload` is the semantic message content.
 
 #### Returns
 
-This `task` causes Ames to `give` `%send` `gift`(s) to Unix.
-
+This `task` returns no `gift`s.
 
 ## System and Lifecycle Tasks
 
@@ -157,6 +161,10 @@ Each time you start your Urbit, the Arvo kernel calls the `%born` task for Ames.
 #### Returns
 
 In response to a `%born` `task`, Ames `%give`s Jael a `%turf` `gift`.
+
+The `duct` along which `%born` comes is Ames' only duct to Unix, so `%send`
+`gift`s (which are instructions for Unix to send a packet) are also returned in
+response to `%born`.
 
 
 ### `%crud`

--- a/reference/vane-apis/ames.md
+++ b/reference/vane-apis/ames.md
@@ -116,7 +116,7 @@ This `task` returns no `gift`s.
 
 ### `%plea`
 
-`%plea` is the `task` used to send messages over Ames. It extends the
+`%plea` is the `task` used to instruct Ames to send a message. It extends the
 `%pass`/`%give` semantics across the network. As such, it is the most
 fundamental `task` in Ames and the primary reason for its existence.
 
@@ -141,7 +141,7 @@ route on the receiving ship, and `payload` is the semantic message content.
 
 #### Returns
 
-This `task` returns no `gift`s.
+This `task` causes Ames to `give` `%send` `gift`(s) to Unix.
 
 
 ## System and Lifecycle Tasks


### PR DESCRIPTION
This PR amends the Ames API doc to explain how `%plea` tasks ultimately end up
triggering Unix to send packets, which is via `%send` gifts in response to the
`%born` task.

----

#