### PR TITLE
Fix hoon school structures & complex types typo

### DIFF
--- a/tutorials/hoon/hoon-school/structures-and-complex-types.md
+++ b/tutorials/hoon/hoon-school/structures-and-complex-types.md
@@ -145,7 +145,7 @@ Let's review (1) and (2) briefly.
 
 The basic types of Hoon are: `*` for [nouns](/docs/glossary/noun/), `@` for atoms (possibly with aura information, e.g., `@ud` and `@sx`), `^` for cells, `?` for flags, and `~` for null.  You can also make constant, one-value types by using `%` followed by a series of lowercase letters, the hyphen symbol `-`, and numbers.  E.g., `%red`, `%2`, `%kebab-case123`.  The lone values of these one-value types are sometimes called 'tags'.
 
-Let's illustrate with the irregular `\` \`` cast syntax:
+Let's illustrate with the irregular ``` ` ` ``` cast syntax:
 
 ```
 > `%blah`%blah


### PR DESCRIPTION
In the discussion of type casting, the irregular type cast renders incorrectly.

This is one way to fix the rendering (at least for the grip markdown rendering tool).

See attached images:

![Screenshot from 2021-02-26 04-16-55-circle](https://user-images.githubusercontent.com/79381743/109299531-1a2ad780-77ea-11eb-9188-c67655f08de2.png)
![Screenshot from 2021-02-26 04-17-54-circle](https://user-images.githubusercontent.com/79381743/109299551-21ea7c00-77ea-11eb-806c-ea82cf8601a4.png)