### PR TITLE
landscape arch and graphstore docs

### DIFF
--- a/tutorials/concepts/arch.md
+++ b/tutorials/concepts/arch.md
@@ -1,0 +1,21 @@
++++
+title = "Landscape Architecture"
+weight = 4
+template = "doc.html"
++++
+
+# Landscape Architecture
+
+Landscape is designed using a particular userspace architecture model known as store/hook/thread. This model divides applications into multiple parts, two gall applications and threads.
+
+## Stores
+
+Stores are the first of the two gall models to form this architecture. A store is intended to maintain all the state required for an application or set of applications. Stores are intended to be only accessible by the ship it's running on. While this is not enforced, it is the convention. The primary example of a store is `graph-store` which can be found at `app/graph-store`
+
+## Hooks
+
+Hooks are the second gall application used in this architecture and are not always present. Hooks are used for inter-ship communication. Anything that needs to speak to a store on another ship does so through a hook. This allows a separation of access control concerns and a division between those things which are able to be done to a remove ship and those which may be performed by the host. `graph-store` in particular has two hooks `graph-pull-hook` for outgoing requests, and `graph-push-hook` for incoming requests.
+
+## Thread
+
+Threads are used when you want to have a series of transactions to a store where the order of those transactions matters. No guarantees are made about what order things process in for individual requests to a gall application and threads are intended to address this. Threads do not maintain their own state while inactive and are instead run only upon request. A good example is `ted/graph/create`

--- a/tutorials/concepts/arch.md
+++ b/tutorials/concepts/arch.md
@@ -6,11 +6,11 @@ template = "doc.html"
 
 # Landscape Architecture
 
-Landscape is designed using a particular userspace architecture model known as store/hook/thread. This model divides applications into multiple parts, two gall applications and threads.
+Landscape is designed using a particular userspace architecture mode consisting of stores, hooks, and threads.
 
 ## Stores
 
-Stores are the first of the two gall models to form this architecture. A store is intended to maintain all the state required for an application or set of applications. Stores are intended to be only accessible by the ship it's running on. A store may not send pokes, peeks, or watches. A store should be treated and thought of as a database table. While this is not enforced, it is the convention. The primary example of a store is `graph-store` which can be found at `app/graph-store`
+Stores are the first of the two gall models to form this architecture. A store is intended to maintain all the state required for an application or set of applications. Stores are intended to be only accessible by the ship it's running on. A store may not send pokes, peeks, or watches. A store should be treated and thought of as a database. While this is not enforced, it is the convention. The primary example of a store is `graph-store` which can be found at `app/graph-store`
 
 ## Hooks
 
@@ -18,4 +18,4 @@ Hooks are the second gall application used in this architecture and are not alwa
 
 ## Thread
 
-Threads are used when you want to have a series of transactions to a store where the order of those transactions matters. No guarantees are made about what order things process in for individual requests to a gall application and threads are intended to address this. Threads do not maintain their own state while inactive and are instead run only upon request. A good example is `ted/graph/create`
+Threads are used when you want to have a series of transactions on a store where the order of those transactions matters. No guarantees are made about the order in which individual requests to a gall applications are processed; threads were introduced to address this. Threads do not maintain their own state while inactive and are instead run only upon request. A good example is `ted/graph/create`

--- a/tutorials/concepts/arch.md
+++ b/tutorials/concepts/arch.md
@@ -10,11 +10,11 @@ Landscape is designed using a particular userspace architecture model known as s
 
 ## Stores
 
-Stores are the first of the two gall models to form this architecture. A store is intended to maintain all the state required for an application or set of applications. Stores are intended to be only accessible by the ship it's running on. While this is not enforced, it is the convention. The primary example of a store is `graph-store` which can be found at `app/graph-store`
+Stores are the first of the two gall models to form this architecture. A store is intended to maintain all the state required for an application or set of applications. Stores are intended to be only accessible by the ship it's running on. A store may not send pokes, peeks, or watches. A store should be treated and thought of as a database table. While this is not enforced, it is the convention. The primary example of a store is `graph-store` which can be found at `app/graph-store`
 
 ## Hooks
 
-Hooks are the second gall application used in this architecture and are not always present. Hooks are used for inter-ship communication. Anything that needs to speak to a store on another ship does so through a hook. This allows a separation of access control concerns and a division between those things which are able to be done to a remove ship and those which may be performed by the host. `graph-store` in particular has two hooks `graph-pull-hook` for outgoing requests, and `graph-push-hook` for incoming requests.
+Hooks are the second gall application used in this architecture and are not always present. Hooks are used for inter-app communication. This allows a separation of access control concerns and a division between those things which are able to be done by a store itself and those done by another gall application. `graph-store` in particular has two hooks `graph-pull-hook` for outgoing requests, and `graph-push-hook` for incoming requests.
 
 ## Thread
 

