### PR TITLE
updating code on advanced types

### DIFF
--- a/reference/hoon-expressions/advanced.md
+++ b/reference/hoon-expressions/advanced.md
@@ -18,27 +18,29 @@ large functions.  Don't worry about them for a little while.
           $@  $?  %noun
                   %void
               ==
-          $%  [$atom p=term q=(unit @)]
-              [$cell p=type q=type]
-              [$core p=type q=coil]
-              [$face p=$@(term tune) q=type]
-              [$fork p=(set type)]
-              [$hint p=(pair type note) q=type]
-              [$hold p=type q=hoon]
+          $%  [%atom p=term q=(unit @)]
+              [%cell p=type q=type]
+              [%core p=type q=coil]
+              [%face p=$@(term tune) q=type]
+              [%fork p=(set type)]
+              [%hint p=(pair type note) q=type]
+              [%hold p=type q=hoon]
           ==
 ::
-+$  coil  $:  p=[p=(unit term) q=poly r=vair]
-              q=type
-              r=[p=seminoun q=(map term tome)]
++$  coil  $:  p=garb                                    ::  name, wet=dry, vary
+              q=type                                    ::  context
+              r=(pair seminoun (map term tome))         ::  chapters
+          ==                                            ::
 ::
++$  garb  (trel (unit term) poly vair)                  ::  core
 +$  poly  ?(%wet %dry)
-+$  vair  ?($gold $iron $lead $zinc)
++$  vair  ?(%gold %iron %lead %zinc)
 +$  tome  (pair what (map term hoon))
-+$  tune
-          $~  [~ ~]
-          $:  p=(map term (unit hoon))
-              q=(list hoon)
-          ==
++$  tune                                                ::  complex
+          $~  [~ ~]                                     ::
+          $:  p=(map term (unit hoon))                  ::  aliases
+              q=(list hoon)                             ::  bridges
+          ==                                            ::
 ```
 
 If you compare this to the basic `type`, you'll see that we've
@@ -66,8 +68,9 @@ the payload the core was compiled with is `q.q`.
 
 In the Bertrand Meyer tradition of type theory, there are two
 forms of polymorphism: variance and genericity.  In Hoon this
-choice is per core, hence the `poly` label in `coil`: it can be either `%wet` or `%dry`.  Dry polymorphism relies on variance; wet
-polymorphism relies on genericity.
+choice is per core, hence the `poly` label in `p.q`: it can be either `%wet`
+or `%dry`. Dry polymorphism relies on variance; wet polymorphism relies on
+genericity.
 
 ### Dry arms
 
@@ -188,13 +191,13 @@ of secret superpowers for hacking the namespace.  Remember that
 Hoon doesn't have anything like a symbol table; to resolve a
 limb, we just search the type depth-first.
 
-If a name is in the `p.p` map, it's an alias.  (An alias is defined using the
+If a name is in the `p.p` `map`, it's an alias.  (An alias is defined using the
 `=*` rune.) The map contains a `(unit hoon)`; if the unit is full, the name
 resolves to that hoon (compiled against the `q` type).  If the unit is empty,
 the name is blocked / skipped (see [limb](@/docs/reference/hoon-expressions/limb/limb.md) for what
 this means).
 
-If a name is in the `q.p` map, it's a bridge.  (A bridge is defined using the
+If a name is in the `q.p` `map`, it's a bridge.  (A bridge is defined using the
 `=,` rune.)  When we search for a name, we also compile the bridge, and check
 if the name resolves against the bridge product.  If so, we use it.
 

--- a/reference/hoon-expressions/advanced.md
+++ b/reference/hoon-expressions/advanced.md
@@ -191,13 +191,13 @@ of secret superpowers for hacking the namespace.  Remember that
 Hoon doesn't have anything like a symbol table; to resolve a
 limb, we just search the type depth-first.
 
-If a name is in the `p.p` `map`, it's an alias.  (An alias is defined using the
+If a name is in the `p.q.p` `map`, it's an alias.  (An alias is defined using the
 `=*` rune.) The map contains a `(unit hoon)`; if the unit is full, the name
 resolves to that hoon (compiled against the `q` type).  If the unit is empty,
 the name is blocked / skipped (see [limb](@/docs/reference/hoon-expressions/limb/limb.md) for what
 this means).
 
-If a name is in the `q.p` `map`, it's a bridge.  (A bridge is defined using the
+If a name is the `p.p` `term`, it's a bridge.  (A bridge is defined using the
 `=,` rune.)  When we search for a name, we also compile the bridge, and check
 if the name resolves against the bridge product.  If so, we use it.
 

--- a/reference/hoon-expressions/advanced.md
+++ b/reference/hoon-expressions/advanced.md
@@ -191,13 +191,13 @@ of secret superpowers for hacking the namespace.  Remember that
 Hoon doesn't have anything like a symbol table; to resolve a
 limb, we just search the type depth-first.
 
-If a name is in the `p.q.p` `map`, it's an alias.  (An alias is defined using the
+If a name is in the `p.p` `map`, it's an alias.  (An alias is defined using the
 `=*` rune.) The map contains a `(unit hoon)`; if the unit is full, the name
 resolves to that hoon (compiled against the `q` type).  If the unit is empty,
 the name is blocked / skipped (see [limb](@/docs/reference/hoon-expressions/limb/limb.md) for what
 this means).
 
-If a name is the `p.p` `term`, it's a bridge.  (A bridge is defined using the
+If a name is the `q.p` `term`, it's a bridge.  (A bridge is defined using the
 `=,` rune.)  When we search for a name, we also compile the bridge, and check
 if the name resolves against the bridge product.  If so, we use it.
 


### PR DESCRIPTION
Was reading this page and noticed the code was out of date.

Went through the text as well to make sure I didn't mess up any references.
There was one part though that looked like it was already wrong even before -
starting at L200:

```
If a name is in the q.p map, it's a bridge. 
```
`tune` only had one `map`, and the line commented with `::bridges` is a `(list
hoon)`. Since a `%face` is a `p=$@(term tune) q=type`, I guessed that it meant
the `term` here, but I think I am still a little mistaken. So I need some
guidance here.

Tagging @jtobin since I ran into this while reading compiler documentation,
which we're supposed to work on together after the new year, which will
hopefully be accompanied by some improvements to the docs on the type system.

----

#