### PR TITLE
Sample change for thread:spider

### DIFF
--- a/tutorials/hoon/hoon-school/aqua.md
+++ b/tutorials/hoon/hoon-school/aqua.md
@@ -32,7 +32,7 @@ run /ted/ph/add.hoon.  Here are the contents of that file:
 /+  *ph-io
 =,  strand=strand:spider
 ^-  thread:spider
-|=  [=bowl:spider args=vase]
+|=  args=vase
 =/  m  (strand ,vase)
 ;<  ~  bind:m  start-simple
 ;<  ~  bind:m  (raw-ship ~bud ~)


### PR DESCRIPTION
Current version gives a `%nest-fail`. The sample should be just a `vase`.