### PR TITLE
moving arvo out of date warning

### DIFF
--- a/tutorials/arvo/arvo.md
+++ b/tutorials/arvo/arvo.md
@@ -5,9 +5,6 @@ template = "doc.html"
 aliases = ["/docs/learn/arvo/arvo/"]
 +++
 
-> Parts of this document are out of date as of 2020.07.20, please use information here with
-> caution. This message will be removed once it is up to date.
-
 Arvo, also called Urbit OS, is our operating system.
 
 # Introduction
@@ -243,6 +240,10 @@ to some heuristic, such as taking too long or because the user pressed Ctrl-C.
 This is known as
 [non-preemptive](https://en.wikipedia.org/wiki/Cooperative_multitasking) or
 cooperative multitasking.
+
+
+> Parts of the remainder of this document are out of date as of 2020.07.20, please use information here with
+> caution. This message will be removed once it is up to date.
 
 
 # The kernel


### PR DESCRIPTION
The first part of this document is not out of date and the warning is scary.
This moves the warning to the kernel section.

Per @jalehman 's suggestion

----

#