### PR TITLE
Ames - packets, diagrams, serf and king

### DIFF
--- a/glossary/comet.md
+++ b/glossary/comet.md
@@ -12,4 +12,4 @@ Comets have no presence on [Azimuth](../azimuth) and thus have no associated Urb
 
 ### Further reading
 
-- [Creating a Comet](@/using/operations/creating-a-comet.md): A guide to spinning up a comet of your own.
+- [Creating a Comet](@/using/install.md#comet): A guide to spinning up a comet of your own.

--- a/reference/library/2e.md
+++ b/reference/library/2e.md
@@ -41,7 +41,7 @@ An atom.
 
 
 ---
-### `++mug`
+### `++mug` {#mug}
 
 FNV-1a scrambler
 

--- a/reference/library/2p.md
+++ b/reference/library/2p.md
@@ -4,7 +4,7 @@ weight = 19
 template = "doc.html"
 +++
 
-### `++cue`
+### `++cue` {#cue}
 
 Unpack atom to noun
 
@@ -59,7 +59,7 @@ A noun.
 ```
 
 ---
-### `++jam`
+### `++jam` {#jam}
 
 Pack noun to atom
 

--- a/tutorials/arvo/ames.md
+++ b/tutorials/arvo/ames.md
@@ -382,12 +382,12 @@ then informs the King of the new state. The King manages snapshots of the Arvo
 state and handles I/O with Unix, among other things. The Serf only ever talks to
 the King, while the King talks with both the Serf and Unix.
 
-### Ames
+### Ames I/O submodule
 
 The King has several submodules, one of them being an Ames I/O submodule. This
 submodule is responsible for wrapping outgoing Ames packets as UDP packets, and
-looking at incoming UDP packets handed to it by Unix to ensure that they are
-valid Ames packets. It also maintains an incoming and outgoing packet queue.
+unwrapping incoming UDP packets into Ames packets and forwarding them to the
+worker. It also maintains an incoming packet queue.
 
 This division is summarized in the following diagram, describing how
 `~bacbel-tagfeb` requests a subscription to the `recipes` notebook of
@@ -403,12 +403,9 @@ Unix a `%send` `gift` containing that packet. This will be a Nock noun
 containing the `@tas` `%send` as well as the serialized packet.
 
 "Unix", in this case, is actually the King. The King receives the `%send`
-instruction, wraps the packet contained within as a UDP packet, and queues the
-UDP packet contained. Once it is time to send it (which will be determined by
-congestion control), it will go ahead and forward the packet to Unix's
-networking interface, at which point it is no longer controlled by any part of Urbit.
+instruction, wraps the packet contained within as a UDP packet, and immediately
+hands it off the the Unix network interface to be sent.
 
 Now the receiving King is handed a UDP packet by Unix. The King removes the UDP
-wrapped and checks to see that it has received a valid Ames packet. If so, it
-`+cue`s the payload and wraps it as a `%hear` `note` and passes it to the Serf.
-
+wrapper, `+jam`s the `lane` on which it heard the packet, and delivers the packet
+to the Ames vane as an atom by copying the bytes it heard on the UDP port.

--- a/tutorials/arvo/ames.md
+++ b/tutorials/arvo/ames.md
@@ -348,7 +348,9 @@ contact `~worwel-sipnum` but does not know the IP address and port at which
 `~worwel-sipnum` resides. Both planets live under `~zod`, which knows both of
 their IP and port numbers by virtue of being the galaxy that both live under.
 
-So `~bacbel-tagfeb` sends a packet addressed to `~worwel-sipnum` to `~zod`.
+To prepare, `~bacbel-tagfeb` forms a Diffie-Hellman symmetric key with their own
+private key and the public key of `~worwel-sipnum`, obtained via Jael. Then
+`~bacbel-tagfeb` sends a packet addressed to `~worwel-sipnum` to `~zod`.
 
 The packet has the following format:
  - The standard Ames header described in [header](#header), where the checksum
@@ -361,8 +363,7 @@ followed by the payload.
  - The payload of this packet will be the `+jam` of `[origin content]`. `origin`
 for this initial packet will be `~`, which implies that the packet is
 originating from the sender. `content` is the `+jam` of the message, encrypted
-using a Diffie-Hellman symmetric key obtained with the private key of
-`~bacbel-tagfeb` and the public key of `~worwel-sipnum`.
+using the Diffie-Hellman symmetric key that was previously computed.
 
 `~zod` receives the packet and reads the body. It sees that it is not the
 intended recipient of the packet, and so gets ready to forward it to

--- a/tutorials/arvo/ames.md
+++ b/tutorials/arvo/ames.md
@@ -149,3 +149,26 @@ The body is of variable length and consists of three parts in this order:
  
  The sender and receiver live outside of the jammed data section to simplify
  packet filtering for the interpreter.
+ 
+
+## Journey of a Packet
+
+In this section we follow a packet through its entire journey, originating from
+the Ames vane of ship A and ending in the Ames vane of ship B.
+
+This journey is broken into several stages:
+
+1. Ames receives a `%plea` note.
+1.5 Does encryption happen here?
+2. Serf A gives the note to King A (in what form? does it jam the payload?)k
+3. King A checks that it is a valid Ames packet and wraps the Ames packet in a UDP packet (what does this look like?) and
+   give it to its Ames I/O submodule to send
+4. UDP packet is sent to the receiving IP address (how is this determined? along
+   some port?)
+5. King B receives a UDP packet on socket ? via the Ames submodule. It checks
+   that it is a valid Ames packet
+
+
+A `%plea` `note` is given by `[vane=@tas =path payload=*]`, where
+`vane` is the destination vane on the remote ship, `path` is the internal
+route on the receiving ship `payload` is the semantic message content.

--- a/tutorials/arvo/ames.md
+++ b/tutorials/arvo/ames.md
@@ -290,7 +290,7 @@ flow, and the types of packets for each bone are:
  - bone 14, acks of naxplanations to `~worwel-sipnum`,
  - bone 15, naxplanations to `~bacbel-tagfeg`.
 
-Each bone is handled separately by congestion control, and this is the reason
+Each bone is handled separately by congestion control, and this is one reason
 for their segregation. For example, say a two-packet `%plea` is sent on bone 12,
 with `~bacbel-tagfeg` requesting to join a group on `~worwel-sipnum`.
 Then `~worwel-sipnum` can ack the first packet on bone 13, and then send a nack
@@ -298,6 +298,14 @@ on bone 13 as well. A nack by itself contains no information as to why the nack
 happened. Then `~worwel-sipnum` can also send a naxplanation on bone 15 saying
 to `~bacbel-tagfeg` that they cannot join the group, to which an ack is received
 on bone 14.
+
+Another reason to separate bones is to avoid race conditions. If
+`~worwel-sipnum` and `~bacbel-tagfeg` attempt to start a flow with each other at
+the same time we do not wish there to be a conflict when they receive each
+others' packets. Flipping the last bit of the bone based on whether a packet is
+an ack or a message fragment allows for `~worwel-sipnum` to create flow 8 with
+`~bacbel-tagfeg` without coming into conflict with the flow 8 `~bacbel-tagfeg`
+created for `~worwel-sipnum`.
 
 `%plea`s and `%boon`s are handled on separate bones so that e.g. sending a large
 `%boon` doesn't stop an additional `%plea` from being received. It is also

--- a/tutorials/arvo/ames.md
+++ b/tutorials/arvo/ames.md
@@ -377,7 +377,7 @@ Once `~worwel-sipnum` processes the packet, it will know the IP and port of
 `~bacbel-tagfeb` since `~zod` included it when it forwarded the packet. Thus
 `~worwel-sipnum` will send an ack packet directly to `~bacbel-tagfeb`, unless a
 NAT and/or firewall prevents a direct peer-to-peer connection, in which case
-`~zod` will contineu to relay packets. Absent these factors preventing a
+`~zod` will continue to relay packets. Absent these factors preventing a
 peer-to-peer connection, communication between the two ships will now be direct
 until one of them changes their IP address, port, or networking keys.
 

--- a/tutorials/arvo/ames.md
+++ b/tutorials/arvo/ames.md
@@ -374,9 +374,12 @@ intended recipient of the packet, and so gets ready to forward it to
 checksum with the new, and then sends the packet along to `~worwel-sipnum`.
 
 Once `~worwel-sipnum` processes the packet, it will know the IP and port of
-`~bacbel-tagfeb` since `~zod` included it when it forwarded the packet and so
-will send an ack packet directly to `~bacbel-tagfeb`. Communication between the
-two ships will now be direct until one of them changes their IP address, port, or networking keys.
+`~bacbel-tagfeb` since `~zod` included it when it forwarded the packet. Thus
+`~worwel-sipnum` will send an ack packet directly to `~bacbel-tagfeb`, unless a
+NAT and/or firewall prevents a direct peer-to-peer connection, in which case
+`~zod` will contineu to relay packets. Absent these factors preventing a
+peer-to-peer connection, communication between the two ships will now be direct
+until one of them changes their IP address, port, or networking keys.
 
 
 ## The Serf and the King

--- a/tutorials/arvo/ames.md
+++ b/tutorials/arvo/ames.md
@@ -172,3 +172,4 @@ This journey is broken into several stages:
 A `%plea` `note` is given by `[vane=@tas =path payload=*]`, where
 `vane` is the destination vane on the remote ship, `path` is the internal
 route on the receiving ship `payload` is the semantic message content.
+


### PR DESCRIPTION
This is the second of several Ames PR's I've been working on (the first being #943), which are mostly being done now for the sake of the security audit but of course the information is widely useful. It is mostly an elaboration on what was already summarized at the top.

This adds two major sections:
- Packets: what format they come in, how they are encrypted, how they are serialized, how messages are packetized, how they are acked, and how they are relayed.
- The Serf and the King: The Serf does most of the grunt work for Ames, but the King has important responsibilities too.

Each section is accompanied by a diagram that helps to describe their content.

There are still some important things to come. A discussion of nacks and failures in Ames in general, how Ames and Jael work together to handle keys, and what specifically constitutes an Arvo event and how that relates to flows. If there are other parts of Ames you'd like documented, now is the time to mention it.