--- a/tutorials/hoon/graph.md
+++ b/tutorials/hoon/graph.md
@@ -6,7 +6,7 @@ template = "doc.html"
 
 # What is Graph Store?
 
-Graph store is a gall implementation of a tree-based database that has an affordance for cyclic structures by allowing nodes to reference other nodes. It is most comparable to modern NoSQL databases in structure, though it allows for schemas to be written in the form of marks. It is used as the backend for an increasing number of Landscape applications, and is considered to be best used for social data.
+Graph Store is a gall implementation of a tree with additional virtual edges by allowing nodes to reference other nodes. It is most comparable to modern NoSQL databases in structure, though it allows for schemas to be written in the form of marks. It is used as the backend for an increasing number of Landscape applications, and is considered to be best used for social data.
 
 ## Data types
 
@@ -22,12 +22,17 @@ Graph store is a gall implementation of a tree-based database that has an afford
 
 `post` is defined in `sur/post`. It contains:
 
-`author=ship`
-`index`
-`time-sent=time`
-`contents=(list content)`
-`hash=(unit hash)`
-`signatures`
+```hoon
++$  post
+  $:  author=ship
+      =index
+      time-sent=time
+      contents=(list content)
+      hash=(unit hash)
+      =signatures
+  ==
+```
+
 
 Most of these elements are self explanatory.
 
@@ -45,11 +50,11 @@ When interacting with `graph-store` you will need to create an `update`
 
 The reason this is a union is to serve as future proofing for version changes.
 
-An `update-0` can either be logged in the case of adding and removing nodes or signatures or non logged as in the case of adding or removing a graph. This logging refers to if this action adds an entry to the update log that is used to synchronize state between ships.
+An `update-0` can either be logged in the case of adding/removing nodes or signatures, or non-logged as in the case of adding/removing a graph. This logging refers to if this action adds an entry to the update log that is used to synchronize state between ships.
 
-Below is an excerpt or `sur/graph-store.hoon` at the time of writing showing the definition of `logged-update-0` and `update-0` which should now be readable.
+Below is an excerpt of `sur/graph-store.hoon` at the time of writing, showing the definition of `logged-update-0` and `update-0` which should now be readable.
 
-```
+```hoon
 +$  logged-update-0
   $%  [%add-nodes =resource nodes=(map index node)]
       [%remove-nodes =resource indices=(set index)]
@@ -80,7 +85,7 @@ Below is an excerpt or `sur/graph-store.hoon` at the time of writing showing the
 
 ## Pokes
 
-Graph store can be poked with a `graph-update` which can:
+Graph Store can be poked with a `graph-update`, which can:
  - add and remove a graph
  
  `[%add-graph =resource =graph mark=(unit mark)]`
@@ -111,7 +116,7 @@ Graph store can be poked with a `graph-update` which can:
  
  `[%unarchive-graph =resource]`
 
-## Scrys
+## Scries
 
 What follows is a summary of the scrys available in graph-store
 
@@ -150,4 +155,4 @@ What follows is a summary of the scrys available in graph-store
 
 ## Marks
 
-There are marks in `mar/graph/validator` that are worth review. They are each short enough to read quickly. They are used to validate the shapes of various nouns to be stored in the graph-store.
+There are marks in `mar/graph/validator` that are worth reviewing. They are each short enough to read quickly. They are used to validate the shapes of various nouns to be stored in the graph-store.

