### PR TITLE
fix jael APi title and header

### DIFF
--- a/reference/vane-apis/jael.md
+++ b/reference/vane-apis/jael.md
@@ -1,10 +1,8 @@
 +++
-title = "Jael Public API"
+title = "Jael"
 weight = 5
 template = "doc.html"
 +++
-
-# Jael
 
 In this document we describe the public interface for Jael.  Namely, we describe
 each `task` that Jael can be `%pass`ed, and which `gift`(s) Jael can `%give` in return.


### PR DESCRIPTION
Changing the title to be in alignment with the other API docs

Also I think I have initially put an unnecessary markdown header at the top of every one of the API docs I've wrote. Maybe I'll finally learn my lesson next time.