### PR TITLE
micfas irregular syntax

### DIFF
--- a/reference/hoon-expressions/irregular.md
+++ b/reference/hoon-expressions/irregular.md
@@ -43,6 +43,14 @@ Miscellaneous useful macros.
 R: `;:(p q)`
 I: `:(p q)`
 
+### ;/ micfas
+
+[docs](@/docs/reference/hoon-expressions/rune/mic.md#micfas) \\/
+`[%mcnt p=hoon]`: tape as XML element.
+
+R: `;/  p`
+I: `:/p`
+
 ## : col (cells)
 
 The cell runes.

--- a/reference/hoon-expressions/rune/mic.md
+++ b/reference/hoon-expressions/rune/mic.md
@@ -172,6 +172,12 @@ ford: %ride failed to execute:
 ~[%$ ~[%$ 'p']]
 ```
 
+##### Syntax
+
+Regular: **1-fixed**
+
+Irregular: `;/  a` is `:/a`
+
 ##### Examples
 
 ```


### PR DESCRIPTION
Following up on @joemfb commenting that `:/` is irregular syntax for `;/`: https://github.com/urbit/docs/pull/890



----

#