--- a/tutorials/hoon/graph.md
+++ b/tutorials/hoon/graph.md
@@ -1,0 +1,153 @@
++++
+title = "Graph Store"
+weight = 3
+template = "doc.html"
++++
+
+# What is Graph Store?
+
+Graph store is a gall implementation of a tree-based database that has an affordance for cyclic structures by allowing nodes to reference other nodes. It is most comparable to modern NoSQL databases in structure, though it allows for schemas to be written in the form of marks. It is used as the backend for an increasing number of Landscape applications, and is considered to be best used for social data.
+
+## Data types
+
+`graphs` is a map of `resource` to `marked-graph`
+
+`resource` is a pair of ship and term which is where the graph is hosted and the name of the resource. Every graph is it's own resource.
+
+`marked-graph` is a pair of `graph` and `(unit mark)`. The semantics of a graph are defined by the mark. This is just for validating the structure of the graph. 
+
+`graph` is a `mop`, a mold builder for order map, of an atom and a `node`.
+
+`node` is a pair of `post` and `children`.
+
+`post` is defined in `sur/post`. It contains:
+
+`author=ship`
+`index`
+`time-sent=time`
+`contents=(list content)`
+`hash=(unit hash)`
+`signatures`
+
+Most of these elements are self explanatory.
+
+`contents` is a `list` of `content` where `content` is a tagged union of text, url, code, or reference. This is where the contents of a publish post or an entry from links would be stored.
+
+`hash` is a `sham` hash of `validated-portion` which includes the parent hash, author, time sent, and contents.
+
+`signatures` is a set of `signature` which is used to cryptographically sign graph-store messages.
+
+When interacting with `graph-store` you will need to create an `update`
+
+`update` is a tagged union that currently only has one option
+
+`[%0 p=time q=update-0]`
+
+The reason this is a union is to serve as future proofing for version changes.
+
+An `update-0` can either be logged in the case of adding and removing nodes or signatures or non logged as in the case of adding or removing a graph. This logging refers to if this action adds an entry to the update log that is used to synchronize state between ships.
+
+Below is an excerpt or `sur/graph-store.hoon` at the time of writing showing the definition of `logged-update-0` and `update-0` which should now be readable.
+
+```
++$  logged-update-0
+  $%  [%add-nodes =resource nodes=(map index node)]
+      [%remove-nodes =resource indices=(set index)]
+      [%add-signatures =uid =signatures]
+      [%remove-signatures =uid =signatures]
+  ==
+::
++$  update-0
+  $%  logged-update-0
+      [%add-graph =resource =graph mark=(unit mark)]
+      [%remove-graph =resource]
+    ::
+      [%add-tag =term =resource]
+      [%remove-tag =term =resource]
+    ::
+      [%archive-graph =resource]
+      [%unarchive-graph =resource]
+      [%run-updates =resource =update-log]
+    ::
+    ::  NOTE: cannot be sent as pokes
+    ::
+      [%keys =resources]
+      [%tags tags=(set term)]
+      [%tag-queries =tag-queries]
+  ==
+```
+
+
+## Pokes
+
+Graph store can be poked with a `graph-update` which can:
+ - add and remove a graph
+ 
+ `[%add-graph =resource =graph mark=(unit mark)]`
+ 
+ `[%remove-graph =resource]`
+ 
+ - add and remove a node to a graph
+ 
+ `[%add-nodes =resource nodes=(map index node)]`
+
+ `[%remove-nodes =resource indices=(set index)]`
+ 
+ - add and remove signatures
+ 
+ `[%add-signatures =uid =signatures]`
+ 
+ `[%remove-signatures =uid =signatures]`
+ 
+ - add and remove tags
+ 
+ `[%add-tag =term =resource]`
+ 
+ `[%remove-tag =term =resource]`
+ 
+ - archive and unarchive a graph
+ 
+ `[%archive-graph =resource]`
+ 
+ `[%unarchive-graph =resource]`
+
+## Scrys
+
+What follows is a summary of the scrys available in graph-store
+
+- Fetch keys
+ `[%x %keys ~]`
+
+- Fetch tags
+ `[%x %tags ~]`
+ 
+- Fetch tag queries
+ `[%x %tag-queries ~]`
+
+- Fetch a specific graph by resource
+ `[%x %graph @ @ ~]`
+ 
+- Archive a specific graph by resource
+ `[%x %archive @ @ ~]`
+ 
+- Fetch a subset of the graph by resource and start and end indices
+ `[%x %graph-subset @ @ @ @ ~]`
+
+- Select a node from a graph by resource and index
+ `[%x %node @ @ @ *]`
+ 
+- Fetch a subset of the children of a node by resource, index, and start and end indices
+ `[%x %node-children-subset @ @ @ @ @ *]`
+ 
+- Fetch a subset of the update log by resource and start and end indices
+ `[%x %update-log-subset @ @ @ @ ~]`
+ 
+- Fetch the update log by resource
+ `[%x %update-log @ @ ~]`
+ 
+- Fetch the time of the last entry of the update log
+ `﻿﻿[%x %peek-update-log @ @ ~]`
+
+## Marks
+
+There are marks in `mar/graph/validator` that are worth review. They are each short enough to read quickly. They are used to validate the shapes of various nouns to be stored in the graph-store.


### PR DESCRIPTION
Initial documentation for graph store
Initial documentation for basic landscape architecture to orient userspace developers

Intent is to provide outside developers a clear path for interacting with the standard suite of urbit userspace apps that are backed by graph store