### PR TITLE
add threads.txt to arvo/gall.md

### DIFF
--- a/tutorials/arvo/gall.md
+++ b/tutorials/arvo/gall.md
@@ -5,7 +5,8 @@ template = "doc.html"
 aliases = ["/docs/learn/arvo/gall/"]
 +++
 
-This document describes Gall, the Arvo userspace vane. It is accurate as of 2019.12.02.
+This document describes Gall, the Arvo userspace vane. It is split into two main
+sections: Agents and [Threads](#threads).
 
 # Agents
 
@@ -557,3 +558,237 @@ If an error happens in `+on-poke`, the crash report goes into the
 `+on-subscription`, the crash report goes into the `%watch-ack`
 response.  If a crash happens in any of the other handlers, the report
 is passed into this arm.
+
+
+# Threads
+
+As discussed in [Agents](#agents), Urbit code lives in the following basic
+categories:
+
+- Runtime (Nock interpreter, persistence engine, IO drivers, jets)
+- Kernel vanes (managed by Arvo)
+- Userspace agents (managed by Gall, permanent state)
+- Userspace threads (managed by Spider, transient state)
+
+This describes the last category:  Threads.
+
+A thread is a monadic function that takes arguments and produces a
+result.  It may perform input and output while running, so it is not a
+pure function.  It may fail.
+
+An agent's strength is that it's permanent and bulletproof.  All state
+transitions are defined, and each action it performs is a transaction.
+Code upgrades preserve existing state.
+
+An agent's weakness is complex input and output.  Since each state
+transition must be explicitly handled, the complexity of an agent
+explodes with the amount of IO it handles.  At best, this results in
+long and complex code; at worst, unexpected states are mishandled,
+corrupting permanent state.
+
+A thread's strength is that it can easily perform complex IO operations.
+It uses what's often called the IO monad (plus the exception monad) to
+provide a natural framework for IO.
+
+A thread's weakness is that it's impermanent and may fail unexpectedly.
+In most of its intermediate states, it expects only a small number of
+events (usually one), so if it receives anything it didn't expect, it
+fails.  When code is upgraded, it's impossible to upgrade a running
+thread, so it fails.
+
+Thus, for anything that needs to be permament, use an agent.  When you
+need to do a long or complex sequence of IO operations, reduce that to a
+single logical IO operation by spinning it out into a thread.  If you
+only change your agent's state in response to success of the thread, an
+IO failure will never result in partially applied state changes.
+
+A thread may also be run from the dojo by prefixing its name with `-`
+and giving it any arguments it requires.  If alone, any result will be
+printed to the screen; else the output may be piped into an agent or
+other sinks.
+
+## Specification
+
+```hoon
++$  thread  $-(vase _*form:(strand ,vase))
+```
+
+A thread is a running strand.  It receives an argument as a vase and may
+prodduce a vase of a result.
+
+```hoon
++$  tid  @tasession
++$  start-args
+  [parent=(unit tid) use=(unit tid) file=term =vase]
+```
+
+To run a thread, poke Spider with mark `%spider-start` and a value of
+type `start-args`.  `parent` is an optional parent, `use` is an optional
+id, `file` is the filename, and `vase` is the argument.  If the parent
+is specified (usually to the thread that spawned this thread), then
+when the parent ends, the child will end too.
+
+A thread may succeed or fail.  You may recieve the return value or be
+notified of failure by subscribing to Spider at `/thread-result/[tid]`,
+where `tid` is the same one you passed in `use`.  Take care to create a
+`tid` that will be unique from any other that may be created, for
+example with:
+
+```hoon
+(scot %ta (cat 3 'my-agent_' (scot %uv (sham eny))))`
+```
+
+The `%fact` that comes back on this subscription will have mark either
+`%thread-fail` or `%thread-done`.  If it failed, the content will have
+type `[term tang]` with an explanation of the error.  If it succeeded,
+the content will be whatever the thread produced.
+
+```hoon
++$  input  [=tid =cage]
+```
+
+You may poke a thread by poking Spider with `%spider-input`.  `tid` is
+the id of the thread you wish to poke, and `cage` is the data to poke it
+with.
+
+You may subscribe to a thread by subscribing to Spider at
+`/thread/[tid]/path`.
+
+You may stop a thread by poking Spider with `%spider-stop` and data
+`[tid ?]`, where `tid` is the thread you wish to stop and the loobean
+decides whether to quit nicely (suppresses printfs).
+
+## Writing threads
+
+A thread is just a function from a vase of arguments to a strand that
+produces a vase of the result.  We say "just" not because it's obvious
+yet what that means but because it means we only need to explain how to
+write strands, and threads are just a particular case.
+
+The type of a strand is defined in lib/strand, but you will rarely touch
+those types directly.  Most of the time, you will use two functions
+`pure` and `bind` combined with any of the functions defined in
+lib/strandio.
+
+### Strand fundamentals
+
+When writing strands, you almost always want to start by specializing
+`strand` to your return type.  A strand can produce any type, but you
+must specify up front what type it will produce.  By convention, we use
+the variable `m` for this.  For example, if you are going to produce a
+`@ud`, use:
+
+```hoon
+=/  m  (strand ,@ud)
+^-  form:m
+...
+```
+
+Note that `m` is a core that has three arms:
+
+`+form` is the mold of the strand, suitable for `^-`.
+
+`+pure` produces a strand that does nothing except return a value.  So,
+`(pure:(strand ,@tas) %foo)` is a strand that produces `%foo` without
+doing any IO.  Thus, the most trivial thread is:
+
+```hoon
+/-  spider
+/+  strandio
+=,  strand=strand:spider
+^-  thread:spider
+|=  vase
+=/  m  (strand ,vase)
+^-  form:m
+(pure:m *vase)
+```
+
+`+bind`, used with `;<`, takes two strands and runs one after the other,
+letting you use the result of the first strand in the second.  For
+example:
+
+```hoon
+;<  num=@ud  bind:m  (pure:m 5)
+(pure:m +(num))
+```
+
+Has the same result as:
+
+```hoon
+(pure:m 6)
+```
+
+### Other useful functions
+
+There are many useful strand functions in lib/strandio and some other
+libraries.  For example:
+
+`+sleep` waits for the specified time.
+
+`+get-time` gets the current time.
+
+`+poke` pokes an agent.
+
+`+watch` subscribes to an agent.
+
+`+fetch-json` produces the JSON at a particular URL.
+
+`+retry` tries a strand repeatedly with exponential backoff until it
+succeeeds.
+
+`+start-thread` starts another thread.
+
+`send-raw-card` sends any card.
+
+## Examples
+
+```hoon
+/-  spider
+/+  strandio
+=,  strand=strand:spider
+^-  thread:spider
+|=  arg=vase
+=/  m  (strand ,vase)
+^-  form:m
+=+  !<([arg=@dr ~] arg)
+;<  now-1=@da  bind:m  get-time:strandio
+;<  ~          bind:m  (sleep:strandio arg)
+;<  now-2=@da  bind:m  get-time:strandio
+(pure:m !>(`@dr`(sub now-2 now-1)))
+```
+
+The first seven lines are the same boilerplate we saw before.  After
+that, it `!<`'s the argument to its expected type.  It saves the current
+time in `now-1`, sleeps how long the argument says to, then gets the
+time again and produces the difference between the two times.  This
+number should be close to the argument you passed in, plus a little for
+computation time.  You can run this at the dojo with `-time ~s1`.
+
+```hoon
+/-  spider
+/+  *ph-io
+=,  strand=strand:spider
+^-  thread:spider
+|=  args=vase
+=/  m  (strand ,vase)
+;<  ~  bind:m  start-simple
+;<  ~  bind:m  (raw-ship ~bud ~)
+;<  ~  bind:m  (dojo ~bud "[%test-result (add 2 3)]")
+;<  ~  bind:m  (wait-for-output ~bud "[%test-result 5]")
+;<  ~  bind:m  end-simple
+(pure:m *vase)
+```
+
+This is uses `lib/ph/io` to run a pH test.  Aqua and pH are described
+[elsewhere](@/docs/tutorials/hoon/hoon-school/aqua.md), but if you've initialized Aqua by running `|start %aqua` and
+`:aqua +solid`, then you can run `-ph-add` to execute this thread.
+
+It starts by running some virtualization initialization with
+`start-simple`.  Then, it boots a guest ship called ~bud, types a line
+into the dojo, and waits for it to printed the expected output.
+
+It's easy to see how this building blocks could be combined to perform
+complex tests.  For example, you could start several ships and have them
+`|hi` each other, sync from each other, or do anything else.  Check out
+`lib/ph/io` and `lib/ph/azimuth` for other useful functions in constructing
+pH tests.


### PR DESCRIPTION
Per @philipcmonk 's request #962 , I've added threads.txt to
the Gall page under `arvo/gall.md`. My only edits were adding in a couple links
and tagging code blocks with `hoon`.

----

#