### PR TITLE
Added missing syntax highlighting from Hoon School code blocks

### DIFF
--- a/hoon/hoon-school/arms-and-cores.md
+++ b/hoon/hoon-school/arms-and-cores.md
@@ -4,27 +4,28 @@ weight = 15
 template = "doc.html"
 aliases = ["/docs/learn/hoon/hoon-tutorial/arms-and-cores/"]
 +++
-The Hoon subject is a [noun](/docs/glossary/noun/).  Each fragment of this [noun](/docs/glossary/noun/) is either an [arm](/docs/glossary/arm/) or a leg.  In the previous lesson you learned what a leg is, and how to return legs of the subject by various means.  In this lesson you'll learn what an [arm](/docs/glossary/arm/) is.  Arms are a bit more complex than legs -- a full understanding of them requires a bit more background knowledge.  Accordingly, in this lesson we must also introduce an important Hoon data structure: a '[core](/docs/glossary/core/)'.
+
+The Hoon subject is a [noun](/docs/glossary/noun/). Each fragment of this [noun](/docs/glossary/noun/) is either an [arm](/docs/glossary/arm/) or a leg. In the previous lesson you learned what a leg is, and how to return legs of the subject by various means. In this lesson you'll learn what an [arm](/docs/glossary/arm/) is. Arms are a bit more complex than legs -- a full understanding of them requires a bit more background knowledge. Accordingly, in this lesson we must also introduce an important Hoon data structure: a '[core](/docs/glossary/core/)'.
 
 After arms are defined and explained we review wing expressions, this time focusing on wing resolution to arms.
 
 ## A Preliminary Explanation
 
-Arms and legs are limbs of the subject, i.e., noun fragments of the subject.  In the last lesson we said that legs are for data and arms are for computations.  But what _specifically_ is an arm, and how is it used for computation?  Let's begin with a preliminary explanation that will be refined later in the lesson.
+Arms and legs are limbs of the subject, i.e., noun fragments of the subject. In the last lesson we said that legs are for data and arms are for computations. But what _specifically_ is an arm, and how is it used for computation? Let's begin with a preliminary explanation that will be refined later in the lesson.
 
-An **arm** is some expression of Hoon encoded as a noun.  (By 'encoded as a noun' we literally mean: 'compiled to a Nock formula'.  But you don't need to know anything about Nock to understand Hoon.)  You virtually never need to treat an arm as raw data, even though technically you can -- it's just a noun like any other.  You virtually always want to think of an arm simply as a way of running some Hoon code.
+An **arm** is some expression of Hoon encoded as a noun. (By 'encoded as a noun' we literally mean: 'compiled to a Nock formula'. But you don't need to know anything about Nock to understand Hoon.) You virtually never need to treat an arm as raw data, even though technically you can -- it's just a noun like any other. You virtually always want to think of an arm simply as a way of running some Hoon code.
 
-Every expression of Hoon is evaluated relative to a subject.  What subject is the arm to be evaluated against?  Answer: the parent [core](/docs/glossary/core/) of that arm.
+Every expression of Hoon is evaluated relative to a subject. What subject is the arm to be evaluated against? Answer: the parent [core](/docs/glossary/core/) of that arm.
 
-So in order to understand fully what an arm is, you must understand what a core is.  Briefly, a **core** is a cell of `[battery payload]`.  The **battery** is a collection of one or more arms, and the **payload** is the data needed by the arms to evaluate correctly.  (The battery is code and the [payload](/docs/glossary/payload/) is data for that code.)  A given core is the **parent core** of all of the arms in its battery.
+So in order to understand fully what an arm is, you must understand what a core is. Briefly, a **core** is a cell of `[battery payload]`. The **battery** is a collection of one or more arms, and the **payload** is the data needed by the arms to evaluate correctly. (The battery is code and the [payload](/docs/glossary/payload/) is data for that code.) A given core is the **parent core** of all of the arms in its battery.
 
 ## Your First Core
 
 To clarify the basic idea, let's look at an example core.
 
-We'll make a core using a multi-line Hoon expression that is more complex than the other examples you've seen up to this point.  The dojo can be used to input multi-line Hoon expressions; just type each line, hitting 'enter' or 'return' at the end.  The expression will be evaluated at the appropriate line break, i.e., when the dojo recognizes it as a complete expression of Hoon.
+We'll make a core using a multi-line Hoon expression that is more complex than the other examples you've seen up to this point. The dojo can be used to input multi-line Hoon expressions; just type each line, hitting 'enter' or 'return' at the end. The expression will be evaluated at the appropriate line break, i.e., when the dojo recognizes it as a complete expression of Hoon.
 
-Use the following to bind `c` to a core.  It begins with a **rune**, `|%`, which is used for creating a core.  (A rune is just a pair of ASCII characters, and it usually indicates the beginning of a complex Hoon expression.)  Take note of the expression spacing -- Hoon uses significant whitespace.  Feel free to cut and paste the following expression into the dojo, starting with `=c`:
+Use the following to bind `c` to a core. It begins with a **rune**, `|%`, which is used for creating a core. (A rune is just a pair of ASCII characters, and it usually indicates the beginning of a complex Hoon expression.) Take note of the expression spacing -- Hoon uses significant whitespace. Feel free to cut and paste the following expression into the dojo, starting with `=c`:
 
 ```hoon
 > =c |%
@@ -33,11 +34,11 @@ Use the following to bind `c` to a core.  It begins with a **rune**, `|%`, which
   --
 ```
 
-This core has two arms, `twenty` and `double-twenty`.  Each arm definition begins with `++` followed by the name of that arm.  After that is the Hoon expression associated with that arm.  The first expression is the trivial `20` (guess what that does?), and the second is the slightly more interesting `(mul 2 twenty)`.
+This core has two arms, `twenty` and `double-twenty`. Each arm definition begins with `++` followed by the name of that arm. After that is the Hoon expression associated with that arm. The first expression is the trivial `20` (guess what that does?), and the second is the slightly more interesting `(mul 2 twenty)`.
 
 You can run these arms using `twenty.c` and `double-twenty.c`:
 
-```
+```hoon
 > twenty.c
 20
 
@@ -45,23 +46,23 @@ You can run these arms using `twenty.c` and `double-twenty.c`:
 40
 ```
 
-Notice that the second arm, `double-twenty`, makes use of the first arm, `twenty`.  It's able to do so because each arm is evaluated with its parent core as the subject.  Hence, each arm is able to use any other arm inside the parent core's battery.
+Notice that the second arm, `double-twenty`, makes use of the first arm, `twenty`. It's able to do so because each arm is evaluated with its parent core as the subject. Hence, each arm is able to use any other arm inside the parent core's battery.
 
 ### `|%` Expressions
 
 Before moving on let's talk about what each part of the `|%` expression is for.
 
-The `|%` indicates the beginning of an expression that produces a core.  The `++` rune is used to define each of the arms of the core's battery, and is followed by both an arm name and a Hoon expression.  The `--` rune is used to indicate that there are no more arms to be defined, and indicates the end of the expression.
+The `|%` indicates the beginning of an expression that produces a core. The `++` rune is used to define each of the arms of the core's battery, and is followed by both an arm name and a Hoon expression. The `--` rune is used to indicate that there are no more arms to be defined, and indicates the end of the expression.
 
-The battery of the core to be produced is explicitly defined by the `|%` expression.  The payload of the core to be produced is implicitly defined as the subject of the `|%` expression.  Let's unbind `c` to keep the subject clean:
+The battery of the core to be produced is explicitly defined by the `|%` expression. The payload of the core to be produced is implicitly defined as the subject of the `|%` expression. Let's unbind `c` to keep the subject clean:
 
-```
+```hoon
 > =c
 ```
 
 ## Cores
 
-Let's go over what a core is a little more carefully and comprehensively.  As stated before, a **core** is a cell of a **battery** and a **payload**.
+Let's go over what a core is a little more carefully and comprehensively. As stated before, a **core** is a cell of a **battery** and a **payload**.
 
 ```
 A core:  [battery payload]
@@ -69,37 +70,37 @@ A core:  [battery payload]
 
 ### Battery
 
-A battery is a collection of arms.  An arm is an encoded Hoon expression, to be used for running computations.  Each arm has a name.  Arm naming rules are the same kebab-case rules that faces have.  When an arm is evaluated, it uses its parent core as the subject.
+A battery is a collection of arms. An arm is an encoded Hoon expression, to be used for running computations. Each arm has a name. Arm naming rules are the same kebab-case rules that faces have. When an arm is evaluated, it uses its parent core as the subject.
 
-That's all you really need to know about the battery.  You can become a master Hoon programmer if you know what is stated above but otherwise think of the battery as a black box.
+That's all you really need to know about the battery. You can become a master Hoon programmer if you know what is stated above but otherwise think of the battery as a black box.
 
-If you'd really like to know, technically a battery is a tree of Nock formulas, one formula per each arm.  Again, however, you don't need to understand the first thing about Nock to understand Hoon.
+If you'd really like to know, technically a battery is a tree of Nock formulas, one formula per each arm. Again, however, you don't need to understand the first thing about Nock to understand Hoon.
 
 ### Payload
 
-The payload contains all the data needed for running the arms in the battery correctly.  In principle, the payload of a core can have data arranged in any arbitrary configuration.  In practice, the payload often has a predictable structure of its own.
+The payload contains all the data needed for running the arms in the battery correctly. In principle, the payload of a core can have data arranged in any arbitrary configuration. In practice, the payload often has a predictable structure of its own.
 
-The payload may include other cores.  Consequently, a core's payload can include other 'code' -- cores in the payload have their own battery arms.
+The payload may include other cores. Consequently, a core's payload can include other 'code' -- cores in the payload have their own battery arms.
 
 ### Subject Organization for Arm Computation
 
-Why must an arm have its parent core as the subject, when it's computed?  As stated previously, the payload of a core contains all the data needed for computing the arms of that core.  Arms can only access data in the subject.  By requiring that the parent core be the subject we guarantee that each arm has the appropriate data available to it.  The tail of its subject contains the payload and thus all the values therein.  The head of the subject is the battery, which allows for making reference to sibling arms of that same core.
+Why must an arm have its parent core as the subject, when it's computed? As stated previously, the payload of a core contains all the data needed for computing the arms of that core. Arms can only access data in the subject. By requiring that the parent core be the subject we guarantee that each arm has the appropriate data available to it. The tail of its subject contains the payload and thus all the values therein. The head of the subject is the battery, which allows for making reference to sibling arms of that same core.
 
 Let's look at an example in which the payload information is needed for correct arm evaluation.
 
 ## Another Example Core
 
-First let's use the dojo to bind the face `a` to the value `12`, and the face `b` to the value `[22 24]`.  These values will be used in the arms of the core we're going to make.
+First let's use the dojo to bind the face `a` to the value `12`, and the face `b` to the value `[22 24]`. These values will be used in the arms of the core we're going to make.
 
-```
+```hoon
 > =a 12
 
 > =b [22 24]
 ```
 
-Now use the following multi-line expression to bind `c` to a core.  As before, feel free to cut and paste the following expression into the dojo (starting at `=c`):
+Now use the following multi-line expression to bind `c` to a core. As before, feel free to cut and paste the following expression into the dojo (starting at `=c`):
 
-```
+```hoon
 > =c |%
   ++  two  2
   ++  inc  (add 1 a)
@@ -108,13 +109,13 @@ Now use the following multi-line expression to bind `c` to a core.  As before, f
   --
 ```
 
-Note: binding `c` to the core created by the `|%` expression will fail unless you have already bound `a` and `b` to the relevant values, as we did above.  Our having already bound them is what lets us use them in the `|%` expression.
+Note: binding `c` to the core created by the `|%` expression will fail unless you have already bound `a` and `b` to the relevant values, as we did above. Our having already bound them is what lets us use them in the `|%` expression.
 
-The `|%` expression above creates a core with four arms.  The first, named `two`, evaluates to the constant `2`.  The second arm, `inc`, adds `1` to `a`.  `double` returns double the value of `a`, and `sum` returns the sum of the two [atoms](/docs/glossary/atom/) in `b`.  The computations defined by these arms are pretty simple (and in the case of `two`, trivial), but a good starting point for learning about cores.
+The `|%` expression above creates a core with four arms. The first, named `two`, evaluates to the constant `2`. The second arm, `inc`, adds `1` to `a`. `double` returns double the value of `a`, and `sum` returns the sum of the two [atoms](/docs/glossary/atom/) in `b`. The computations defined by these arms are pretty simple (and in the case of `two`, trivial), but a good starting point for learning about cores.
 
 Let's run the arm names in the dojo:
 
-```
+```hoon
 > two.c
 2
 
@@ -130,13 +131,13 @@ Let's run the arm names in the dojo:
 
 Ideally these wing expressions behave the way you expected!
 
-To reiterate a point made earlier: a wing resolution to a leg returns the value of that leg.  A wing resolution to an arm returns the value produced by the arm computation.
+To reiterate a point made earlier: a wing resolution to a leg returns the value of that leg. A wing resolution to an arm returns the value produced by the arm computation.
 
 ### Dissecting a Core
 
 Enter `c` in the dojo to look at this core as printed data:
 
-```
+```hoon
 > c
 < 4.cvq
   { {{a/@ud b/{@ud @ud}} our/@p now/@da eny/@uvJ}
@@ -145,15 +146,15 @@ Enter `c` in the dojo to look at this core as printed data:
 >
 ```
 
-`c`, like all cores, is a cell of `[battery payload]`, and it's pretty-printed inside a set of angled brackets: `< >`.  The battery of four arms is represented by the pretty-printer as `4.cvq`.  The `4` represents the number of arms in the battery, and the `cvq` is a [hash](https://en.wikipedia.org/wiki/Hash_function) of the battery.
+`c`, like all cores, is a cell of `[battery payload]`, and it's pretty-printed inside a set of angled brackets: `< >`. The battery of four arms is represented by the pretty-printer as `4.cvq`. The `4` represents the number of arms in the battery, and the `cvq` is a [hash](https://en.wikipedia.org/wiki/Hash_function) of the battery.
 
-The tail, i.e., the payload, might look suspiciously familiar.  It looks an awful lot like the default dojo subject, which has `our`, `now`, and `eny` in the head, but it also has `a` and `b`, which we also bound in the dojo subject.  That's exactly what the payload is.  The tail is a copy of what the subject was for the `|%` expression.  (It's pretty-printed in a slightly compressed way).
+The tail, i.e., the payload, might look suspiciously familiar. It looks an awful lot like the default dojo subject, which has `our`, `now`, and `eny` in the head, but it also has `a` and `b`, which we also bound in the dojo subject. That's exactly what the payload is. The tail is a copy of what the subject was for the `|%` expression. (It's pretty-printed in a slightly compressed way).
 
-(You'll notice that there are several other cores in the payload.  For example, `19.anu` is a battery of `19` arms, `24.tmo` is a battery of `24` arms, etc.)
+(You'll notice that there are several other cores in the payload. For example, `19.anu` is a battery of `19` arms, `24.tmo` is a battery of `24` arms, etc.)
 
 This means, among other things, that we should be able to unbind `a` and `b` in the subject, but the arms of `c` should still work correctly:
 
-```
+```hoon
 > =a
 
 > =b
@@ -171,17 +172,17 @@ This means, among other things, that we should be able to unbind `a` and `b` in 
 46
 ```
 
-This works because `a` and `b` were copied into the core payload when the core was initially created.  Unbinding them in the dojo subject doesn't matter to the arms in `c`, which only look in `c`'s payload anyway.
+This works because `a` and `b` were copied into the core payload when the core was initially created. Unbinding them in the dojo subject doesn't matter to the arms in `c`, which only look in `c`'s payload anyway.
 
-The payload stores all the data needed to compute the arms correctly.  That also includes `add` and `mul`, which themselves are arms in a core of the Hoon standard library.  This library core is available as part of the default dojo subject.
+The payload stores all the data needed to compute the arms correctly. That also includes `add` and `mul`, which themselves are arms in a core of the Hoon standard library. This library core is available as part of the default dojo subject.
 
 ## Wings that Resolve to Arms
 
-To reinforce your newfound understanding of arms and cores, let's go over the various ways that wings resolve to arms in cores.  Remember that face resolution to a leg of the subject produces the leg value unchanged, but resolution to an arm produces the _computed_ value of that arm.
+To reinforce your newfound understanding of arms and cores, let's go over the various ways that wings resolve to arms in cores. Remember that face resolution to a leg of the subject produces the leg value unchanged, but resolution to an arm produces the _computed_ value of that arm.
 
 ### Address-Based Wings
 
-In the [previous lesson](@/docs/hoon/hoon-school/the-subject-and-its-legs.md), you saw how the following expressions return legs based on an address in the subject: `+n`, `.`, `-`, `+`, `+>`, `+<`, `->`, `-<`, `&`, `|` etc.  When these resolve to the part of the subject containing an arm, they **don't** evaluate the arm.  They simply return the indicated noun fragment of the subject, as if it were a leg.
+In the [previous lesson](@/docs/hoon/hoon-school/the-subject-and-its-legs.md), you saw how the following expressions return legs based on an address in the subject: `+n`, `.`, `-`, `+`, `+>`, `+<`, `->`, `-<`, `&`, `|` etc. When these resolve to the part of the subject containing an arm, they **don't** evaluate the arm. They simply return the indicated noun fragment of the subject, as if it were a leg.
 
 Let's use `-.c` to look at the head of `c`, i.e., the battery of the core:
 
@@ -209,13 +210,13 @@ Let's use `-.c` to look at the head of `c`, i.e., the battery of the core:
 ]
 ```
 
-The result is a tree of uncomputed Nock formulas.  But you virtually never need to see or use this raw data.  Generally speaking, don't use address-based expressions to look at arms for any reason other than to satisfy your curiosity (and even then only if you've learned or plan to learn Nock).  Use name-based expressions instead.
+The result is a tree of uncomputed Nock formulas. But you virtually never need to see or use this raw data. Generally speaking, don't use address-based expressions to look at arms for any reason other than to satisfy your curiosity (and even then only if you've learned or plan to learn Nock). Use name-based expressions instead.
 
 ### Name-based Wings
 
-To get the arm of a core to compute you must use its name.  The arm names of `c` are in the expression used to create `c`:
+To get the arm of a core to compute you must use its name. The arm names of `c` are in the expression used to create `c`:
 
-```
+```hoon
 > =c |%
   ++  two  2
   ++  inc  (add 1 a)
@@ -226,7 +227,7 @@ To get the arm of a core to compute you must use its name.  The arm names of `c`
 
 We evaluated the arms of `c` previously:
 
-```
+```hoon
 > two.c
 2
 
@@ -242,7 +243,7 @@ We evaluated the arms of `c` previously:
 
 You can also evaluate the arms of `c` using `:` instead:
 
-```
+```hoon
 > two:c
 2
 
@@ -256,13 +257,13 @@ You can also evaluate the arms of `c` using `:` instead:
 46
 ```
 
-The difference between `two.c` and `two:c` is as follows.  `two.c` is an instruction for finding `two` in `c` in the subject.  `two:c` is an instruction for setting `c` as the subject, and then for finding `two`.  In the examples above both versions amount to the same thing, and so return the same product.  (There are other cases in which `two.c` and `two:c` _don't_ amount to the same thing.  We'll address the difference in more detail later.)
+The difference between `two.c` and `two:c` is as follows. `two.c` is an instruction for finding `two` in `c` in the subject. `two:c` is an instruction for setting `c` as the subject, and then for finding `two`. In the examples above both versions amount to the same thing, and so return the same product. (There are other cases in which `two.c` and `two:c` _don't_ amount to the same thing. We'll address the difference in more detail later.)
 
 ### Name Searches and Collisions
 
-It's possible to have 'name collisions' with faces and arm names.  Nothing prevents one from using the name of some arm as a face too.  For example:
+It's possible to have 'name collisions' with faces and arm names. Nothing prevents one from using the name of some arm as a face too. For example:
 
-```
+```hoon
 > double:c
 24
 
@@ -272,7 +273,7 @@ It's possible to have 'name collisions' with faces and arm names.  Nothing preve
 
 When `[double=123 c]` is the subject, the result is a cell of: (1) `double=123` and (2) the core `c`:
 
-```
+```hoon
 > [double=123 c]
 [ double=123
   < 4.cvq
@@ -283,9 +284,9 @@ When `[double=123 c]` is the subject, the result is a cell of: (1) `double=123` 
 ]
 ```
 
-Hoon doesn't know whether `double` is a face or an arm name until it conducts a search looking for name matches.  If it finds a face first, the value of the face is returned.  If it finds an arm first, the arm will be evaluated and the product returned.  You may use `^` to indicate that you want to skip the first match, and multiple `^`s to indicate multiple skips:
+Hoon doesn't know whether `double` is a face or an arm name until it conducts a search looking for name matches. If it finds a face first, the value of the face is returned. If it finds an arm first, the arm will be evaluated and the product returned. You may use `^` to indicate that you want to skip the first match, and multiple `^`s to indicate multiple skips:
 
-```
+```hoon
 > double:[double=123 c]
 123
 
@@ -301,9 +302,9 @@ Hoon doesn't know whether `double` is a face or an arm name until it conducts a 
 
 ### Modifying a Core's Payload
 
-We can produce a modified version of the core `c` in which `a` and `b` have different values.  A core is just a noun in the subject, so we can modify it in the way we learned to modify legs in the last lesson.  To change `a` to `99`, use `c(a 99)`:
+We can produce a modified version of the core `c` in which `a` and `b` have different values. A core is just a noun in the subject, so we can modify it in the way we learned to modify legs in the last lesson. To change `a` to `99`, use `c(a 99)`:
 
-```
+```hoon
 > c(a 99)
 < 4.cvq
   { {{a/@ud b/{@ud @ud}} our/@p now/@da eny/@uvJ}
@@ -315,9 +316,9 @@ We can produce a modified version of the core `c` in which `a` and `b` have diff
 12
 ```
 
-The expression `c(a 99)` produces a core exactly like `c` except that the value of `a` in the payload is `99` instead of `12`.  But when we evaluate `a.c` we still get the original value, `12`.  Why?  The value of `c` in the dojo is bound to the original core value, and will stay that way until we unbind `c` or bind it to something else.  We can ask for a modified copy of `c` but that value doesn't automatically persist.  It must be put into the subject if we're to find it there.  So how do we know that `c(a 99)` successfully modified the value of `a`?  We can check by setting the new version of the core as the subject and checking `a`:
+The expression `c(a 99)` produces a core exactly like `c` except that the value of `a` in the payload is `99` instead of `12`. But when we evaluate `a.c` we still get the original value, `12`. Why? The value of `c` in the dojo is bound to the original core value, and will stay that way until we unbind `c` or bind it to something else. We can ask for a modified copy of `c` but that value doesn't automatically persist. It must be put into the subject if we're to find it there. So how do we know that `c(a 99)` successfully modified the value of `a`? We can check by setting the new version of the core as the subject and checking `a`:
 
-```
+```hoon
 > a:c(a 99)
 99
 
@@ -327,7 +328,7 @@ The expression `c(a 99)` produces a core exactly like `c` except that the value 
 
 To make the modified core persist as `c`, we can rebind `c` to the new value:
 
-```
+```hoon
 > =c c(a 99)
 
 > a:c
@@ -339,7 +340,7 @@ To make the modified core persist as `c`, we can rebind `c` to the new value:
 
 We can make multiple changes to `c` at once:
 
-```
+```hoon
 > =c c(a 123, b [44 55])
 
 > a:c
@@ -363,22 +364,22 @@ We can make multiple changes to `c` at once:
 
 ### Arms on the Search Path
 
-A wing is a search path into the subject.  We've looked at some examples of wings that resolve to arms; e.g., `double.c`, which resolves to `double` in `c` in the subject.  In the latter example the arm `double` is the final limb in the resolution path.  What if an arm name in a wing isn't the final limb?  What if it's elsewhere in the wing path?
+A wing is a search path into the subject. We've looked at some examples of wings that resolve to arms; e.g., `double.c`, which resolves to `double` in `c` in the subject. In the latter example the arm `double` is the final limb in the resolution path. What if an arm name in a wing isn't the final limb? What if it's elsewhere in the wing path?
 
-Normally we might read a wing expression like `two.double.c` as '`two` in `double` in `c`'.  Does that make sense when `double` is itself an arm?  Try it:
+Normally we might read a wing expression like `two.double.c` as '`two` in `double` in `c`'. Does that make sense when `double` is itself an arm? Try it:
 
-```
+```hoon
 > two.double.c
 2
 ```
 
-It produces the value of `two` in `c`.  This is a fact in need of explanation.
+It produces the value of `two` in `c`. This is a fact in need of explanation.
 
-When arm names are included in the body of a wing, the resolution behavior is a little different from that of legs.  Instead of indicating that the wing resolution should continue in the arm itself, an arm name indicates that the resolution should continue in the parent core of the arm.
+When arm names are included in the body of a wing, the resolution behavior is a little different from that of legs. Instead of indicating that the wing resolution should continue in the arm itself, an arm name indicates that the resolution should continue in the parent core of the arm.
 
-So the meaning of `two.double.c` is, roughly, '`two` in the parent core of `double` in `c`'.  Of course, Hoon doesn't know that `double` is an arm until the search for it ends; but once the `double` arm is found, Hoon continues the resolution from _the parent core of_ `double`, not `double` itself.  It turns out in this case that this is a redundant step.  `c` is the parent core and was already in the wing path.  We can illustrate redundancy more dramatically:
+So the meaning of `two.double.c` is, roughly, '`two` in the parent core of `double` in `c`'. Of course, Hoon doesn't know that `double` is an arm until the search for it ends; but once the `double` arm is found, Hoon continues the resolution from _the parent core of_ `double`, not `double` itself. It turns out in this case that this is a redundant step. `c` is the parent core and was already in the wing path. We can illustrate redundancy more dramatically:
 
-```
+```hoon
 > double.two.sum.two.double.inc.c
 246
 
@@ -389,19 +390,19 @@ So the meaning of `two.double.c` is, roughly, '`two` in the parent core of `doub
 99
 ```
 
-In each of the following examples, the only wings that matter are `c` and whichever arm name is left-most in the expression.  The other arm names in the path simply resolve to their parent core, which is just `c`.
+In each of the following examples, the only wings that matter are `c` and whichever arm name is left-most in the expression. The other arm names in the path simply resolve to their parent core, which is just `c`.
 
 ### The `..arm` Syntax
 
-Let's say you have a wing that resolves to a leg of the subject.  In this wing is an arm name, e.g., `a.b.arm`.  As you learned in lesson 1.4, this should be read as '`a` in `b` in the parent core of `arm`'.  Speaking more directly: the wing resolution path goes through the parent core of the arm, not the arm itself.
+Let's say you have a wing that resolves to a leg of the subject. In this wing is an arm name, e.g., `a.b.arm`. As you learned in lesson 1.4, this should be read as '`a` in `b` in the parent core of `arm`'. Speaking more directly: the wing resolution path goes through the parent core of the arm, not the arm itself.
 
-Recall that using `.` by itself returns the whole subject.  With that in mind, take a moment to answer the following question on your own.  In general, what should the expression `..arm` produce?
+Recall that using `.` by itself returns the whole subject. With that in mind, take a moment to answer the following question on your own. In general, what should the expression `..arm` produce?
 
-Do you have an answer?  If not, consider going back and trying to figure it out before moving on.
+Do you have an answer? If not, consider going back and trying to figure it out before moving on.
 
-You may read `..arm` as '`.` of the parent core of `arm`'.  This amounts to just the parent core of `arm`.  Let's try this out with the arms of `c`:
+You may read `..arm` as '`.` of the parent core of `arm`'. This amounts to just the parent core of `arm`. Let's try this out with the arms of `c`:
 
-```
+```hoon
 > ..inc:c
 < 4.han
   { {our/@p now/@da eny/@uvJ}
@@ -417,25 +418,24 @@ You may read `..arm` as '`.` of the parent core of `arm`'.  This amounts to just
 >
 ```
 
-Yes, they match.  `..inc` of `c` is just the parent core of `inc`, `c` itself.  But why would we ever use `..inc` to refer to `c`?  It's much simpler to use `c`.
+Yes, they match. `..inc` of `c` is just the parent core of `inc`, `c` itself. But why would we ever use `..inc` to refer to `c`? It's much simpler to use `c`.
 
-Sometimes the `..arm` syntax is quite useful.  Often there is a core in the subject without a face bound to it; i.e., the core might be nameless.  In that case you can use an arm name in that core to refer to the whole core.
+Sometimes the `..arm` syntax is quite useful. Often there is a core in the subject without a face bound to it; i.e., the core might be nameless. In that case you can use an arm name in that core to refer to the whole core.
 
-For an example of this, consider the `add` arm of the Hoon standard library.  This arm is in a nameless core.  To see the parent core of `add`, try `..add`:
+For an example of this, consider the `add` arm of the Hoon standard library. This arm is in a nameless core. To see the parent core of `add`, try `..add`:
 
-```
+```hoon
 > ..add
 <74.dbd 1.qct $141>
 ```
 
 Here you see a core with a battery of 74 arms (!), and whose payload is another core with one arm.
 
-
 ### Evaluating an Arm Against a Modified Core
 
-Assume `this.is.a.wing` is a wing that resolves to an arm.  You can use the `this.is.a.wing(face new-value)` syntax to compute the arm against a modified version of the parent core of `this.is.a.wing`.
+Assume `this.is.a.wing` is a wing that resolves to an arm. You can use the `this.is.a.wing(face new-value)` syntax to compute the arm against a modified version of the parent core of `this.is.a.wing`.
 
-```
+```hoon
 > double.c(a 55)
 110
 
@@ -445,12 +445,11 @@ Assume `this.is.a.wing` is a wing that resolves to an arm.  You can use the `thi
 
 This almost looks like a function call of sorts.
 
-
 ### Cores, Gates, and Traps
 
 Let's take a quick look at the battery of one core in the dojo to show that this is true by inputting one into the dojo.
 
-```
+```hoon
 > =dec |%
   ++  dec
     |=  a=@
@@ -491,15 +490,17 @@ Again, being able to read Nock is not essential to understanding Hoon.
 ### Cores and Contexts
 
 Let's take a quick look at how cores can be combined with `=>` to build up
-larger structures.  `=>  p=hoon  q=hoon` yields the product of `q` with the product of `p` taken as the subject.
+larger structures. `=> p=hoon q=hoon` yields the product of `q` with the product of `p` taken as the subject.
 
 We can use this to set the context of cores. Recall that the payload of a gate
 is a cell of `[sample context]`. For example:
-```
+
+```hoon
 ~zod:dojo> =foo =>([1 2] |=(@ 15))
 > +3:foo
 [0 1 2]
 ```
+
 Here we have created a gate with `[1 2]` as its context that takes in an `@` and
 returns `15`. `+3:foo` shows the payload of the core to be `[0 [1 2]]`. Here `0`
 is the default value of `@` and is the sample, while `[1 2]` is the context that
@@ -507,6 +508,7 @@ was given to `foo`.
 
 `=>` (and its reversed version `=<`) are used extensively to put cores into the
 context of other cores.
+
 ```hoon
 =>
 |%
@@ -520,6 +522,7 @@ context of other cores.
   (mul (foo a) 2)
 --
 ```
+
 At the level of arms, `+foo` is in the subject of `+bar`, and so `+bar` is able to call `+foo`. On the other hand, `+bar` is not in the subject of `+foo`, so `+foo` cannot call `+bar` - you will get a `-find.bar` error.
 
 At the level of cores, the `=>` sets the context of the core containing `+bar` to be the core
@@ -531,18 +534,22 @@ the scope of `+bar` but not vice versa.
 Let's look inside `hoon.hoon`, where the standard library is located, to see how this is being used.
 
 The first core listed here has just one arm.
+
 ```hoon
 |%
 ++  hoon-version  141
 --
 ```
+
 This is reflected in the subject of `hoon-version`.
-```
+
+```hoon
 > ..hoon-version
 <1.ane $141>
 ```
 
 After several lines that we'll ignore for pedagogical purposes, we see
+
 ```hoon
 |%
 ::  #  %math
@@ -562,7 +569,9 @@ After several lines that we'll ignore for pedagogical purposes, we see
 ::
 ++  dec
 ```
+
 and so on, down to
+
 ```hoon
 ++  unit
   |$  [item]
@@ -574,22 +583,28 @@ and so on, down to
   $@(~ [~ u=item])
 --
 ```
-This core contains the arms in parts [1a-1c of the standard library documentation](@/docs/hoon/reference/stdlib/1a.md). If you count them, there are 41 arms in the core from `++  add` down to `++  unit`. We again can see this fact reflected in the dojo by looking at the subject of `add`.
-```
+
+This core contains the arms in parts [1a-1c of the standard library documentation](@/docs/hoon/reference/stdlib/1a.md). If you count them, there are 41 arms in the core from `++ add` down to `++ unit`. We again can see this fact reflected in the dojo by looking at the subject of `add`.
+
+```hoon
 > ..add
 <41.mac 1.ane $141>
 ```
+
 Here we see that core containing `hoon-version` is in the subject of the
 section one core.
 
 Next, [section two](@/docs/hoon/reference/stdlib/2a.md) starts:
-```
+
+```hoon
 =>
 ::                                                      ::
 ::::  2: layer two                                      ::
 ```
+
 ...
-```
+
+```hoon
 |%
 ::                                                      ::
 ::::  2a: unit logic                                    ::
@@ -602,34 +617,43 @@ Next, [section two](@/docs/hoon/reference/stdlib/2a.md) starts:
   ?~  a  ~
   (b u.a)
 ```
+
 If you counted the arms in this core by hand, you'll come up with 126 arms. This is also reflected in the dojo:
-```
+
+```hoon
 > ..biff
 <126.xjf 41.mac 1.ane $141>
 ```
+
 and we also see the section 1 core and the core containing `hoon-version` in the subject.
 
 We can also confirm that `add` is in the subject of `biff`
-```
+
+```hoon
 > add:biff
 <1.vwd {{a/@ b/@} <41.mac 1.ane $141>}>
 ```
+
 and that `biff` is not in the subject of `add`.
-```
+
+```hoon
 > biff:add
 -find.biff
 ```
 
 Lastly, let's check the subject of the last arm in `hoon.hoon` (as of November 2019)
-```
+
+```hoon
 > ..pi-tell
 <92.nnn 247.tye 51.mvt 126.xjf 41.mac 1.ane $141>
 ```
+
 This confirms for us, then, that `hoon.hoon` consists of six nested cores, with one
 inside the payload of the next, with
 the `hoon-version` core most deeply nested.
 
 #### Exercise 1.7a
+
 Pick a couple of arms in `hoon.hoon` and check to make sure that they are only
 referenced in its parent core or core(s) that have the parent core put in its
 context via the `=>` or `=<` runes.
@@ -640,11 +664,11 @@ Once again we remind you it's a good idea when writing your code to cast your da
 
 ## Summary
 
-At this point you should have a pretty good understanding of what an arm is, and how wing resolution to an arm works.  But so far the arms you've created have been fairly simple.  In the next lesson you'll learn about Hoon functions, and how to create your own.
+At this point you should have a pretty good understanding of what an arm is, and how wing resolution to an arm works. But so far the arms you've created have been fairly simple. In the next lesson you'll learn about Hoon functions, and how to create your own.
 
 You can now unbind `c` in the dojo -- this will help to keep your dojo subject tidy:
 
-```
+```hoon
 > =c
 
 > c

--- a/hoon/hoon-school/atoms-auras-and-simple-cell-types.md
+++ b/hoon/hoon-school/atoms-auras-and-simple-cell-types.md
@@ -4,33 +4,34 @@ weight = 24
 template = "doc.html"
 aliases = ["/docs/learn/hoon/hoon-tutorial/atoms-auras-and-simple-cell-types/"]
 +++
-Like most modern high-level programming languages, Hoon has a type system.  Because Hoon is a functional programming language, its type system differs somewhat from those of non-functional languages.  In the next few lessons we'll go over Hoon's type system and point out some of its distinctive features.  Certain advanced topics (e.g. type [polymorphism](https://en.wikipedia.org/wiki/Polymorphism_%28computer_science%29)) won't be addressed until a later chapter.
 
-A type is ordinarily understood to be a set of values.  Examples: the set of all [atoms](/docs/glossary/atom/) is a type, the set of all cells is a type, and so on.
+Like most modern high-level programming languages, Hoon has a type system. Because Hoon is a functional programming language, its type system differs somewhat from those of non-functional languages. In the next few lessons we'll go over Hoon's type system and point out some of its distinctive features. Certain advanced topics (e.g. type [polymorphism](https://en.wikipedia.org/wiki/Polymorphism_%28computer_science%29)) won't be addressed until a later chapter.
 
-Type systems provide type safety, in part by making sure functions produce values of the correct type.  When you write a function whose product is intended to be an atom, it would be nice to know that the function is guaranteed to produce an atom.  Hoon's type system provides such guarantees with **type checking** and **type inference**.
+A type is ordinarily understood to be a set of values. Examples: the set of all [atoms](/docs/glossary/atom/) is a type, the set of all cells is a type, and so on.
+
+Type systems provide type safety, in part by making sure functions produce values of the correct type. When you write a function whose product is intended to be an atom, it would be nice to know that the function is guaranteed to produce an atom. Hoon's type system provides such guarantees with **type checking** and **type inference**.
 
 ## Brief Overview of the Next Few Lessons
 
 In order to have a solid foundational knowledge of Hoon's type system, you must understand: (1) precisely what kind of information is tracked by Hoon's type system, (2) what a type check is and where they occur, (3) what type inference is and how it works, and (4) how to build your own custom types.
 
-In this lesson we'll cover (1)-(4) as they pertain to atoms and simple cell types.  In the next lesson (2) and (3) will be addressed as they pertain to complex expressions of Hoon.  In the lesson after that you'll learn more about (4), for building more complex types.
+In this lesson we'll cover (1)-(4) as they pertain to atoms and simple cell types. In the next lesson (2) and (3) will be addressed as they pertain to complex expressions of Hoon. In the lesson after that you'll learn more about (4), for building more complex types.
 
 ## Atoms and Auras
 
-In [Lesson 1.2](@/docs/hoon/hoon-school/nouns.md) we defined what an atom is: any unsigned integer.  In this lesson we'll expand on that discussion, going over how Hoon's type system implements auras.
+In [Lesson 1.2](@/docs/hoon/hoon-school/nouns.md) we defined what an atom is: any unsigned integer. In this lesson we'll expand on that discussion, going over how Hoon's type system implements auras.
 
-In the most straightforward sense, atoms simply are unsigned integers.  But they can also be interpreted as representing signed integers, ASCII symbols, floating-point values, dates, binary numbers, hexadecimal numbers, and more.  Every atom is, in and of itself, just an unsigned integer; but Hoon keeps track of type information about each atom, and this info tells Hoon how to interpret the atom in question.
+In the most straightforward sense, atoms simply are unsigned integers. But they can also be interpreted as representing signed integers, ASCII symbols, floating-point values, dates, binary numbers, hexadecimal numbers, and more. Every atom is, in and of itself, just an unsigned integer; but Hoon keeps track of type information about each atom, and this info tells Hoon how to interpret the atom in question.
 
-The piece of type information that determines how Hoon interprets an atom is called an **aura**.  The set of all atoms is indicated with the symbol `@`.  An aura is indicated with `@` followed by some letters, e.g., `@ud` for unsigned decimal.  Accordingly, the Hoon type system does more than track sets of values.  It also tracks certain other relevant metadata about how those values are to be interpreted.
+The piece of type information that determines how Hoon interprets an atom is called an **aura**. The set of all atoms is indicated with the symbol `@`. An aura is indicated with `@` followed by some letters, e.g., `@ud` for unsigned decimal. Accordingly, the Hoon type system does more than track sets of values. It also tracks certain other relevant metadata about how those values are to be interpreted.
 
-How is aura information generated so that it can be tracked?  One way involves **type inference**.  In certain cases Hoon's type system can infer the type of an expression using syntactic clues.  In the most straightforward case of type inference, the expression is simply data as a [literal](https://en.wikipedia.org/wiki/Literal_%28computer_programming%29).  Hoon recognizes the aura literal syntax and infers that the data in question is an atom with the aura associated with that syntax.
+How is aura information generated so that it can be tracked? One way involves **type inference**. In certain cases Hoon's type system can infer the type of an expression using syntactic clues. In the most straightforward case of type inference, the expression is simply data as a [literal](https://en.wikipedia.org/wiki/Literal_%28computer_programming%29). Hoon recognizes the aura literal syntax and infers that the data in question is an atom with the aura associated with that syntax.
 
-To see the inferred type of a literal expression in the dojo, use the `?` operator.  (Note: this operator isn't part of the Hoon programming language; it's a dojo-only tool.  It's a very useful tool for learning about types in Hoon, however.)
+To see the inferred type of a literal expression in the dojo, use the `?` operator. (Note: this operator isn't part of the Hoon programming language; it's a dojo-only tool. It's a very useful tool for learning about types in Hoon, however.)
 
-The `?` dojo operator shows both the product and the inferred type of an expression.  Let's try `?` on `15`:
+The `?` dojo operator shows both the product and the inferred type of an expression. Let's try `?` on `15`:
 
-```
+```hoon
 > 15
 15
 
@@ -39,41 +40,41 @@ The `?` dojo operator shows both the product and the inferred type of an express
 15
 ```
 
-The `@ud` is the inferred type of `15` (and of course `15` is the product).  The `@` is for 'atom' and the `ud` is for 'unsigned decimal'.  The letters after the `@` indicate the 'aura' of the atom.
+The `@ud` is the inferred type of `15` (and of course `15` is the product). The `@` is for 'atom' and the `ud` is for 'unsigned decimal'. The letters after the `@` indicate the 'aura' of the atom.
 
-One important role played by the type system is to make sure that the output of an expression is of the intended data type.  If the output is of the wrong type then the programmer did something wrong.  But how does Hoon know what the intended data type is?  The programmer must specify this explicitly by using a 'cast'.  To cast for an unsigned decimal atom, you can use the `^-` rune along with the `@ud` from above.
+One important role played by the type system is to make sure that the output of an expression is of the intended data type. If the output is of the wrong type then the programmer did something wrong. But how does Hoon know what the intended data type is? The programmer must specify this explicitly by using a 'cast'. To cast for an unsigned decimal atom, you can use the `^-` rune along with the `@ud` from above.
 
-What exactly does the `^-` rune do?  It compares the inferred type of some expression with the desired cast type.  If the expression's inferred type 'nests' under the desired type, then the product of the expression is returned.
+What exactly does the `^-` rune do? It compares the inferred type of some expression with the desired cast type. If the expression's inferred type 'nests' under the desired type, then the product of the expression is returned.
 
-Let's try one in the dojo.  For the expression to be assessed we'll use `15` again:
+Let's try one in the dojo. For the expression to be assessed we'll use `15` again:
 
-```
+```hoon
 > ^-(@ud 15)
 15
 ```
 
-Because `@ud` is the inferred type of `15`, the cast succeeds.  Notice that the `^-` expression never does anything to modify the underlying [noun](/docs/glossary/noun/) of the second subexpression.  It's used simply to mandate a type-check on that expression.  This check occurs at compile-time (i.e., when the expression is compiled to Nock).
+Because `@ud` is the inferred type of `15`, the cast succeeds. Notice that the `^-` expression never does anything to modify the underlying [noun](/docs/glossary/noun/) of the second subexpression. It's used simply to mandate a type-check on that expression. This check occurs at compile-time (i.e., when the expression is compiled to Nock).
 
-What about when the inferred type doesn't fit under the cast type?  You get a `nest-fail` crash at compile-time:
+What about when the inferred type doesn't fit under the cast type? You get a `nest-fail` crash at compile-time:
 
-```
+```hoon
 > ^-(@ud [13 14])
 nest-fail
 [crash message]
 ```
 
-Why 'nest-fail'?  The inferred type of `[13 14]` doesn't 'nest' under the cast type `@ud`.  It's a cell, not an atom.  But if we use the symbol for nouns, `*`, then the cast succeeds:
+Why 'nest-fail'? The inferred type of `[13 14]` doesn't 'nest' under the cast type `@ud`. It's a cell, not an atom. But if we use the symbol for nouns, `*`, then the cast succeeds:
 
-```
+```hoon
 > ^-(* [13 14])
 [13 14]
 ```
 
-A cell of atoms is a noun, so the inferred type of `[13 14]` nests under `*`.  Every product of a Hoon expression nests under `*` because every product is a noun.
+A cell of atoms is a noun, so the inferred type of `[13 14]` nests under `*`. Every product of a Hoon expression nests under `*` because every product is a noun.
 
 ## What Auras are There?
 
-Hoon has a wide (but not extensible) variety of atom literal syntaxes.  Each literal syntax indicates to the Hoon type checker which predefined aura is intended.  Hoon can also pretty-print any aura literal it can parse.  Because atoms make great path nodes and paths make great URLs, all regular atom literal syntaxes use only URL-safe characters.
+Hoon has a wide (but not extensible) variety of atom literal syntaxes. Each literal syntax indicates to the Hoon type checker which predefined aura is intended. Hoon can also pretty-print any aura literal it can parse. Because atoms make great path nodes and paths make great URLs, all regular atom literal syntaxes use only URL-safe characters.
 
 Here's a non-exhaustive list of auras, along with examples of corresponding literal syntax:
 
@@ -107,15 +108,15 @@ Aura         Meaning                        Example Literal Syntax
   @ux           unsigned hexadecimal        0x5f5.e138
 ```
 
-Some of these auras nest under others.  For example, `@u` is for all unsigned auras.  But there are other, more specific auras; `@ub` for unsigned binary numbers, `@ux` for unsigned hexadecimal numbers, etc.
+Some of these auras nest under others. For example, `@u` is for all unsigned auras. But there are other, more specific auras; `@ub` for unsigned binary numbers, `@ux` for unsigned hexadecimal numbers, etc.
 
 For a more complete list of auras, see [Auras](@/docs/hoon/reference/auras.md).
 
 ## Aura Inference in Hoon
 
-Let's do more examples in the Dojo using the `?` operator.  We'll focus on just the unsigned auras for now:
+Let's do more examples in the Dojo using the `?` operator. We'll focus on just the unsigned auras for now:
 
-```
+```hoon
 > 15
 15
 
@@ -131,15 +132,15 @@ Let's do more examples in the Dojo using the `?` operator.  We'll focus on just 
 0x15
 ```
 
-When you enter just `15`, the Hoon type checker infers from the syntax that its aura is `@ud` because you typed an unsigned integer in decimal notation.  Hence, when you use `?` to check the aura, you get `@ud`.
+When you enter just `15`, the Hoon type checker infers from the syntax that its aura is `@ud` because you typed an unsigned integer in decimal notation. Hence, when you use `?` to check the aura, you get `@ud`.
 
-And when you enter `0x15` the type checker infers that its aura is `@ux`, because you used `0x` before the number to indicate the unsigned hexadecimal literal syntax.  In both cases, Hoon pretty-prints the appropriate literal syntax by using inferred type information from the input expression; the Dojo isn't (just) echoing what you enter.
+And when you enter `0x15` the type checker infers that its aura is `@ux`, because you used `0x` before the number to indicate the unsigned hexadecimal literal syntax. In both cases, Hoon pretty-prints the appropriate literal syntax by using inferred type information from the input expression; the Dojo isn't (just) echoing what you enter.
 
-More generally: for each atom expression in Hoon, you can use the literal syntax of an aura to force Hoon to interpret the atom as having that aura type.  For example, when you type `~sorreg-namtyv` Hoon will interpret it as an atom with aura `@p` and treat it accordingly.
+More generally: for each atom expression in Hoon, you can use the literal syntax of an aura to force Hoon to interpret the atom as having that aura type. For example, when you type `~sorreg-namtyv` Hoon will interpret it as an atom with aura `@p` and treat it accordingly.
 
 Here's another example of type inference at work:
 
-```
+```hoon
 > (add 15 15)
 30
 
@@ -155,9 +156,9 @@ Here's another example of type inference at work:
 36
 ```
 
-The `add` function in the Hoon standard library operates on all atoms, regardless of aura, and returns atoms with no aura specified.  Hoon isn't able to infer anything more specific than `@` for the product of `add`.  This is by design, however.  Notice that when you `add` a decimal and a hexadecimal above, the correct answer is returned (pretty-printed as a decimal).  This works for all of the unsigned auras:
+The `add` function in the Hoon standard library operates on all atoms, regardless of aura, and returns atoms with no aura specified. Hoon isn't able to infer anything more specific than `@` for the product of `add`. This is by design, however. Notice that when you `add` a decimal and a hexadecimal above, the correct answer is returned (pretty-printed as a decimal). This works for all of the unsigned auras:
 
-```
+```hoon
 > (add 100 0b101)
 105
 
@@ -168,15 +169,15 @@ The `add` function in the Hoon standard library operates on all atoms, regardles
 30
 ```
 
-The reason these add up correctly is that unsigned auras all map directly to the 'correct' atom underneath.  For example, `16`, `0b1.0000`, and `0x10` are all the exact same atom, just with different literal syntax.  (This doesn't hold for signed versions of the auras!)
+The reason these add up correctly is that unsigned auras all map directly to the 'correct' atom underneath. For example, `16`, `0b1.0000`, and `0x10` are all the exact same atom, just with different literal syntax. (This doesn't hold for signed versions of the auras!)
 
 ## Auras as 'Soft' Types
 
-It's important to understand that Hoon's type system doesn't enforce auras as strictly as it does other types.  Auras are 'soft' type information.  To see how this works, we'll take you through the process of converting the aura of an atom to another aura.
+It's important to understand that Hoon's type system doesn't enforce auras as strictly as it does other types. Auras are 'soft' type information. To see how this works, we'll take you through the process of converting the aura of an atom to another aura.
 
 Hoon makes **some** effort to enforce that the correct aura is produced by an expression:
 
-```
+```hoon
 > ^-(@ud 0x10)
 nest-fail
 
@@ -187,9 +188,9 @@ nest-fail
 nest-fail
 ```
 
-But there are ways around this.  First, you can cast to a more general aura, as long as the current aura nests under the cast aura.  E.g., `@ub` to `@u`, `@ux` to `@u`, `@u` to `@`, etc.  By doing this you're essentially telling Hoon to throw away some aura information:
+But there are ways around this. First, you can cast to a more general aura, as long as the current aura nests under the cast aura. E.g., `@ub` to `@u`, `@ux` to `@u`, `@u` to `@`, etc. By doing this you're essentially telling Hoon to throw away some aura information:
 
-```
+```hoon
 > ^-(@u 0x10)
 16
 
@@ -207,7 +208,7 @@ But there are ways around this.  First, you can cast to a more general aura, as 
 
 In fact, you can cast any atom all the way to the most general case `@`:
 
-```
+```hoon
 > ^-(@ 0x10)
 16
 
@@ -223,9 +224,9 @@ In fact, you can cast any atom all the way to the most general case `@`:
 2
 ```
 
-Anything of the general aura `@` can, in turn, be cast to more specific auras.  We can show this by embedding a cast expression inside another cast:
+Anything of the general aura `@` can, in turn, be cast to more specific auras. We can show this by embedding a cast expression inside another cast:
 
-```
+```hoon
 > ^-(@ud ^-(@ 0x10))
 16
 
@@ -238,15 +239,15 @@ Anything of the general aura `@` can, in turn, be cast to more specific auras.  
 
 Hoon uses the outermost cast to infer the type:
 
-```
+```hoon
 > ? ^-(@ub ^-(@ 0x10))
   @ub
 0b1.0000
 ```
 
-As you can see, an atom with one aura can be converted to another aura.  For a convenient shorthand, you can do this conversion with irregular cast syntax, e.g. `` `@ud` ``, rather than using the `^-` rune twice:
+As you can see, an atom with one aura can be converted to another aura. For a convenient shorthand, you can do this conversion with irregular cast syntax, e.g. `` `@ud` ``, rather than using the `^-` rune twice:
 
-```
+```hoon
 > `@ud`0x10
 16
 
@@ -257,15 +258,15 @@ As you can see, an atom with one aura can be converted to another aura.  For a c
 0xa
 ```
 
-This is what we mean when we call auras 'soft' types.  The above examples show that the programmer can get around the type system for auras by casting up to `@` and then back down to the specific aura, say `@ub`; or by casting with `` `@ub` `` for short.
+This is what we mean when we call auras 'soft' types. The above examples show that the programmer can get around the type system for auras by casting up to `@` and then back down to the specific aura, say `@ub`; or by casting with `` `@ub` `` for short.
 
 ## Examples
 
-So far you've only used the auras for unsigned integers.  Let's try some others.
+So far you've only used the auras for unsigned integers. Let's try some others.
 
 ### Signed integers
 
-```
+```hoon
 > -7
 -7
 
@@ -280,20 +281,20 @@ So far you've only used the auras for unsigned integers.  Let's try some others.
 --7
 ```
 
-`--7` means "positive 7".  `+7` might have been better but `+` is not URL-safe.
+`--7` means "positive 7". `+7` might have been better but `+` is not URL-safe.
 
-Hoon needs `--` to distinguish positive signed numbers such as `--7` from the unsigned `7`.  The latter is always understood by Hoon as an unsigned literal.  If you want Hoon to infer that a literal is signed you must explicitly include the `--`.
+Hoon needs `--` to distinguish positive signed numbers such as `--7` from the unsigned `7`. The latter is always understood by Hoon as an unsigned literal. If you want Hoon to infer that a literal is signed you must explicitly include the `--`.
 
 Whereas we could use the `add` function on different unsigned auras and still get the correct answer, this doesn't work for signed auras:
 
-```
+```hoon
 > (add -7 --7)
 27
 ```
 
-Why not?  `add` is happy to operate on any atom, regardless of aura, but it's intended for auras whose literals map directly to numerically equivalent general atoms `@`.  For example, the `@ud` `7`, the `@ub` `0b111`, and the `@ux` `0x7` all map to the same `@` `7`.  Signed literals such as `--7` are different, because some underlying atoms are used for representing negative numbers.  We can see how this works by forcibly converting `@sd` atoms to `@ud`:
+Why not? `add` is happy to operate on any atom, regardless of aura, but it's intended for auras whose literals map directly to numerically equivalent general atoms `@`. For example, the `@ud` `7`, the `@ub` `0b111`, and the `@ux` `0x7` all map to the same `@` `7`. Signed literals such as `--7` are different, because some underlying atoms are used for representing negative numbers. We can see how this works by forcibly converting `@sd` atoms to `@ud`:
 
-```
+```hoon
 > `@ud`-1
 1
 
@@ -309,7 +310,7 @@ Why not?  `add` is happy to operate on any atom, regardless of aura, but it's in
 
 If you want to add signed atoms use the function `sum:si` instead of `add`:
 
-```
+```hoon
 > (sum:si -7 --7)
 --0
 
@@ -326,13 +327,13 @@ If you want to add signed atoms use the function `sum:si` instead of `add`:
 
 ### Exercise 2.1a
 
-Does Hoon's `@s` aura make a distinction between positive and negative zero, e.g., `-0` and `--0`?  Use what you've learned in this lesson so far to come up with a principled answer.  (As always, exercise solutions are at the bottom of the lesson.)
+Does Hoon's `@s` aura make a distinction between positive and negative zero, e.g., `-0` and `--0`? Use what you've learned in this lesson so far to come up with a principled answer. (As always, exercise solutions are at the bottom of the lesson.)
 
 ### Text and Symbols
 
-Atoms can also represent text.  The `@t` aura is for UTF-8 text.  We call `@t` strings 'cords' (to distinguish them from tapes, e.g., `"hello!"`):
+Atoms can also represent text. The `@t` aura is for UTF-8 text. We call `@t` strings 'cords' (to distinguish them from tapes, e.g., `"hello!"`):
 
-```
+```hoon
 > ? 'Ürbit'
   @t
 'Ürbit'
@@ -350,11 +351,11 @@ Atoms can also represent text.  The `@t` aura is for UTF-8 text.  We call `@t` s
 't'
 ```
 
-As you can see by casting a cord to `@ux`, the first byte (here the `74` of `0x74`) represents the last character of the cord.  The next byte is the next to last character, and so on.
+As you can see by casting a cord to `@ux`, the first byte (here the `74` of `0x74`) represents the last character of the cord. The next byte is the next to last character, and so on.
 
-Hoon also has `@ta`, which is intended for ASCII text.  In practice, the Hoon parser rejects `@ta` literals that aren't in so-called 'kebab case'.  That is, lower-case letters, numerals, and hyphens.  Each `@ta` atom is called a 'knot'.
+Hoon also has `@ta`, which is intended for ASCII text. In practice, the Hoon parser rejects `@ta` literals that aren't in so-called 'kebab case'. That is, lower-case letters, numerals, and hyphens. Each `@ta` atom is called a 'knot'.
 
-```
+```hoon
 > ? ~.urbit
   @ta
 ~.urbit
@@ -365,16 +366,16 @@ Hoon also has `@ta`, which is intended for ASCII text.  In practice, the Hoon pa
 
 You can get around Hoon's parser restrictions for `@ta` atoms by casting to `@ta` from a cord:
 
-```
+```hoon
 > `@ta`'The quick brown fox jumped over the lazy dog.'
 ~.The quick brown fox jumped over the lazy dog.
 ```
 
-The Hoon **parser** prevents you from typing the literal `~.The quick brown fox jumped over the lazy dog.` into the dojo.  Try it!
+The Hoon **parser** prevents you from typing the literal `~.The quick brown fox jumped over the lazy dog.` into the dojo. Try it!
 
 The `@tas` aura is intended for 'symbols', i.e., kebab case strings following a `%`:
 
-```
+```hoon
 > %hello
 %hello
 
@@ -392,7 +393,7 @@ The `@tas` aura is intended for 'symbols', i.e., kebab case strings following a 
 
 You can think of `now` as being a dojo environment variable that tells you what time it is:
 
-```
+```hoon
 > now
 ~2018.5.16..23.42.06..5da3
 
@@ -401,9 +402,9 @@ You can think of `now` as being a dojo environment variable that tells you what 
 ~2018.5.16..23.42.08..3455
 ```
 
-The `@da` aura is for 'absolute dates' represented with 128-bit atoms; 64 bits for the year, month, day, hour, minute, and second, 64 bits for fractions of a second.  There is also `@dr` for relative date:
+The `@da` aura is for 'absolute dates' represented with 128-bit atoms; 64 bits for the year, month, day, hour, minute, and second, 64 bits for fractions of a second. There is also `@dr` for relative date:
 
-```
+```hoon
 > ~h6
 ~h6
 
@@ -419,9 +420,9 @@ The `@da` aura is for 'absolute dates' represented with 128-bit atoms; 64 bits f
 0x5460.0000.0000.0000.0000
 ```
 
-The literal `~h6.m32.s11` is for 6 hours, 32 minutes, and 11 seconds.  You can add `@dr` atoms together, or add a `@dr` atom to a `@da` atom.  Remember that the `add` function produces atoms with no aura, so you'll have to cast the the aura you want the dojo to pretty-print to:
+The literal `~h6.m32.s11` is for 6 hours, 32 minutes, and 11 seconds. You can add `@dr` atoms together, or add a `@dr` atom to a `@da` atom. Remember that the `add` function produces atoms with no aura, so you'll have to cast the the aura you want the dojo to pretty-print to:
 
-```
+```hoon
 > (add ~h2 ~h3)
 332.041.393.326.771.929.088.000
 
@@ -452,9 +453,9 @@ Aura         Meaning                        Example Literal
   @rs        single precision (32 bits)     .6.022141e23
 ```
 
-One thing needs to be pointed out for float auras.  Atoms are fundamentally integers, and only when interpreted differently can they be understood as floats.  Floats obviously can't all map to numerically equivalent atoms:
+One thing needs to be pointed out for float auras. Atoms are fundamentally integers, and only when interpreted differently can they be understood as floats. Floats obviously can't all map to numerically equivalent atoms:
 
-```
+```hoon
 > .6.022
 .6.022
 
@@ -468,7 +469,7 @@ One thing needs to be pointed out for float auras.  Atoms are fundamentally inte
 
 As a result, the standard mathematical functions for atoms won't work correctly for floats:
 
-```
+```hoon
 > (add .6.022 .1.000)
 2.151.724.089
 
@@ -478,7 +479,7 @@ As a result, the standard mathematical functions for atoms won't work correctly 
 
 Instead, you'll have to call the variant function for that type of float: `add:rs` for adding `@rs` floats, `add:rd` for `@rd` floats, `add:rq` for `@rq` floats, and `add:rh` for `@rh` floats.
 
-```
+```hoon
 > (add:rs .6.022 .1.000)
 .7.022
 
@@ -488,13 +489,13 @@ Instead, you'll have to call the variant function for that type of float: `add:r
 
 ## Custom Auras
 
-Programmers can use their own auras if desired, keeping in mind however that Hoon won't support custom aura literals or pretty-printing.  The set of literals Hoon knows how to parse and/or print is fixed.  But there are plenty of good reasons to use your own user-defined auras.
+Programmers can use their own auras if desired, keeping in mind however that Hoon won't support custom aura literals or pretty-printing. The set of literals Hoon knows how to parse and/or print is fixed. But there are plenty of good reasons to use your own user-defined auras.
 
-If your program uses both fortnights and furlongs, Hoon will not parse a user-defined fortnight syntax. It will not print furlongs in the dojo.  But the type system can prevent you from accidentally passing a furlong to a function that expects a fortnight.
+If your program uses both fortnights and furlongs, Hoon will not parse a user-defined fortnight syntax. It will not print furlongs in the dojo. But the type system can prevent you from accidentally passing a furlong to a function that expects a fortnight.
 
-Remember also that auras specialize to the right.  For example, `@u` atoms are interpreted as unsigned integers; `@ux` atoms are interpreted as unsigned **hexadecimal** integers.
+Remember also that auras specialize to the right. For example, `@u` atoms are interpreted as unsigned integers; `@ux` atoms are interpreted as unsigned **hexadecimal** integers.
 
-```
+```hoon
 > `@madeupaura`123
 0x7b
 
@@ -513,13 +514,13 @@ nest-fail
 
 ## General and Constant Atoms
 
-There's more to the type information of an atom than its aura.  Another distinction is necessary.  Some atoms are **general** in type, meaning that the type in question includes all atoms.  For example, the type of the literal `17` is `@ud`; every atom can be of that type.  Up to this point of this lesson every atom has been general.
+There's more to the type information of an atom than its aura. Another distinction is necessary. Some atoms are **general** in type, meaning that the type in question includes all atoms. For example, the type of the literal `17` is `@ud`; every atom can be of that type. Up to this point of this lesson every atom has been general.
 
-There are also atoms that are **constant** in type.  Constant atom types contain just one atom.  But that's not all.  Constant atom types contain just one atom **with just one aura**.
+There are also atoms that are **constant** in type. Constant atom types contain just one atom. But that's not all. Constant atom types contain just one atom **with just one aura**.
 
 For atomic constant literal syntax simply put `%` in front of the atom literal:
 
-```
+```hoon
 > ? 15
   @ud
 15
@@ -537,16 +538,16 @@ For atomic constant literal syntax simply put `%` in front of the atom literal:
 %hello
 ```
 
-The `$` on the type indicates the constant.  You can use the same literal syntax to cast:
+The `$` on the type indicates the constant. You can use the same literal syntax to cast:
 
-```
+```hoon
 > ^-(%15 %15)
 %15
 ```
 
 Keep in mind that, underneath, `15` and `%15` are the same atom:
 
-```
+```hoon
 > ^-(@ 15)
 15
 
@@ -556,14 +557,14 @@ Keep in mind that, underneath, `15` and `%15` are the same atom:
 
 But because they have different auras, `15` doesn't nest under the type for `%15`:
 
-```
+```hoon
 > ^-(%15 15)
 nest-fail
 ```
 
-When you cast using a constant as your type, you're asking for something very specific: one particular atom with one particular aura.  If both conditions aren't met, the result of the cast will be a `nest-fail`.
+When you cast using a constant as your type, you're asking for something very specific: one particular atom with one particular aura. If both conditions aren't met, the result of the cast will be a `nest-fail`.
 
-```
+```hoon
 > `@`%0xf
 15
 
@@ -582,9 +583,9 @@ nest-fail
 
 ## Common irregulars
 
-There are a few special forms worth learning early.  Null `@n`, a special constant type for `0`:
+There are a few special forms worth learning early. Null `@n`, a special constant type for `0`:
 
-```
+```hoon
 > ~
 ~
 
@@ -597,7 +598,7 @@ There are a few special forms worth learning early.  Null `@n`, a special consta
 
 Flag `?`, which is for boolean values:
 
-```
+```hoon
 > |
 %.n
 
@@ -613,7 +614,7 @@ Flag `?`, which is for boolean values:
 
 And ship names use `@p`:
 
-```
+```hoon
 > ~zod
 ~zod
 
@@ -632,13 +633,13 @@ And ship names use `@p`:
 
 ## Simple Cell Types
 
-Let's move on to cells.  For now we'll limit ourselves to simple cell types made up of various atom types.
+Let's move on to cells. For now we'll limit ourselves to simple cell types made up of various atom types.
 
 ## Generic Cells
 
-The `^` symbol is used to indicate the type for cells (i.e., the set of all cells).  We can use it for casting as we did with, e.g., `@ux` and `@t`:
+The `^` symbol is used to indicate the type for cells (i.e., the set of all cells). We can use it for casting as we did with, e.g., `@ux` and `@t`:
 
-```
+```hoon
 > ^-(^ [12 13])
 [12 13]
 
@@ -659,7 +660,7 @@ If the expression to be evaluated produces a cell, the cast succeeds; if the exp
 
 The downside of using `^` for casts is that Hoon will infer only that the product of the expression is a cell; it won't be known what _kind_ of cell is produced.
 
-```
+```hoon
 > ? ^-(^ [12 13])
   {* *}
 [12 13]
@@ -673,15 +674,15 @@ The downside of using `^` for casts is that Hoon will infer only that the produc
 [[12 13] [14 15 16]]
 ```
 
-When we use the `?` operator to see the type inferred by Hoon for the expression, in all three of the above cases the same thing is returned: `{* *}`.  The `*` symbol indicates the type for any noun, and the curly braces `{ }` indicate a cell.  Every cell in Hoon is a cell of nouns; remember that cells are defined as pairs of nouns.
+When we use the `?` operator to see the type inferred by Hoon for the expression, in all three of the above cases the same thing is returned: `{* *}`. The `*` symbol indicates the type for any noun, and the curly braces `{ }` indicate a cell. Every cell in Hoon is a cell of nouns; remember that cells are defined as pairs of nouns.
 
-Yet the cell `[[12 13] [14 15 16]]` is a bit more complex than the cell `[12 13]`.  Can we use the type system to distinguish them?  Yes.
+Yet the cell `[[12 13] [14 15 16]]` is a bit more complex than the cell `[12 13]`. Can we use the type system to distinguish them? Yes.
 
 ## Getting More Specific
 
-What if you want to cast for a particular kind of cell?  You can use square brackets when casting for a specific cell type.  For example, if you want to cast for a cell in which the head and the tail must each be an atom, then simply cast using `[@ @]`:
+What if you want to cast for a particular kind of cell? You can use square brackets when casting for a specific cell type. For example, if you want to cast for a cell in which the head and the tail must each be an atom, then simply cast using `[@ @]`:
 
-```
+```hoon
 > ^-([@ @] [12 13])
 [12 13]
 
@@ -696,11 +697,11 @@ nest-fail
 nest-fail
 ```
 
-The `[@ @]` cast accepts any expression that evaluates to a cell with exactly two atoms, and crashes with a `nest-fail` for any expression that evaluates to something different.  The expression `12` doesn't evaluate to a cell; and while the expression `[[12 13] 14]` **does** evaluate to a cell, the left-hand side isn't an atom, but is instead another cell.
+The `[@ @]` cast accepts any expression that evaluates to a cell with exactly two atoms, and crashes with a `nest-fail` for any expression that evaluates to something different. The expression `12` doesn't evaluate to a cell; and while the expression `[[12 13] 14]` **does** evaluate to a cell, the left-hand side isn't an atom, but is instead another cell.
 
 You can get even more specific about the kind of cell you want by using atom auras:
 
-```
+```hoon
 > ^-([@ud @ux] [12 0x10])
 [12 0x10]
 
@@ -717,7 +718,7 @@ nest-fail
 
 You are also free to embed more square brackets `[ ]` to indicate cells within cells:
 
-```
+```hoon
 > ^-([[@ud @sb] @ux] [[12 --0b1101] 0xdead.beef])
 [[12 --0b1101] 0xdead.beef]
 
@@ -729,9 +730,9 @@ You are also free to embed more square brackets `[ ]` to indicate cells within c
 nest-fail
 ```
 
-You can also be highly specific with certain parts of the type structure, leaving other parts more general.  Keep in mind that when you do this, Hoon's type system will infer a general type from the general part of the cast.  Type information may be thrown away:
+You can also be highly specific with certain parts of the type structure, leaving other parts more general. Keep in mind that when you do this, Hoon's type system will infer a general type from the general part of the cast. Type information may be thrown away:
 
-```
+```hoon
 > ^-([^ @ux] [[12 --0b1101] 0xdead.beef])
 [[12 26] 0xdead.beef]
 
@@ -747,17 +748,17 @@ You can also be highly specific with certain parts of the type structure, leavin
 [[12 26] 3.735.928.559]
 ```
 
-Because every piece of Hoon data is a noun, everything nests under `*`.  When you cast to `*` you can see the raw noun with cells as brackets and atoms as unsigned integers.
+Because every piece of Hoon data is a noun, everything nests under `*`. When you cast to `*` you can see the raw noun with cells as brackets and atoms as unsigned integers.
 
-That's it for this lesson.  Move on to the next one to learn more about when a type check occurs, and how type inference works for non-literal Hoon expressions.
+That's it for this lesson. Move on to the next one to learn more about when a type check occurs, and how type inference works for non-literal Hoon expressions.
 
 ## Exercise Answer
 
 ### 2.1a
 
-There is no distinction between positive and negative zero for `@s`.  To see this, let's cast each of `--0` and `-0` to `@s`:
+There is no distinction between positive and negative zero for `@s`. To see this, let's cast each of `--0` and `-0` to `@s`:
 
-```
+```hoon
 > ^-(@s --0)
 --0
 
@@ -765,9 +766,9 @@ There is no distinction between positive and negative zero for `@s`.  To see thi
 --0
 ```
 
-Hoon pretty-prints them the same way, but can we be sure that they are the same thing?  Let's check the atom underneath:
+Hoon pretty-prints them the same way, but can we be sure that they are the same thing? Let's check the atom underneath:
 
-```
+```hoon
 > `@`--0
 0
 
@@ -776,4 +777,3 @@ Hoon pretty-prints them the same way, but can we be sure that they are the same 
 ```
 
 They are indeed the same.
-

--- a/hoon/hoon-school/caesar.md
+++ b/hoon/hoon-school/caesar.md
@@ -92,7 +92,7 @@ that has been shifted left. It also converts any uppercase input into lowercase.
 
 Try it out in the Dojo:
 
-```
+```hoon
 > +caesar ["abcdef" 1]
 ["bcdefg" "zabcde"]
 
@@ -131,7 +131,7 @@ itself before reading the explanation.
 The `!:` in the first line of the above code enables a full stack trace in the
 event of an error.
 
-`|=  [msg=tape steps=@ud]` creates a [gate](/docs/glossary/gate/) that takes a cell. The head of this cell
+`|= [msg=tape steps=@ud]` creates a [gate](/docs/glossary/gate/) that takes a cell. The head of this cell
 is a `tape`, which is a string type that's a list of `cord`s. Tapes are represented
 as text surrounded by double-quotes, such as this: `"a tape"`. We give this input
 tape the face `msg`. The tail of our cell is a `@ud` -- an unsigned decimal [atom](/docs/glossary/atom/)
@@ -141,7 +141,7 @@ tape the face `msg`. The tail of our cell is a `@ud` -- an unsigned decimal [ato
 second child expression as the subject. In this case, we evaluate the
 expressions in the code chunk below against the [core](/docs/glossary/core/) declared later, which
 allows us reference the core's contained [arms](/docs/glossary/arm/) before they are defined. Without
-`=<`, we would need to put the code chunk below at the bottom of our program.  In Hoon, as previously
+`=<`, we would need to put the code chunk below at the bottom of our program. In Hoon, as previously
 stated, we always want to keep the longer code towards the bottom of our programs - `=<` helps us do that.
 
 ```hoon
@@ -150,19 +150,19 @@ stated, we always want to keep the longer code towards the bottom of our program
 (unshift msg steps)
 ```
 
-`=.  msg  (cass msg)` changes the input string `msg` to lowercases. `=.` changes
+`=. msg (cass msg)` changes the input string `msg` to lowercases. `=.` changes
 the leg of the subject to something else. In our case, the leg to be changed is
 `msg`, and the thing to replace it is `(cass msg)`. `cass` is a standard-library
 gate that converts uppercase letters to lowercase.
 
-`:-  (shift msg steps)` and `(unshift msg steps)` simply composes a
+`:- (shift msg steps)` and `(unshift msg steps)` simply composes a
 cell of a right-shifted cipher and a left-shifted cipher of our original message.
 We will see how this is done using the core described below, but this is the final
 output of our generator.
 
 `|%` creates a `core`, the second child of `=<`. Everything after `|%` is part of that
 second child `core`, and will be used as the subject of the first child of `=<`, described
-above.  The various parts, or `arm`s, of the `core` are denoted by `++` beneath it, for
+above. The various parts, or `arm`s, of the `core` are denoted by `++` beneath it, for
 instance:
 
 ```hoon
@@ -174,23 +174,23 @@ instance:
 ```
 
 The `rotation` arm takes takes a specified number of characters off of a tape and
-puts them on the end of the tape.  We're going to use this to create our shifted alphabet,
+puts them on the end of the tape. We're going to use this to create our shifted alphabet,
 based on the number of `steps` given as an argument to our gate.
 
-`|=  [my-alphabet=tape my-steps=@ud]` creates a gate that takes two arguments: `my-alphabet`, a `tape`,
+`|= [my-alphabet=tape my-steps=@ud]` creates a gate that takes two arguments: `my-alphabet`, a `tape`,
 and `my-steps`, a `@ud`.
 
-`=/  length=@ud  (lent my-alphabet)` stores the length of `my-alphabet` to make the following
+`=/ length=@ud (lent my-alphabet)` stores the length of `my-alphabet` to make the following
 code a little clearer.
 
 `trim` is a a gate from the standard library that splits a tape at into two
-parts at a specified position. So `=+  (trim (mod my-steps length) my-alphabet)` splits the
+parts at a specified position. So `=+ (trim (mod my-steps length) my-alphabet)` splits the
 tape `my-alphabet` into two parts, `p` and `q`, which are now directly available in the subject.
-We call the modulus operation `mod` to make sure that the point at which we split our `tape` is 
+We call the modulus operation `mod` to make sure that the point at which we split our `tape` is
 a valid point inside of `my-alphabet` even if `my-steps` is greater than `length`, the length of
-`my-alphabet`.  Try trim in the dojo:
+`my-alphabet`. Try trim in the dojo:
 
-```
+```hoon
 > (trim 2 "abcdefg")
 [p="ab" q="cdefg"]
 
@@ -199,7 +199,7 @@ a valid point inside of `my-alphabet` even if `my-steps` is greater than `length
 ```
 
 `(weld q p)` uses `weld`, which combines two strings into one. Remember that `trim` has given us
-a split version of `my-alphabet` with `p` being the front half that was split off of `my-alphabet` 
+a split version of `my-alphabet` with `p` being the front half that was split off of `my-alphabet`
 and `q` being the back half. Here we are welding the two parts back together, but in reverse order:
 the second part `q` is welded to the front, and the first part `p` is welded to the back.
 
@@ -217,46 +217,46 @@ the second part `q` is welded to the front, and the first part `p` is welded to 
 ```
 
 The `map-maker` arm, as the name implies, takes two tapes and creates a [`map`](/docs/hoon/reference/stdlib/2o/#map) out of them.
-A `map` is a type equivalent to a dictionary in other languages: it's a data structure that 
-associates a key with a value. If, for example, we wanted to have an association 
+A `map` is a type equivalent to a dictionary in other languages: it's a data structure that
+associates a key with a value. If, for example, we wanted to have an association
 between `a` and 1 and `b` and 2, we could use a `map`.
 
-`|=  [a=tape b=tape]` builds a gate that takes two tapes, `a` and `b`, as its
+`|= [a=tape b=tape]` builds a gate that takes two tapes, `a` and `b`, as its
 sample.
 
-`^-  (map @t @t)` casts the gate to a `map` with a `cord` (or `@t`) key and a `cord`
-value. 
+`^- (map @t @t)` casts the gate to a `map` with a `cord` (or `@t`) key and a `cord`
+value.
 
 You might wonder, if our gate in this arm takes `tape`s, why then are we producing
 a map of `cord` keys and values?
 
-As we discussed earlier, a `tape` is a list of `cord`s.  In this case what we are going to do
+As we discussed earlier, a `tape` is a list of `cord`s. In this case what we are going to do
 is map a single element of a `tape` (either our alphabet or shifted-alphabet) to an element of
-a different `tape` (either our shifted-alphabet or our alphabet).  This pair will therefore be
-a pair of `cord`s.  When we go to use this `map` to convert our incoming `msg`, we will take 
+a different `tape` (either our shifted-alphabet or our alphabet). This pair will therefore be
+a pair of `cord`s. When we go to use this `map` to convert our incoming `msg`, we will take
 each element (`cord`) of our `msg` `tape`, use it as a `key` when accessing our `map` and get
 the corresponding `value` from that position in the `map`. This is how we're going to encode
 or decode our `msg` `tape`.
 
-`=|  chart=(map @t @t)` adds a [noun](/docs/glossary/noun/) to the subject with the default value of
+`=| chart=(map @t @t)` adds a [noun](/docs/glossary/noun/) to the subject with the default value of
 the `(map @t @t)` type, and gives that noun the face `chart`.
 
-`?.  =((lent key-position) (lent value-result))` checks if the two `tape`s are the same length. If not,
-the program crashes with an error message of `%uneven-lengths`, using `|~  %uneven-lengths  !!`.
+`?. =((lent key-position) (lent value-result))` checks if the two `tape`s are the same length. If not,
+the program crashes with an error message of `%uneven-lengths`, using `|~ %uneven-lengths !!`.
 
 If the two `tape`s are of the same length, we continue on to create a trap.
 `|-` creates a [trap](/docs/glossary/trap/), a gate that is called immediately.
 
-`?:  |(?=(~ key-position) ?=(~ value-result))` checks if either `tape` is empty. If this is true, the
+`?: |(?=(~ key-position) ?=(~ value-result))` checks if either `tape` is empty. If this is true, the
 `map-maker` arm is finished and can return `chart`, the `map` that we have been
 creating.
 
 If the above test finds that the `tape`s are not empty, we trigger a recursion
 that constructs our `map`: `$(chart (~(put by chart) i.a i.b), a t.a, b t.b)`.
 This code recursively adds an entry in our `map` where the head of the `tape` `a`
-maps to the value of the head of `tape` `b` with  `~(put by chart)`, our calling
+maps to the value of the head of `tape` `b` with `~(put by chart)`, our calling
 of the `put` arm of the `by` map-engine core (note that `~(<wing> <door> <sample>`) is
-a shorthand for `%~  <wing>  <door>  <sample>` (see the [Calls % ('cen')](@/docs/hoon/reference/rune/cen.md#censig)
+a shorthand for `%~ <wing> <door> <sample>` (see the [Calls % ('cen')](@/docs/hoon/reference/rune/cen.md#censig)
 documentation for more information). The recursion also "consumes"
 those heads with every iteration by changing `a` and `b` to their tails using `a t.a, b t.b`.
 
@@ -271,7 +271,7 @@ first.
       (~(put by (map-maker key-position value-result)) ' ' ' ')
 ```
 
-`|=  [key-position=tape value-result=tape]` creates a gate that takes two `tapes`.
+`|= [key-position=tape value-result=tape]` creates a gate that takes two `tapes`.
 
 We use the `put` arm of the `by` core on the next line, giving it a `map` produced
 by the `map-maker` arm that we created before as its sample. This adds an entry to the
@@ -300,12 +300,12 @@ that we can use to encode and decode messages.
 In both cases, we create a gate that accepts a `@ud` named `steps`.
 
 In `encoder`:
-`=/  value-tape=tape  (rotation alpha steps)` creates a `value-tape` noun by calling `rotation`
-on `alpha`. `alpha` is our arm which contains a `tape` of the entire alphabet. The 
+`=/ value-tape=tape (rotation alpha steps)` creates a `value-tape` noun by calling `rotation`
+on `alpha`. `alpha` is our arm which contains a `tape` of the entire alphabet. The
 `value-tape` will be the list of `value`s in our `map`.
 
 In `decoder`:
-`=/  key-tape  (rotation alpha steps)` does the same work, but when passed to `space-adder`
+`=/ key-tape (rotation alpha steps)` does the same work, but when passed to `space-adder`
 it will be the list of `key`s in our `map`.
 
 `(space-adder alpha value-tape)`, for `encoder`, and `(space-adder key-tape alpha)`, for
@@ -355,7 +355,7 @@ with a pair sample. The arm we are going to pull is `turn`. This arm
 takes two arguments, a `list` and a `gate` to apply to each element of the
 `list`.
 
-In this case, the `gate` we are applying to our `message` uses the `got` arm 
+In this case, the `gate` we are applying to our `message` uses the `got` arm
 of the `by` door with our `shift-map` as the sample (which is either the standard alphabet
 for keys, and the shifted alphabet for values, or the other way, depending on
 whether we are encoding or decoding) to look up each `cord` in our `message`, one by one
@@ -364,7 +364,7 @@ and replace it with the `value` from our `map` (either the encoded or decoded ve
 If we then give our arm Caesar's famous statement, and get our left- and
 right-ciphers.
 
-```
+```hoon
 > +caesar ["i came i saw i conquered" 4]
 ["m geqi m wea m gsruyivih" "e ywia e ows e ykjmqanaz"]
 ```
@@ -372,7 +372,7 @@ right-ciphers.
 Now, to decode, we can put either of our ciphers in with the appropriate key and
 look for the legible result.
 
-```
+```hoon
 > +caesar ["m geqi m wea m gsruyivih" 4]
 ["q kium q aie q kwvycmzml" "i came i saw i conquered"]
 

--- a/hoon/hoon-school/doors.md
+++ b/hoon/hoon-school/doors.md
@@ -5,15 +5,15 @@ template = "doc.html"
 aliases = ["/docs/learn/hoon/hoon-tutorial/doors/"]
 +++
 
-It's useful to have [cores](/docs/glossary/core/) whose [arms](/docs/glossary/arm/) evaluate to make [gates](/docs/glossary/gate/).  The use of such cores is common in Hoon; that's how the functions of the Hoon standard library are stored in the subject.  Learning about such cores will also deepen the reader's understanding of Hoon semantics, and for that reason alone is worthwhile.
+It's useful to have [cores](/docs/glossary/core/) whose [arms](/docs/glossary/arm/) evaluate to make [gates](/docs/glossary/gate/). The use of such cores is common in Hoon; that's how the functions of the Hoon standard library are stored in the subject. Learning about such cores will also deepen the reader's understanding of Hoon semantics, and for that reason alone is worthwhile.
 
 In this lesson you'll also learn about a new kind of core, called a 'door'.
 
 ## Two Kinds of Function Calls
 
-There are two ways of making a function call in Hoon.  First, you can call a gate in the subject by name.  This is what you did with `inc` in the last lesson; you bound `inc` to a gate that adds `1` to an input:
+There are two ways of making a function call in Hoon. First, you can call a gate in the subject by name. This is what you did with `inc` in the last lesson; you bound `inc` to a gate that adds `1` to an input:
 
-```
+```hoon
 > =inc |=(a=@ (add 1 a))
 
 > (inc 10)
@@ -24,7 +24,7 @@ There are two ways of making a function call in Hoon.  First, you can call a gat
 
 The second way of making a function call involves an expression that _produces_ a gate:
 
-```
+```hoon
 > (|=(a=@ (add 1 a)) 123)
 124
 
@@ -32,11 +32,11 @@ The second way of making a function call involves an expression that _produces_ 
 246
 ```
 
-The difference is that `inc` is an already-created gate in the subject when we called it.  The latter calls involve producing a gate that doesn't exist anywhere in the subject, and then calling it.
+The difference is that `inc` is an already-created gate in the subject when we called it. The latter calls involve producing a gate that doesn't exist anywhere in the subject, and then calling it.
 
 Are calls to `add` and `mul` of the Hoon standard library of the first kind, or the second?
 
-```
+```hoon
 > (add 12 23)
 35
 
@@ -44,15 +44,15 @@ Are calls to `add` and `mul` of the Hoon standard library of the first kind, or 
 276
 ```
 
-They're of the second kind.  Neither `add` nor `mul` resolves to a gate directly; they're each arms that _produce_ gates.
+They're of the second kind. Neither `add` nor `mul` resolves to a gate directly; they're each arms that _produce_ gates.
 
-Often the difference doesn't matter much.  Either way you can do a function call using the `(gate arg)` syntax.
+Often the difference doesn't matter much. Either way you can do a function call using the `(gate arg)` syntax.
 
 It's important to learn the difference, however, because for certain use cases you'll want the extra flexibility that comes with having an already produced core in the subject.
 
 ## A Gate-Building Core
 
-Let's make a core with arms that build gates of various kinds.  As we did in a previous lesson, we'll use the `|%` rune.  Feel free to cut and paste the following into the dojo:
+Let's make a core with arms that build gates of various kinds. As we did in a previous lesson, we'll use the `|%` rune. Feel free to cut and paste the following into the dojo:
 
 ```hoon
 > =c |%
@@ -65,7 +65,7 @@ Let's make a core with arms that build gates of various kinds.  As we did in a p
 
 Let's try out these arms, using them for function calls:
 
-```
+```hoon
 > (inc:c 10)
 11
 
@@ -79,30 +79,30 @@ Let's try out these arms, using them for function calls:
 30
 ```
 
-Notice that each arm in core `c` is able to call the other arms of `c` -- `add-two` uses the `inc` arm to increment a number twice.  As a reminder, each arm is evaluated with its parent core as the subject.  In the case of `add-two` the parent core is `c`, which has `inc` in it.
+Notice that each arm in core `c` is able to call the other arms of `c` -- `add-two` uses the `inc` arm to increment a number twice. As a reminder, each arm is evaluated with its parent core as the subject. In the case of `add-two` the parent core is `c`, which has `inc` in it.
 
 ### Mutating a Gate
 
-Let's say you want to modify the default sample of the gate for `double`.  We can infer the default sample by calling `double` with no argument:
+Let's say you want to modify the default sample of the gate for `double`. We can infer the default sample by calling `double` with no argument:
 
-```
+```hoon
 > (double:c)
 0
 ```
 
-Given that `a x 2 = 0`, `a` must be `0`.  (Remember that `a` is the face for the `double` sample, as defined in the core we bound to `c` above.)
+Given that `a x 2 = 0`, `a` must be `0`. (Remember that `a` is the face for the `double` sample, as defined in the core we bound to `c` above.)
 
-Let's say we want to mutate the `double` gate so that the default sample is `25`.  There is only one problem: `double` isn't a gate!
+Let's say we want to mutate the `double` gate so that the default sample is `25`. There is only one problem: `double` isn't a gate!
 
-```
+```hoon
 > double.c(a 25)
 -tack.a
 -find.a
 ```
 
-It's an arm that produces a gate, and `a` cannot be found in `double` until the gate is created.  Furthermore, every time the gate is created, it has the default sample, `0`.  If you want to mutate the gate produced by `double`, you'll first have to put a copy of that gate into the subject:
+It's an arm that produces a gate, and `a` cannot be found in `double` until the gate is created. Furthermore, every time the gate is created, it has the default sample, `0`. If you want to mutate the gate produced by `double`, you'll first have to put a copy of that gate into the subject:
 
-```
+```hoon
 > =double-copy double:c
 
 > (double-copy 123)
@@ -111,36 +111,36 @@ It's an arm that produces a gate, and `a` cannot be found in `double` until the 
 
 Now let's mutate the sample to `25`, and check that it worked with `+6`:
 
-```
+```hoon
 > +6:double-copy(a 25)
 a=25
 ```
 
-Good.  Let's call it with no argument and see if it returns double the value of the modified sample.
+Good. Let's call it with no argument and see if it returns double the value of the modified sample.
 
-```
+```hoon
 > (double-copy(a 25))
 50
 ```
 
-It does indeed.  Unbind `c` and `double-copy`:
+It does indeed. Unbind `c` and `double-copy`:
 
-```
+```hoon
 > =c
 
 > =double-copy
 ```
 
-Contrast this with the behavior of `add`.  We can look at the sample of the gate for `add` with `+6:add`:
+Contrast this with the behavior of `add`. We can look at the sample of the gate for `add` with `+6:add`:
 
-```
+```hoon
 > +6:add
 [a=0 b=0]
 ```
 
 If you try to mutate the default sample of `add`, it won't work:
 
-```
+```hoon
 > add(a 3)
 -tack.a
 -find.a
@@ -152,16 +152,16 @@ As before with `double`, Hoon can't find an `a` to modify in a gate that doesn't
 
 Let's look once more at the parent core of the `add` arm in the Hoon standard library:
 
-```
+```hoon
 > ..add
 <74.dbd 1.qct $141>
 ```
 
-The battery of this core contains 74 arms, each of which evaluates to a gate in the standard library.  This 'library' is nothing more than a core containing useful basic functions that Hoon often makes available as part of the subject.  You can see the Hoon code defining these arms near the beginning of [hoon.hoon](https://github.com/urbit/urbit/blob/master/pkg/arvo/sys/hoon.hoon), starting with [`++  add`](https://github.com/urbit/urbit/blob/master/pkg/arvo/sys/hoon.hoon#L21).  (Yes, the Hoon standard library is written in Hoon.)
+The battery of this core contains 74 arms, each of which evaluates to a gate in the standard library. This 'library' is nothing more than a core containing useful basic functions that Hoon often makes available as part of the subject. You can see the Hoon code defining these arms near the beginning of [hoon.hoon](https://github.com/urbit/urbit/blob/master/pkg/arvo/sys/hoon.hoon), starting with [`++ add`](https://github.com/urbit/urbit/blob/master/pkg/arvo/sys/hoon.hoon#L21). (Yes, the Hoon standard library is written in Hoon.)
 
-Here are some of the other gates that can be generated from this core in the Hoon standard library.  It should be fairly obvious what they do:
+Here are some of the other gates that can be generated from this core in the Hoon standard library. It should be fairly obvious what they do:
 
-```
+```hoon
 > (dec 18)
 17
 
@@ -210,9 +210,9 @@ Here are some of the other gates that can be generated from this core in the Hoo
 
 ## Doors
 
-A brief review: A core is a cell of battery and [payload](/docs/glossary/payload/): `[battery payload]`.  The battery is code and the payload is data.  The battery contains a series of arms, and the payload contains all the data necessary to run those arms correctly.
+A brief review: A core is a cell of battery and [payload](/docs/glossary/payload/): `[battery payload]`. The battery is code and the payload is data. The battery contains a series of arms, and the payload contains all the data necessary to run those arms correctly.
 
-New material: A **door** is a core with a sample.  That is, a [door](/docs/glossary/door/) is a core whose payload is a cell of sample and context: `[sample context]`.
+New material: A **door** is a core with a sample. That is, a [door](/docs/glossary/door/) is a core whose payload is a cell of sample and context: `[sample context]`.
 
 ```
         Door
@@ -222,15 +222,15 @@ Battery      .
       Sample   Context
 ```
 
-It follows from this definition that a gate is a special case of a door.  A gate is a door with exactly one arm, named `$`.
+It follows from this definition that a gate is a special case of a door. A gate is a door with exactly one arm, named `$`.
 
-Gates are useful for defining functions.  But there are many-armed doors as well.  How are they used?  Doors are quite useful data structures.  In Chapter 2 of the Hoon tutorial series you'll learn how to use doors to implement state machines, where the sample stores the relevant state data.  For now let's talk about how to use doors for simpler purposes.
+Gates are useful for defining functions. But there are many-armed doors as well. How are they used? Doors are quite useful data structures. In Chapter 2 of the Hoon tutorial series you'll learn how to use doors to implement state machines, where the sample stores the relevant state data. For now let's talk about how to use doors for simpler purposes.
 
 ### An Example Door
 
-Let's write an example door in order to illustrate its features.  Each of the arms in the door will define a simple gate.  Let's bind the door to `c` as we did with the last core.  To make a door we use the `|_` rune:
+Let's write an example door in order to illustrate its features. Each of the arms in the door will define a simple gate. Let's bind the door to `c` as we did with the last core. To make a door we use the `|_` rune:
 
-```
+```hoon
 > =c |_  b=@
   ++  plus  |=(a=@ (add a b))
   ++  times  |=(a=@ (mul a b))
@@ -238,7 +238,7 @@ Let's write an example door in order to illustrate its features.  Each of the ar
   --
 ```
 
-If you type this into the dojo manually, make sure you attend carefully to the spacing.  Feel free to cut and paste the code, if desired.
+If you type this into the dojo manually, make sure you attend carefully to the spacing. Feel free to cut and paste the code, if desired.
 
 Before getting into what these arms do, let's cover how the `|_` rune works in general.
 
@@ -246,15 +246,15 @@ Before getting into what these arms do, let's cover how the `|_` rune works in g
 
 The `|_` rune for making a door works exactly like the `|%` rune for making a core, except it takes one additional subexpression.
 
-The first subexpression after the `|_` rune defines the door's sample.  (This is the subexpression the `|%` rune lacks.)  Following that are a series of `++` runes, each of which defines an arm of the door.  Finally, the expression is terminated with a `--` rune.
+The first subexpression after the `|_` rune defines the door's sample. (This is the subexpression the `|%` rune lacks.) Following that are a series of `++` runes, each of which defines an arm of the door. Finally, the expression is terminated with a `--` rune.
 
 #### Back to the Example
 
-For the door defined above, `c`, the sample is defined as an [atom](/docs/glossary/atom/), `@`, and given the face `b`.  The `plus` arm defines a gate that takes a single [atom](/docs/glossary/atom/) as its argument, `a`, and which returns the sum of `a` and `b`.  The `times` arm defines a gate that takes a single [atom](/docs/glossary/atom/), `a`, and returns `a` times `b`.  The `greater` arm defines a gate that takes a single [atom](/docs/glossary/atom/), `a`, and if `a` is greater than `b` returns `%.y`; otherwise `%.n`.
+For the door defined above, `c`, the sample is defined as an [atom](/docs/glossary/atom/), `@`, and given the face `b`. The `plus` arm defines a gate that takes a single [atom](/docs/glossary/atom/) as its argument, `a`, and which returns the sum of `a` and `b`. The `times` arm defines a gate that takes a single [atom](/docs/glossary/atom/), `a`, and returns `a` times `b`. The `greater` arm defines a gate that takes a single [atom](/docs/glossary/atom/), `a`, and if `a` is greater than `b` returns `%.y`; otherwise `%.n`.
 
 Let's try out the arms of `c` with ordinary function calls:
 
-```
+```hoon
 > (plus:c 10)
 10
 
@@ -265,16 +265,16 @@ Let's try out the arms of `c` with ordinary function calls:
 %.y
 ```
 
-This works, but the results are not exciting.  Passing `10` to the `plus` gate returns `10`, so it must be that the value of `b` is `0` (the bunt value of `@`).  The products of the other function calls reinforce that assessment.  Let's look directly at `+6` of `c`:
+This works, but the results are not exciting. Passing `10` to the `plus` gate returns `10`, so it must be that the value of `b` is `0` (the bunt value of `@`). The products of the other function calls reinforce that assessment. Let's look directly at `+6` of `c`:
 
-```
+```hoon
 > +6:c
 b=0
 ```
 
 Having confirmed that `b` is `0`, let's mutate the `c` sample and then call its arms:
 
-```
+```hoon
 > (plus:c(b 7) 10)
 17
 
@@ -290,7 +290,7 @@ Having confirmed that `b` is `0`, let's mutate the `c` sample and then call its 
 
 Doing the same mutation repeatedly can be tedious, so let's bind `c` to the modified version of the door, where `b` is `7`:
 
-```
+```hoon
 > =c c(b 7)
 
 > (plus:c 10)
@@ -303,9 +303,9 @@ Doing the same mutation repeatedly can be tedious, so let's bind `c` to the modi
 %.y
 ```
 
-There's a more direct way of passing arguments for both the door sample and the gate sample simultaneously.  We may use the `~(arm door arg)` syntax.  This generates the `arm` product after modifying the `door`'s sample to be `arg`.
+There's a more direct way of passing arguments for both the door sample and the gate sample simultaneously. We may use the `~(arm door arg)` syntax. This generates the `arm` product after modifying the `door`'s sample to be `arg`.
 
-```
+```hoon
 > (~(plus c 7) 10)
 17
 
@@ -319,9 +319,9 @@ There's a more direct way of passing arguments for both the door sample and the 
 %.n
 ```
 
-Readers with some mathematical background may notice that `~( )` expressions allow us to [curry](https://en.wikipedia.org/wiki/Currying).  For each of the arms above, the `~( )` expression is used to create different versions of the same gate:
+Readers with some mathematical background may notice that `~( )` expressions allow us to [curry](https://en.wikipedia.org/wiki/Currying). For each of the arms above, the `~( )` expression is used to create different versions of the same gate:
 
-```
+```hoon
 > ~(plus c 7)
 < 1.gxk
   { a/@
@@ -353,7 +353,7 @@ Readers with some mathematical background may notice that `~( )` expressions all
 17
 ```
 
-Thus, you may think of the `c` door as a function for making functions.  Use the `~(arm c arg)` syntax -- `arm` defines which kind of gate is produced (i.e., which arm of the door is used to create the gate), and `arg` defines the value of `b` in that gate, which in turn affects the product value of the gate produced.
+Thus, you may think of the `c` door as a function for making functions. Use the `~(arm c arg)` syntax -- `arm` defines which kind of gate is produced (i.e., which arm of the door is used to create the gate), and `arg` defines the value of `b` in that gate, which in turn affects the product value of the gate produced.
 
 The standard library provides [currying
 functionality](@/docs/hoon/reference/stdlib/2n.md#curry) outside of the context of
@@ -362,52 +362,54 @@ doors - see `+curr` and `+cury`.
 #### Creating Doors with a Modified Sample
 
 In the above example we created a door `c` with sample `b=@` and found that the initial value of `b` was `0`, the bunt value of `@`. We then created new door from `c` by modifying the value of `b`. But what if we wish to define a door with a chosen sample value directly? We make use of the `$_` rune, whose irregular form is simply `_`. To create the door `c` with the sample `b=@` set to have the value `7` in the dojo, we would write
-```
+
+```hoon
 > =c |_  b=_7
   ++  plus  |=(a=@ (add a b))
   ++  times  |=(a=@ (mul a b))
   ++  greater  |=(a=@ (gth a b))
   --
 ```
+
 Here the type of `b` is inferred to be `@` based on the example value `7`, similar to how we've seen casting done by example. You will learn more about how types are inferred in [Lesson 2.2](@docs/hoon/hoon-school/type-checking-and-type-inference.md).
 
 ### Doors in the Hoon Standard Library
 
-Back in lesson 1.2 you were introduced to atom auras, which are metadata used by Hoon that defines how that atom is interpreted and pretty-printed.  Atoms are unsigned integers, but sometimes programmers want to work with fractions and decimal points.  Accordingly, there are auras for [floating point numbers](https://en.wikipedia.org/wiki/Floating-point_arithmetic).  Let's work with the aura for doing [single-precision](https://en.wikipedia.org/wiki/Single-precision_floating-point_format) floating point arithmetic: `@rs`.
+Back in lesson 1.2 you were introduced to atom auras, which are metadata used by Hoon that defines how that atom is interpreted and pretty-printed. Atoms are unsigned integers, but sometimes programmers want to work with fractions and decimal points. Accordingly, there are auras for [floating point numbers](https://en.wikipedia.org/wiki/Floating-point_arithmetic). Let's work with the aura for doing [single-precision](https://en.wikipedia.org/wiki/Single-precision_floating-point_format) floating point arithmetic: `@rs`.
 
-The `@rs` has its own literal syntax.  These atoms are represented as a `.` followed by digits, and possibly another `.` (for the decimal point) and more digits.  For example, the float 3.14159 can be represented as a single-precision (32 bit) float with the literal expression `.3.14159`.
+The `@rs` has its own literal syntax. These atoms are represented as a `.` followed by digits, and possibly another `.` (for the decimal point) and more digits. For example, the float 3.14159 can be represented as a single-precision (32 bit) float with the literal expression `.3.14159`.
 
 You can't use the ordinary `add` function to get the correct sum of two `@rs` atoms:
 
-```
+```hoon
 > (add .3.14159 .2.22222)
 2.153.203.882
 ```
 
-That's because the `add` gate is designed for use with raw atoms, not floating point values.  You can add two `@rs` atoms as follows:
+That's because the `add` gate is designed for use with raw atoms, not floating point values. You can add two `@rs` atoms as follows:
 
-```
+```hoon
 > (add:rs .3.14159 .2.22222)
 .5.36381
 ```
 
-It turns out that the `rs` in `add:rs` is a Hoon standard library arm that produces a door.  Let's take a closer look:
+It turns out that the `rs` in `add:rs` is a Hoon standard library arm that produces a door. Let's take a closer look:
 
-```
+```hoon
 > rs
 <21|fan {r/?($n $u $d $z) <51.zox 93.pqh 74.dbd 1.qct $141>}>
 ```
 
-The battery of this core, pretty-printed as `21|fan`, has 21 arms that define functions specifically for `@rs` atoms.  One of these arms is named `add`; it's a different `add` from the standard one we've been using for vanilla atoms.  So when you invoke `add:rs` instead of just `add` in a function call, (1) the `rs` door is produced, and then (2) the name search for `add` resolves to the special `add` arm in `rs`.  This produces the gate for adding `@rs` atoms:
+The battery of this core, pretty-printed as `21|fan`, has 21 arms that define functions specifically for `@rs` atoms. One of these arms is named `add`; it's a different `add` from the standard one we've been using for vanilla atoms. So when you invoke `add:rs` instead of just `add` in a function call, (1) the `rs` door is produced, and then (2) the name search for `add` resolves to the special `add` arm in `rs`. This produces the gate for adding `@rs` atoms:
 
-```
+```hoon
 > add:rs
 < 1.hsu
   {{a/@rs b/@rs} <21.fan {r/?($n $u $d $z) <51.zox 93.pqh 74.dbd 1.qct $141>}>}
 >
 ```
 
-What about the sample of the `rs` door?  The pretty-printer shows `r/?($n $u $d $z)`.  What does this mean?  Without yet explaining this notation fully, we'll simply say that the `rs` sample can take one of four values: `%n`, `%u`, `%d`, and `%z`.  These argument values represent four options for how to round `@rs` numbers:
+What about the sample of the `rs` door? The pretty-printer shows `r/?($n $u $d $z)`. What does this mean? Without yet explaining this notation fully, we'll simply say that the `rs` sample can take one of four values: `%n`, `%u`, `%d`, and `%z`. These argument values represent four options for how to round `@rs` numbers:
 
 ```
 %n -- round to the nearest value
@@ -416,41 +418,41 @@ What about the sample of the `rs` door?  The pretty-printer shows `r/?($n $u $d 
 %z -- round to zero
 ```
 
-The default value is `%z` -- round to zero.  When we invoke `add:rs` to call the addition function, there is no way to modify the `rs` door sample, so the default rounding option is used.  How do we change it?  We use the `~( )` notation: `~(arm door arg)`.
+The default value is `%z` -- round to zero. When we invoke `add:rs` to call the addition function, there is no way to modify the `rs` door sample, so the default rounding option is used. How do we change it? We use the `~( )` notation: `~(arm door arg)`.
 
 Let's evaluate the `add` arm of `rs`, also modifying the door sample to `%u` for 'round up':
 
-```
+```hoon
 > ~(add rs %u)
 < 1.hsu
   {{a/@rs b/@rs} <21.fan {r/?($n $u $d $z) <51.zox 93.pqh 74.dbd 1.qct $141>}>}
 >
 ```
 
-This is the gate produced by `add`, and you can see that its sample is a pair of `@rs` atoms.  But if you look in the context you'll see the `rs` door.  Let's look in the sample of that core to make sure that it changed to `%u`.  We'll use the wing `+6.+7` to look at the sample of the gate's context:
+This is the gate produced by `add`, and you can see that its sample is a pair of `@rs` atoms. But if you look in the context you'll see the `rs` door. Let's look in the sample of that core to make sure that it changed to `%u`. We'll use the wing `+6.+7` to look at the sample of the gate's context:
 
-```
+```hoon
 > +6.+7:~(add rs %u)
 r=%u
 ```
 
-It did indeed change.  We also see that the door sample uses the face `r`, so let's use that instead of the unwieldy `+6.+7`:
+It did indeed change. We also see that the door sample uses the face `r`, so let's use that instead of the unwieldy `+6.+7`:
 
-```
+```hoon
 > r:~(add rs %u)
 %u
 ```
 
 We can do the same thing for rounding down, `%d`:
 
-```
+```hoon
 > r:~(add rs %d)
 %d
 ```
 
-Let's see the rounding differences in action.  Because `~(add rs %u)` produces a gate, we can call it like we would any other gate:
+Let's see the rounding differences in action. Because `~(add rs %u)` produces a gate, we can call it like we would any other gate:
 
-```
+```hoon
 > (~(add rs %u) .3.14159265 .1.11111111)
 .4.252704
 
@@ -458,20 +460,20 @@ Let's see the rounding differences in action.  Because `~(add rs %u)` produces a
 .4.2527037
 ```
 
-This difference between rounding up and rounding down might seem strange at first.  There is a difference of 0.0000003 between the two answers.  Why does this gap exist?  Single-precision floats are 32-bit and there's only so many distinctions that can be made in floats before you run out of bits.
+This difference between rounding up and rounding down might seem strange at first. There is a difference of 0.0000003 between the two answers. Why does this gap exist? Single-precision floats are 32-bit and there's only so many distinctions that can be made in floats before you run out of bits.
 
 Just as there is a door for `@rs` functions, there is a Hoon standard library door for `@rd` functions (double-precision 64 bit floats), another for `@rq` functions (quad-precision 128 bit floats), and more.
 
 ### Mutating the `rs` Door
 
-Can we mutate the `rs` door so that its sample is `%u`?  Let's try it:
+Can we mutate the `rs` door so that its sample is `%u`? Let's try it:
 
-```
+```hoon
 > rs(r %u)
 -tack.r
 -find.r
 ```
 
-Oops!  Why didn't this work?  Remember, `rs` isn't itself a door; it's an arm that produces a door.  The `rs` in `rs(r %u)` resolves to the nameless parent core of `rs`, and the search for `r` commences there.  But that face can't be found in that parent core -- it's not where we want to look.
+Oops! Why didn't this work? Remember, `rs` isn't itself a door; it's an arm that produces a door. The `rs` in `rs(r %u)` resolves to the nameless parent core of `rs`, and the search for `r` commences there. But that face can't be found in that parent core -- it's not where we want to look.
 
 It's better simply to use the `~(arm rs arg)` syntax to replace the value of the `rs` door sample with `arg`.

--- a/hoon/hoon-school/gates.md
+++ b/hoon/hoon-school/gates.md
@@ -51,7 +51,7 @@ Like all arms, `$` is computed with its parent core as the subject. When `$` is 
 
 Let's make a gate that takes any unsigned integer (i.e., an [atom](/docs/glossary/atom/)) as its sample and returns that value plus one as the product. To do this we'll use the `|=` rune. We'll bind this gate to the face `inc` for "increment":
 
-```
+```hoon
 > =inc |=(a=@ (add 1 a))
 
 > (inc 1)
@@ -210,7 +210,7 @@ It _is_ possible to modify the context of a gate when you make a function call; 
 
 Now let's write a gate called `ten` that adds `b` to the input value:
 
-```
+```hoon
 > =ten |=(a=@ (add a b))
 
 > (ten 10)
@@ -261,7 +261,7 @@ Before finishing the lesson let's unbind `ten`:
 
 Write a gate that takes an atom, `a=@`, and which returns double the value of `a`. Bind this gate to `double` and test it in the Dojo.
 
-```
+```hoon
 > =double |=(a=@ (mul 2 a))
 
 > (double 10)

--- a/hoon/hoon-school/generators.md
+++ b/hoon/hoon-school/generators.md
@@ -28,7 +28,7 @@ a
 This generator takes one argument of any noun and produces it without any
 changes. Once you put this into a file named `echo.hoon` in the `/gen` directory, you must make your ship recognize the change by inputting `|commit %home` in the dojo. You can then run it from the dojo:
 
-```
+```hoon
 > +echo 42
 42
 ```
@@ -36,7 +36,7 @@ changes. Once you put this into a file named `echo.hoon` in the `/gen` directory
 This command just passes in 42 and gets 42 back. But what about when we pass in
 `"asdf"`?
 
-```
+```hoon
 > +echo "asdf"
 [97 115 100 102 0]
 ```
@@ -58,7 +58,7 @@ is terminated with.
 We can tell the Dojo to cast -- apply a specific type to -- the output of our
 generator to see something more familiar:
 
-```
+```hoon
 > _tape +echo "asdf"
 "asdf"
 ```
@@ -73,7 +73,7 @@ below as `add.hoon` in the `/gen` directory.
 
 Now, run the generator:
 
-```
+```hoon
 > +add [3 4]
 7
 ```
@@ -115,7 +115,7 @@ directory.
 
 Now run the generator as below:
 
-```
+```hoon
 > +add
 42
 ```
@@ -133,7 +133,7 @@ Recall that the rune `:-` produces a cell, with the first following expression
 as its head and the second following expression as its tail.
 
 The expression above creates a cell with `%say` as the head. The tail is
-the `|=  *` expression on the line that follows.
+the `|= *` expression on the line that follows.
 
 ```hoon
 |=  *
@@ -141,10 +141,10 @@ the `|=  *` expression on the line that follows.
 (add 40 2)
 ```
 
-`|=  *` constructs a [gate](/docs/glossary/gate/) that takes a noun. This [gate](/docs/glossary/gate/) will itself produce a
+`|= *` constructs a [gate](/docs/glossary/gate/) that takes a noun. This [gate](/docs/glossary/gate/) will itself produce a
 `cask`, which is cell formed by the prepending `:-`. The head of that `cask` is
 `%noun` and the tail is the rest of the program, `(add 40 2)`. The tail of the
-`cask`  will be our actual data produced by the body of the program: in this
+`cask` will be our actual data produced by the body of the program: in this
 case, just adding 40 and 2 together.
 
 #### `%say` generators with arguments
@@ -238,7 +238,7 @@ pseudorandom number between 0 and `n`. Then we form a cell with the result and
 
 We can run this generator like so:
 
-```
+```hoon
 > +dice 6, =bet 2
 [4 2]
 
@@ -280,7 +280,7 @@ list of optional arguments is _empty_.
 Run a command like the one below in the Dojo. Notice that you can use two
 arguments that aren't in the cells.
 
-```
+```hoon
 > +add 40 2
 42
 ```
@@ -379,7 +379,7 @@ This code might be familiar. Just as with their `%say` cousins, `%ask`
 generators need to produce a `cell`, the head of which specifies what kind of
 generator we are running.
 
-With `|=  *`, we create a gate and ignore the standard arguments we are given,
+With `|= *`, we create a gate and ignore the standard arguments we are given,
 because we're not using them.
 
 ```hoon
@@ -434,7 +434,6 @@ use to prompt the user. In the case of our example, we use `"color: "`.
 **`produce`** is used to construct the output of the generator. In our example,
 we produce a `tang`.
 
-
 ```hoon
 |=  t=tape
 ```
@@ -458,4 +457,4 @@ This is a [known issue](https://github.com/urbit/arvo/issues/840) to be resolved
 
 ## Conclusion
 
-You've now reached the end of Chapter 1 of the Hoon tutorial.  Ideally you should have a fair understanding of the fundamental concepts of subject-oriented programming: limbs, legs, faces, wings, arms, cores, gates, and [doors](/docs/glossary/door/).  If you can master these concepts you should have little or no trouble learning to write substantial Hoon programs.
+You've now reached the end of Chapter 1 of the Hoon tutorial. Ideally you should have a fair understanding of the fundamental concepts of subject-oriented programming: limbs, legs, faces, wings, arms, cores, gates, and [doors](/docs/glossary/door/). If you can master these concepts you should have little or no trouble learning to write substantial Hoon programs.

--- a/hoon/hoon-school/hoon-syntax.md
+++ b/hoon/hoon-school/hoon-syntax.md
@@ -7,9 +7,9 @@ aliases = ["/docs/learn/hoon/hoon-tutorial/hoon-syntax/"]
 
 The study of Hoon can be divided into two parts: syntax and semantics.
 
-The [syntax](https://en.wikipedia.org/wiki/Syntax_%28programming_languages%29 ) of a programming language is the set of rules that determine what counts as admissible code in that language. It determines which characters may be used in the source, and also how these characters may be assembled to constitute a program. Attempting to run a program that doesn’t follow these rules will result in a syntax error.
+The [syntax](https://en.wikipedia.org/wiki/Syntax_%28programming_languages%29) of a programming language is the set of rules that determine what counts as admissible code in that language. It determines which characters may be used in the source, and also how these characters may be assembled to constitute a program. Attempting to run a program that doesn’t follow these rules will result in a syntax error.
 
-The [semantics](https://en.wikipedia.org/wiki/Semantics_%28computer_science%29 ) of a programming language concerns the meaning of the various parts of that language’s code.
+The [semantics](https://en.wikipedia.org/wiki/Semantics_%28computer_science%29) of a programming language concerns the meaning of the various parts of that language’s code.
 
 In this lesson we will give a general overview of Hoon’s syntax. By the end of it, you should be familiar with all the basic elements of Hoon code.
 
@@ -53,7 +53,7 @@ Note that the list includes two separate whitespace forms: `ace` for a single sp
 
 ## Expressions of Hoon
 
-An [expression](https://en.wikipedia.org/wiki/Expression_%28computer_science%29 ) is a combination of characters that the language interprets and evaluates as producing a value. Hoon programs are made up entirely of expressions.
+An [expression](https://en.wikipedia.org/wiki/Expression_%28computer_science%29) is a combination of characters that the language interprets and evaluates as producing a value. Hoon programs are made up entirely of expressions.
 
 Hoon expressions can be either basic or complex. Basic expressions of Hoon are fundamental, meaning that they can’t be broken down into smaller expressions. Complex expressions are made up of smaller expressions (which are called **subexpressions**).
 
@@ -63,11 +63,11 @@ There are many categories of Hoon expressions: [noun](/docs/glossary/noun/) lite
 
 A noun is either an [atom](/docs/glossary/atom/) or a cell. An [atom](/docs/glossary/atom/) is an unsigned integer and a cell is a pair of nouns.
 
-There are [literal](https://en.wikipedia.org/wiki/Literal_%28computer_programming%29 ) expressions for each kind of noun. A noun literal is just a notation for representing a fixed noun value.
+There are [literal](https://en.wikipedia.org/wiki/Literal_%28computer_programming%29) expressions for each kind of noun. A noun literal is just a notation for representing a fixed noun value.
 
 We start with atom literals. Each of these is a basic expression of Hoon that evaluates to itself. Examples:
 
-```
+```hoon
 > 1
 1
 
@@ -88,7 +88,7 @@ Recall from [Lesson 1.2](@/docs/hoon/hoon-school/nouns.md) that even though atom
 
 Cell literals can be written in Hoon using `[ ]`. Cell literals are complex, because other expressions are put inside the square brackets. Examples:
 
-```
+```hoon
 > [6 7]
 [6 7]
 
@@ -104,7 +104,7 @@ Cell literals can be written in Hoon using `[ ]`. Cell literals are complex, bec
 
 You can also put complex expressions inside square brackets to make a cell. These are valid expressions but they aren’t cell literals, naturally:
 
-```
+```hoon
 > [(add 22 33) (mul 22 33)]
 [55 726]
 ```
@@ -136,7 +136,6 @@ Wing expressions with multiple limbs are complex expressions. Examples:
 - `-.b.+2`
 - `-.add`
 
-
 ### Type Expressions
 
 Hoon is a statically typed language. You’ll learn more about the type system later in the chapter. For now, just know that Hoon’s type system uses special symbols to indicate certain fundamental types: `~` (null), `*` (noun), `@` (atom), `^` (cell), and `?` (flag). Each of these symbols can be used as a stand-alone expression of Hoon. In the case of `@` there may be a series of letters following it, to indicate an atom aura; e.g., `@s`, `@rs`, `@tas`, and `@tD`.
@@ -163,7 +162,7 @@ The spacing rules differ in the two forms. In tall form, each rune and subexpres
 
 Seeing an example will help you understand the difference. The `:-` rune is used to produce a cell. Accordingly, it is followed by two subexpressions: the first defines the head of the cell, and the second defines the tail. Here are three different ways to write a `:-` expression in tall form:
 
-```
+```hoon
 > :-  11  22
 [11 22]
 
@@ -181,7 +180,7 @@ These all do the same thing. The first example shows that, if you want to, you c
 
 Usually one or more line breaks are used to break up a tall form expression. This is especially useful when the subexpressions are themselves long stretches of code. The same `:-` expression in wide form is:
 
-```
+```hoon
 > :-(11 22)
 [11 22]
 ```
@@ -196,11 +195,11 @@ Since runes take a fixed number of children, one can visualize how Hoon expressi
 
 ![](https://media.urbit.org/docs/hoon-syntax/cell1.png)
 
-Here we have drawn the `:-` rune followed by a box for each of its two children. We can fill these boxes with either a value or an additional rune. The following figure corresponds to the Hoon expression `:-  2  3`.
+Here we have drawn the `:-` rune followed by a box for each of its two children. We can fill these boxes with either a value or an additional rune. The following figure corresponds to the Hoon expression `:- 2 3`.
 
 ![](https://media.urbit.org/docs/hoon-syntax/cell2.png)
 
-This, of course, evaluates to the cell `[2 3]`. This next figure corresponds to the Hoon expression `:-  :-  2  3  4`.
+This, of course, evaluates to the cell `[2 3]`. This next figure corresponds to the Hoon expression `:- :- 2 3 4`.
 
 ![](https://media.urbit.org/docs/hoon-syntax/cell3.png)
 
@@ -210,7 +209,7 @@ What Hoon expression does the following figure correspond to, and what does it e
 
 ![](https://media.urbit.org/docs/hoon-syntax/cell4.png)
 
-Right. This represents the Hoon expression `:-  2  :-  3  4`,
+Right. This represents the Hoon expression `:- 2 :- 3 4`,
 and evaluates to `[2 [3 4]]`. Remember, though, that if you input this into dojo it will print as `[2 3 4]`.
 
 Thinking in terms of these “LEGO block” diagrams, as well as the more literal binary tree diagrams utilized in [Lesson 1.2](@/docs/hoon/hoon-school/nouns.md), can be a helpful learning and debugging tactic.
@@ -225,7 +224,7 @@ Some runes are used so frequently that they have irregular counterparts that are
 
 Let’s look at another example. The `.=` rune takes two subexpressions, evaluates them, and tests the results for equality. If they’re equal it produces `%.y` for “yes”; otherwise `%.n` for “no”. In tall form:
 
-```
+```hoon
 > .=  22  11
 %.n
 
@@ -236,7 +235,7 @@ Let’s look at another example. The `.=` rune takes two subexpressions, evaluat
 
 And in wide form:
 
-```
+```hoon
 > .=(22 11)
 %.n
 
@@ -246,7 +245,7 @@ And in wide form:
 
 The irregular form of the `.=` rune is just `=( )`:
 
-```
+```hoon
 > =(22 11)
 %.n
 
@@ -256,7 +255,7 @@ The irregular form of the `.=` rune is just `=( )`:
 
 The examples above have another irregular form: `(add 11 11)`. This is the irregular form of `%+`, which calls a [gate](/docs/glossary/gate/) (i.e., a Hoon function) with two arguments for the sample.
 
-```
+```hoon
 > %+  add  11  11
 22
 
@@ -266,7 +265,7 @@ The examples above have another irregular form: `(add 11 11)`. This is the irreg
 
 The irregular `( )` gate-calling syntax is versatile -- it is also a shortcut for calling a gate with one argument, which is what the `%-` rune is for:
 
-```
+```hoon
 > (dec 11)
 10
 
@@ -287,7 +286,7 @@ There are certain irregular expressions that aren’t syntactic sugar for regula
 
 Below we use the `` ` `` symbol to create a cell whose head is null, `~`.
 
-```
+```hoon
 > `12
 [~ 12]
 
@@ -297,7 +296,7 @@ Below we use the `` ` `` symbol to create a cell whose head is null, `~`.
 
 Putting `,.` in front of a wing expression removes a face, if there is one.
 
-```
+```hoon
 > -:[a=[12 14] b=[16 18]]
 a=[12 14]
 
@@ -315,7 +314,6 @@ b=[16 18]
 ```
 
 To see other irregular expressions, check the irregular expression [reference document](@/docs/hoon/reference/irregular.md).
-
 
 ## The Standard Library
 
@@ -340,7 +338,7 @@ The Hoon syntax can be intimidating for the uninitiated, so it’s good to remem
 
 - The [Runes](@/docs/hoon/reference/rune/_index.md) page will show you how to use any Hoon rune.
 - The [Cheat Sheet](@/docs/hoon/reference/cheat-sheet.md) is a more compact place to look up rune expressions.
-- The [Standard Library](@/docs/hoon/reference/stdlib/table-of-contents.md)  section has its sub-pages arranged by category. So arithmetic functions, for example, are all found on the same page.
+- The [Standard Library](@/docs/hoon/reference/stdlib/table-of-contents.md) section has its sub-pages arranged by category. So arithmetic functions, for example, are all found on the same page.
 - The [Hoon Style Guide](@/docs/hoon/reference/style.md) will show you how to write your Hoon code so that it’s idiomatic and easily understood by others.
 
 ### Debugging

--- a/hoon/hoon-school/lists.md
+++ b/hoon/hoon-school/lists.md
@@ -15,7 +15,7 @@ It's easy to see where the heads are and where the nesting tails are. The head o
 
 To make a list, let's cast nouns to the `(list @)` ("list of atoms") type.
 
-```
+```hoon
 > `(list @)`~
 ~
 
@@ -37,14 +37,14 @@ The use of casts in this example is helpful to explain to the Hoon compiler exac
 
 Let's make a list whose items are of the `@t` string type:
 
-```
+```hoon
 > `(list @t)`['Urbit' 'will' 'rescue' 'the' 'internet' ~]
 <|Urbit will rescue the internet|>
 ```
 
 The head of a list has the face `i` and the tail has the face `t`. (For the sake of neatness, these faces aren't shown by the Hoon pretty printer.) To use the `i` and `t` faces of a list, you must first prove that the list is non-null by using the conditional family of runes, `?`:
 
-```
+```hoon
 > =>(b=`(list @)`[1 2 3 4 5 ~] i.b)
 -find.i.b
 find-fork-d
@@ -66,7 +66,7 @@ While a list can be of any type, there are some special types of lists that are 
 
 Hoon has two kinds of strings: cords and tapes. Cords are atoms with aura `@t`, and they're pretty-printed between `''` marks.
 
-```
+```hoon
 > 'this is a cord'
 'this is a cord'
 
@@ -76,7 +76,7 @@ Hoon has two kinds of strings: cords and tapes. Cords are atoms with aura `@t`, 
 
 A tape is a list of `@tD` atoms (i.e., ASCII characters).
 
-```
+```hoon
 > "this is a tape"
 "this is a tape"
 
@@ -86,7 +86,7 @@ A tape is a list of `@tD` atoms (i.e., ASCII characters).
 
 You can also use the words `cord` and `tape` for casting:
 
-```
+```hoon
 > `tape`"this is a tape"
 "this is a tape"
 
@@ -104,7 +104,7 @@ For a complete list of these functions, check out the standard library reference
 
 The `flop` function takes a list and returns it in reverse order:
 
-```
+```hoon
 > (flop ~[11 22 33])
 ~[33 22 11]
 
@@ -123,21 +123,21 @@ Without using `flop`, write a [gate](/docs/glossary/gate/) that takes a `(list @
 
 The `sort` function uses the "quicksort" algorithm to sort a list. It takes a list to sort and a gate that serves as a comparator. For example, if you want to sort the list `~[37 62 49 921 123]` from least to greatest, you would pass that list along with the `lth` gate (for "less than"):
 
-```
+```hoon
 > (sort ~[37 62 49 921 123] lth)
 ~[37 49 62 123 921]
 ```
 
 To sort the list from greatest to least, use the `gth` gate ("greater than") as the basis of comparison instead:
 
-```
+```hoon
 > (sort ~[37 62 49 921 123] gth)
 ~[921 123 62 49 37]
 ```
 
 You can sort letters this way as well:
 
-```
+```hoon
 > (sort ~['a' 'f' 'e' 'k' 'j'] lth)
 <|a e f j k|>
 ```
@@ -148,7 +148,7 @@ The function passed to `sort` must produce a `flag`, i.e., `?`.
 
 The `weld` function takes two lists of the same type and concatenates them:
 
-```
+```hoon
 > (weld ~[1 2 3] ~[4 5 6])
 ~[1 2 3 4 5 6]
 
@@ -164,7 +164,7 @@ Without using `weld`, write a gate that takes a `[(list @) (list @)]` of which t
 
 The `snag` function takes an atom `n` and a list, and returns the `n`th item of the list, where `0` is the first item:
 
-```
+```hoon
 > (snag 0 `(list @)`~[11 22 33 44])
 11
 
@@ -186,7 +186,7 @@ The `snag` function takes an atom `n` and a list, and returns the `n`th item of 
 
 Note: there is currently a type system issue that causes some of these functions to fail when passed a list `b` after some type inference has been performed on `b`. For an illustration of the bug, let's set `b` to be a `(list @)` of `~[11 22 33 44]` in the Dojo:
 
-```
+```hoon
 > =b `(list @)`~[11 22 33 44]
 
 > b
@@ -195,7 +195,7 @@ Note: there is currently a type system issue that causes some of these functions
 
 Now let's use `?~` to prove that `b` isn't null, and then try to `snag` it:
 
-```
+```hoon
 > ?~(b ~ (snag 0 b))
 nest-fail
 ```
@@ -204,7 +204,7 @@ The problem is that `snag` is expecting a raw list, not a list that is known to 
 
 You can cast `b` to `(list)` to work around this:
 
-```
+```hoon
 > ?~(b ~ (snag 0 `(list)`b))
 11
 ```
@@ -217,7 +217,7 @@ Without using `snag`, write a gate that returns the `n`th item of a list. There 
 
 The `oust` function takes a pair of atoms `[a=@ b=@]` and a list, and returns the list with `b` items removed, starting at item `a`:
 
-```
+```hoon
 > (oust [0 1] `(list @)`~[11 22 33 44])
 ~[22 33 44]
 
@@ -235,7 +235,7 @@ The `oust` function takes a pair of atoms `[a=@ b=@]` and a list, and returns th
 
 The `lent` function takes a list and returns the number of items in it:
 
-```
+```hoon
 > (lent ~[11 22 33 44])
 4
 
@@ -251,7 +251,7 @@ Without using `lent`, write a gate that takes a list and returns the number of i
 
 The `roll` function takes a list and a gate, and accumulates a value of the list items using that gate. For example, if you want to add or multiply all the items in a list of atoms, you would use `roll`:
 
-```
+```hoon
 > (roll `(list @)`~[11 22 33 44 55] add)
 165
 
@@ -263,14 +263,14 @@ The `roll` function takes a list and a gate, and accumulates a value of the list
 
 The `turn` function takes a list and a gate, and returns a list of the products of applying each item of the input list to the gate. For example, to add `1` to each item in a list of atoms:
 
-```
+```hoon
 > (turn `(list @)`~[11 22 33 44] |=(a=@ +(a)))
 ~[12 23 34 45]
 ```
 
 Or to double each item in a list of atoms:
 
-```
+```hoon
 > (turn `(list @)`~[11 22 33 44] |=(a=@ (mul 2 a)))
 ~[22 44 66 88]
 ```
@@ -307,15 +307,15 @@ The Hoon standard library and compiler are written in Hoon. At this point, you k
 
 Without entering these expressions into the Dojo, what are the products of the following expressions?
 
-```
+```hoon
 > (lent ~[1 2 3 4 5])
 ```
 
-```
+```hoon
 > (lent ~[~[1 2] ~[1 2 3] ~[2 3 4]])
 ```
 
-```
+```hoon
 > (lent ~[1 2 (weld ~[1 2 3] ~[4 5 6])])
 ```
 
@@ -323,26 +323,26 @@ Without entering these expressions into the Dojo, what are the products of the f
 
 First, bind these faces.
 
-```
+```hoon
 > =b ~['moon' 'planet' 'star' 'galaxy']
 > =c ~[1 2 3]
 ```
 
 Then determine whether the following Dojo expressions are valid, and if so, what they evaluate to.
 
-```
+```hoon
 > (weld b b)
 ```
 
-```
+```hoon
 > (weld b c)
 ```
 
-```
+```hoon
 > (lent (weld b c))
 ```
 
-```
+```hoon
 > (add (lent b) (lent c))
 ```
 
@@ -366,7 +366,7 @@ $(b [i.a b], a t.a)
 
 Run in Dojo:
 
-```
+```hoon
 > +flop ~[11 22 33 44]
 ~[44 33 22 11]
 ```
@@ -384,7 +384,7 @@ Run in Dojo:
 
 Run in Dojo:
 
-```
+```hoon
 > +weld [~[1 2 3] ~[3 4 5 6]]
 ~[1 2 3 3 4 5 6]
 ```
@@ -402,7 +402,7 @@ $(a (dec a), b t.b)
 
 Run in Dojo:
 
-```
+```hoon
 > +snag [0 ~[11 22 33 44]]
 11
 
@@ -425,7 +425,7 @@ $(a t.a, b +(b))
 
 Run in Dojo:
 
-```
+```hoon
 > +lent ~[1 2 3 4 5]
 5
 > +lent "asdf"
@@ -436,7 +436,7 @@ Run in Dojo:
 
 Run in Dojo:
 
-```
+```hoon
 > (lent ~[1 2 3 4 5])
 5
 > (lent ~[~[1 2] ~[1 2 3] ~[2 3 4]])
@@ -449,24 +449,24 @@ Run in Dojo:
 
 Run in Dojo:
 
-```
+```hoon
 > (weld b b)
 <|moon planet star galaxy moon planet star galaxy|>
 ```
 
-```
+```hoon
 > (weld b c)
 ```
 
 This will not run because `weld` expects the elements of both lists to be of the same type.
 
-```
+```hoon
 > (lent (weld b c))
 ```
 
 This also fails for the same reason, but it is important to note that in some languages that are more lazily evaluated, such an expression would still work since it would only look at the length of `b` and `c` and not worry about what the elements were. In that case, it would return `7`.
 
-```
+```hoon
 > (add (lent b) (lent c))
 7
 ```
@@ -484,7 +484,7 @@ We see here the correct way to find the sum of the length of two lists of unknow
 
 Run in Dojo:
 
-```
+```hoon
 > +palindrome "urbit"
 %.n
 > +palindrome "racecar"

--- a/hoon/hoon-school/molds.md
+++ b/hoon/hoon-school/molds.md
@@ -8,19 +8,19 @@ aliases = ["/docs/learn/hoon/hoon-tutorial/molds/"]
 A mold is an idempotent function that coerces a [noun](/docs/glossary/noun/) to
 be of a specific type or crashes.
 
-
 The simplest molds to understand are arms of cores created with `+$`
 
-```
+```hoon
 +$  height  [feet=@ud inches=@ud]
 ```
 
 A mold is compiled to a gate that takes in any noun and produces a typed value, or crashes:
 
-```
+```hoon
 (height [5 11])
 ::  produces [feet=5 inches=11]
 ```
+
 ```
 (height %wrong)
 ::  crashes
@@ -28,16 +28,15 @@ A mold is compiled to a gate that takes in any noun and produces a typed value, 
 
 To coerce using a gate, it's good practice to use the `;;` rune, which can parse inline molds.
 
-
-```
+```hoon
 ;;(height [5 11])
 ::  produces [feet=5 inches=11]
 ```
+
 ```hoon
 ;;([feet=@ud inches=@ud] [5 11])
 ::  produces [feet=5 inches=11]
 ```
-
 
 `|$` is the mold builder rune which takes a list of molds and produces a mold.
 
@@ -46,13 +45,13 @@ polymorphism](https://en.wikipedia.org/wiki/Parametric_polymorphism) in Hoon,
 and as such we call gates produced with `|$` a **wet gate**. We discuss what this
 means in further detail in the upcoming lesson on [polymorphism](@/docs/hoon/hoon-school/type-polymorphism.md).
 
-Let's look at some examples from `hoon.hoon`. 
+Let's look at some examples from `hoon.hoon`.
+
 ```hoon
 ++  pair
   |$  [head tail]
   [p=head q=tail]
 ```
-
 
 Here is a very simple mold builder. It takes two molds and produces a mold that is a pair of those with the faces `p` and `q`. An example of using this would be `(pair @ud @ud)` which would produce a mold for a cell of `@ud` and `@ud`.
 
@@ -71,14 +70,15 @@ Here is a very simple mold builder. It takes two molds and produces a mold that 
   |$  [item]
   $@(~ [i=item t=(list item)])
 ```
-Here is a mold builder you've used previously. `$@` is a rune that will match the first thing if its sample is an [atom](/docs/glossary/atom/) and the second if the sample is a cell. You should be familiar at this point that a `list` is either `~`  or a pair of an item and a list of item.
 
+Here is a mold builder you've used previously. `$@` is a rune that will match the first thing if its sample is an [atom](/docs/glossary/atom/) and the second if the sample is a cell. You should be familiar at this point that a `list` is either `~` or a pair of an item and a list of item.
 
 ```hoon
 ++  lest
   |$  [item]
   [i/item t/(list item)]
 ```
+
 `lest` you may have heard of as a "non empty list." You can see that it lacks the `~` case that `list` has but it matches the second part of the `list` definition. Remember that Hoon types are defined by shape. `list` could also have been defined in terms of `lest` like this:
 
 ```hoon

--- a/hoon/hoon-school/nouns.md
+++ b/hoon/hoon-school/nouns.md
@@ -142,7 +142,7 @@ In computer science, a "literal" is an expression that represents and evaluates 
 
 All of the above are atoms. The underlying noun of each is just an unsigned integer, but each is written in a special syntax indicating to Hoon that the atom is to be represented in a different way. To see their values in the default atom notation, you can tell Hoon to throw away the aura information. Do this by preceding each expression above with `` `@` ``.
 
-```
+```hoon
 > `@`0b1001
 9
 
@@ -174,7 +174,7 @@ The `` `@` `` syntax is used to "cast" a value to a raw atom, i.e., an atom with
 
 Urbit identities such as `~zod` and `~sorreg-namtyv` are also atoms, but of the aura `@p`:
 
-```
+```hoon
 > ~zod
 ~zod
 
@@ -196,7 +196,7 @@ Urbit identities such as `~zod` and `~sorreg-namtyv` are also atoms, but of the 
 
 Hoon permits the use of atoms as strings. Strings that are encoded as atoms are called **cords**. Cords are of the aura `@t`. The literal syntax of a cord is text inside a pair of single-quotes, e.g., `'Hello world!'`.
 
-```
+```hoon
 > 'Howdy!'
 'Howdy!'
 
@@ -212,7 +212,7 @@ Hoon permits the use of atoms as strings. Strings that are encoded as atoms are 
 
 Hoon also has **terms**, of the aura `@tas`. Terms are constant values that are used to tag data using the type system. These are strings preceded with a `%` and made up of lowercase letters, numbers, and hyphens, i.e., "kebab case". The first character after the `%` must be a letter. For example, `%a`, `%hello`, `%this-is-kebab-case123`.
 
-```
+```hoon
 > %howdy
 %howdy
 
@@ -267,7 +267,7 @@ Aura         Meaning                        Example of Literal Syntax
 
 You can force Hoon to interpret an atom differently by using the aura symbols in the chart above; e.g., `` `@ux` `` for unsigned hexadecimal, `` `@ub` `` for unsigned binary, etc.:
 
-```
+```hoon
 > `@ux`157
 0x9d
 
@@ -289,14 +289,14 @@ You'll learn more about atoms and auras in [Lesson 2.1](@/docs/hoon/hoon-school/
 
 There's not much mystery about cells. The left of a cell is called the **head**, and the right is called the **tail**. Cells are typically represented in Hoon with square brackets around a pair of nouns.
 
-```
+```hoon
 > [32 320]
 [32 320]
 ```
 
 In this cell `32` is the head and `320` is the tail. Cells can contain cells, and atoms of other auras as well:
 
-```
+```hoon
 > [%hello 'world!']
 [%hello 'world!']
 
@@ -377,7 +377,7 @@ If the way this works isn't immediately clear, remember that each noun can be un
 
 Let's do some examples in the Dojo. We're going to use the `slot` operator, `+`, to return fragments of a noun. For any unsigned integer `n`, `+n` evaluates to the fragment at address `n`.
 
-```
+```hoon
 > +1:[22 [33 44]]
 [22 33 44]
 
@@ -398,14 +398,14 @@ You'll notice that we use the `:` symbol between the slot syntax and the noun. D
 
 What happens if you ask for a fragment that doesn't exist?
 
-```
+```hoon
 > +4:[22 [33 44]]
 ford: %ride failed to execute:
 ```
 
 Let's do a few more examples:
 
-```
+```hoon
 > +2:[['apple' %pie] [0b1101 0xdad]]
 ['apple' %pie]
 
@@ -423,7 +423,6 @@ Let's do a few more examples:
 ```
 
 For those who prefer to think in terms of binary numbers and binary trees, there is another (equivalent) way to understand noun addressing. When the noun address is expressed as a binary number, you can think of the number as indicating a tree path from the top node.
-
 
 As before, the root of the binary tree (i.e., the whole noun) is at address `1`. For the node of a tree at any address `b`, where `b` is a binary number, you get the address of its head by concatenating a `0` to the end of `b`; and to get its tail, concatenate a `1` to the end. For example, the head of the node at binary address `111` is at `1110`, and the tail is at `1111`.
 
@@ -485,27 +484,27 @@ Write the following binary tree as a noun.
 
 ### 1.2a
 
-+ No
-+ Yes
-+ No
-+ Yes
-+ Yes
+- No
+- Yes
+- No
+- Yes
+- Yes
 
 ### 1.2b
 
-+ 86
-+ [[[65 35] 54] 77]
-+ [65 35]
-+ 77
-+ 3
+- 86
+- [[[65 35] 54] 77]
+- [65 35]
+- 77
+- 3
 
 ### 1.2c
 
-+ +2
-+ +6
-+ +14
-+ +15
-+ +31
+- +2
+- +6
+- +14
+- +15
+- +31
 
 ### 1.2d
 
@@ -523,7 +522,7 @@ Write the following binary tree as a noun.
      / \
     /   \
    .     .
-  / \   / \  
+  / \   / \
  2   3 4   .
           / \
          5   .

--- a/hoon/hoon-school/recursion.md
+++ b/hoon/hoon-school/recursion.md
@@ -155,7 +155,7 @@ total for the factorial computation.
 Let's use pseudo-Hoon to illustrate how the stack is working in this example for
 the factorial of 5.
 
-```
+```hoon
 (factorial 5)
 (|- 5 1)
 (|- 4 5)
@@ -185,11 +185,10 @@ skips the first match of a name.
 ### Exercises
 
 1. Write a recursive gate that produces the first _n_
-[Fibonacci numbers](https://en.wikipedia.org/wiki/Fibonacci_number)
+   [Fibonacci numbers](https://en.wikipedia.org/wiki/Fibonacci_number)
 
 2. Write a recursive gate that produces a list of moves to solve the
-[Tower of Hanoi problem](https://en.wikipedia.org/wiki/Tower_of_Hanoi).
-Disks are stacked on a pole by decreasing order of size. Move all of the
-disks from one pole to another with a third pole as a spare, moving one
-disc at a time, without putting a larger disk on top of a smaller disk.
-
+   [Tower of Hanoi problem](https://en.wikipedia.org/wiki/Tower_of_Hanoi).
+   Disks are stacked on a pole by decreasing order of size. Move all of the
+   disks from one pole to another with a third pole as a spare, moving one
+   disc at a time, without putting a larger disk on top of a smaller disk.

--- a/hoon/hoon-school/structures-and-complex-types.md
+++ b/hoon/hoon-school/structures-and-complex-types.md
@@ -5,19 +5,19 @@ template = "doc.html"
 aliases = ["/docs/learn/hoon/hoon-tutorial/structures-and-complex-types/"]
 +++
 
-In this lesson we'll talk a little about how type expressions become structures, and how these structures manifest in different ways in different parts of your Hoon code.  We'll also talk about how to create your own custom-defined complex types from simpler ones.
+In this lesson we'll talk a little about how type expressions become structures, and how these structures manifest in different ways in different parts of your Hoon code. We'll also talk about how to create your own custom-defined complex types from simpler ones.
 
 ## Structures
 
-Attentive readers may remember that Hoon programs are made of expressions.  By definition, an expression produces a value.  We've talked about expressions for types such as `@`, `^`, `[? *]`, etc.  What values do these subexpressions produce?  The answer is that they produce a **structure**.  But what are structures, and what role do they play in Hoon?
+Attentive readers may remember that Hoon programs are made of expressions. By definition, an expression produces a value. We've talked about expressions for types such as `@`, `^`, `[? *]`, etc. What values do these subexpressions produce? The answer is that they produce a **structure**. But what are structures, and what role do they play in Hoon?
 
-You don't actually need to know much about what a structure is in order to write Hoon programs that use the type system effectively.  Accordingly, we'll save the particular details for a later lesson.  Here we'll give only a sketch of the most important features.
+You don't actually need to know much about what a structure is in order to write Hoon programs that use the type system effectively. Accordingly, we'll save the particular details for a later lesson. Here we'll give only a sketch of the most important features.
 
 ### Cast Expressions
 
-Structures play different roles in different code contexts.  First, let's look at type expressions in casts:
+Structures play different roles in different code contexts. First, let's look at type expressions in casts:
 
-```
+```hoon
 > ^-(@ 15)
 15
 
@@ -30,17 +30,17 @@ Structures play different roles in different code contexts.  First, let's look a
 
 The `@`, `^`, and `[? *]` subexpressions have no effect on the overall value produced.
 
-It's important to understand that these casts don't affect the [runtime](https://en.wikipedia.org/wiki/Run_time_%28program_lifecycle_phase%29) semantics of a program at all.  They affect only the compiler behavior at compile-time.  The compiler does these type-checks when compiling, but the resulting code has no value corresponding to the types above.
+It's important to understand that these casts don't affect the [runtime](https://en.wikipedia.org/wiki/Run_time_%28program_lifecycle_phase%29) semantics of a program at all. They affect only the compiler behavior at compile-time. The compiler does these type-checks when compiling, but the resulting code has no value corresponding to the types above.
 
-Accordingly, the structures produced by the type subexpressions above aren't part of the program's runtime semantics.  They are compile-time values only.
+Accordingly, the structures produced by the type subexpressions above aren't part of the program's runtime semantics. They are compile-time values only.
 
 ### Type Example Values ('Bunt' Values)
 
-In other cases, structures _can_ have an effect on runtime semantics.  For example, consider the expression `|=(a=@ 15)`.  This produces a [gate](/docs/glossary/gate/) that takes any [atom](/docs/glossary/atom/) as its sample and returns `15`.
+In other cases, structures _can_ have an effect on runtime semantics. For example, consider the expression `|=(a=@ 15)`. This produces a [gate](/docs/glossary/gate/) that takes any [atom](/docs/glossary/atom/) as its sample and returns `15`.
 
-The `@` subexpression of `|=(a=@ 15)` produces a structure at compile time.  In the compiled program this structure is converted to a default value for the appropriate type, sometimes called an **example** value (or a **bunt** value).
+The `@` subexpression of `|=(a=@ 15)` produces a structure at compile time. In the compiled program this structure is converted to a default value for the appropriate type, sometimes called an **example** value (or a **bunt** value).
 
-```
+```hoon
 > |=(a=@ 15)
 < 1.xqz
   { a/@
@@ -53,9 +53,9 @@ The `@` subexpression of `|=(a=@ 15)` produces a structure at compile time.  In 
 0
 ```
 
-As you can see, the example value for `@` is `0`.  Example values are used as placeholder data for the gate's sample.  You can prepend `*` to a type expression to see the default value of that type:
+As you can see, the example value for `@` is `0`. Example values are used as placeholder data for the gate's sample. You can prepend `*` to a type expression to see the default value of that type:
 
-```
+```hoon
 > *^
 [0 0]
 
@@ -71,9 +71,9 @@ As you can see, the example value for `@` is `0`.  Example values are used as pl
 
 ### Molds
 
-Structures can also become gates at runtime.  To produce such a gate, use a type expression as a stand-alone expression in the dojo:
+Structures can also become gates at runtime. To produce such a gate, use a type expression as a stand-alone expression in the dojo:
 
-```
+```hoon
 > @
 < 1.goa
   { *
@@ -99,11 +99,11 @@ Structures can also become gates at runtime.  To produce such a gate, use a type
 >
 ```
 
-In all three cases, the result of evaluation is a gate.  For each, the head is a single [arm](/docs/glossary/arm/), signified by `1.xxx`.  The sample -- i.e., the head of the tail -- in each case is of the type `*`.  These gates are sometimes called **molds**.
+In all three cases, the result of evaluation is a gate. For each, the head is a single [arm](/docs/glossary/arm/), signified by `1.xxx`. The sample -- i.e., the head of the tail -- in each case is of the type `*`. These gates are sometimes called **molds**.
 
-Molds are gates with two special properties: (1) they are guaranteed to produce a value of the type indicated by the type expression, and (2) they are [idempotent](https://en.wikipedia.org/wiki/Idempotence).  (A gate `i` is idempotent if and only if the result of applying `i` multiple times to a value produces the same result as applying it once.  In other words, `(i val)` must produce the same result as `(i (i val))`.)
+Molds are gates with two special properties: (1) they are guaranteed to produce a value of the type indicated by the type expression, and (2) they are [idempotent](https://en.wikipedia.org/wiki/Idempotence). (A gate `i` is idempotent if and only if the result of applying `i` multiple times to a value produces the same result as applying it once. In other words, `(i val)` must produce the same result as `(i (i val))`.)
 
-```
+```hoon
 > (@ 123)
 123
 
@@ -126,28 +126,28 @@ Molds are gates with two special properties: (1) they are guaranteed to produce 
 %.y
 ```
 
-But what if we call a mold with the 'wrong' type of sample?  It will crash:
+But what if we call a mold with the 'wrong' type of sample? It will crash:
 
-```
+```hoon
 > (@ [12 14])
 ford: %ride failed to execute:
 ```
 
-Molds are designed for data validation.  We won't discuss that particular use case here.
+Molds are designed for data validation. We won't discuss that particular use case here.
 
 ## Constructing Complex Types
 
-Up to this point we've only talked about relatively simple data types.  You've seen (1) the basic types and (2) one way of combining basic types to make complex types.  In the rest of this lesson you'll learn other ways to create custom data types in Hoon.
+Up to this point we've only talked about relatively simple data types. You've seen (1) the basic types and (2) one way of combining basic types to make complex types. In the rest of this lesson you'll learn other ways to create custom data types in Hoon.
 
 Let's review (1) and (2) briefly.
 
 ### Basic Types
 
-The basic types of Hoon are: `*` for [nouns](/docs/glossary/noun/), `@` for atoms (possibly with aura information, e.g., `@ud` and `@sx`), `^` for cells, `?` for flags, and `~` for null.  You can also make constant, one-value types by using `%` followed by a series of lowercase letters, the hyphen symbol `-`, and numbers.  E.g., `%red`, `%2`, `%kebab-case123`.  The lone values of these one-value types are sometimes called 'tags'.
+The basic types of Hoon are: `*` for [nouns](/docs/glossary/noun/), `@` for atoms (possibly with aura information, e.g., `@ud` and `@sx`), `^` for cells, `?` for flags, and `~` for null. You can also make constant, one-value types by using `%` followed by a series of lowercase letters, the hyphen symbol `-`, and numbers. E.g., `%red`, `%2`, `%kebab-case123`. The lone values of these one-value types are sometimes called 'tags'.
 
-Let's illustrate with the irregular ``` ` ` ``` cast syntax:
+Let's illustrate with the irregular `` ` ` `` cast syntax:
 
-```
+```hoon
 > `%blah`%blah
 %blah
 
@@ -157,9 +157,9 @@ nest-fail
 
 ### Complex Types
 
-In certain parts of Hoon code (not all) you can define a complex cell type from simpler types using square brackets, `[ ]`.  For some examples: `[@ ^]`, `[@ud @ub]`, `[@t [? ^]]`, `[%employee @t ? @]` etc.
+In certain parts of Hoon code (not all) you can define a complex cell type from simpler types using square brackets, `[ ]`. For some examples: `[@ ^]`, `[@ud @ub]`, `[@t [? ^]]`, `[%employee @t ? @]` etc.
 
-```
+```hoon
 > `[@ud @ub]`[12 0b11]
 [12 0b11]
 
@@ -175,13 +175,13 @@ nest-fail
 
 ## Building Structures: The `$` Rune Family
 
-The purpose of the `$` family of runes is to construct user-defined complex structures from simpler ones.  Let's take a look at some of these runes and use them to make custom types.
+The purpose of the `$` family of runes is to construct user-defined complex structures from simpler ones. Let's take a look at some of these runes and use them to make custom types.
 
 ### `$:` Build a Cell Structure
 
-The `$:` takes two subexpressions, each of which must be a structure.  The result is a cell structure whose head and tail are the two structures indicated.  For example, the type defined by `$:(@ ?)` is the set of cells whose head is an atom, `@` and whose tail is a flag, `?`.  Most of the time you can achieve the same result using square brackets: `[@ ?]`.  (Most of the time, but not always!)
+The `$:` takes two subexpressions, each of which must be a structure. The result is a cell structure whose head and tail are the two structures indicated. For example, the type defined by `$:(@ ?)` is the set of cells whose head is an atom, `@` and whose tail is a flag, `?`. Most of the time you can achieve the same result using square brackets: `[@ ?]`. (Most of the time, but not always!)
 
-```
+```hoon
 > `$:(@ ?)`[123 %.y]
 [123 %.y]
 
@@ -197,17 +197,17 @@ nest-fail
 
 #### Two Interpretations for `[@ ?]` (and Other Such Expressions)
 
-Why are `$:(@ ?)` and `[@ ?]` the same only 'most of the time'?  Why not always?  The answer has to do with the way Hoon handles certain rune subexpressions.  Some subexpressions are reserved exclusively for types.  For example, the `^-` rune is always followed by two subexpressions, the first of which must indicate a type.  Subexpressions reserved exclusively for types are interpreted as types.  These subexpressions must **always** produce a single structure, at least as an intermediate piece of data at compile-time.  When `[@ ?]` is interpreted by Hoon as indicating a type, the result is a structure equivalent to that of `$:(@ ?)`.
+Why are `$:(@ ?)` and `[@ ?]` the same only 'most of the time'? Why not always? The answer has to do with the way Hoon handles certain rune subexpressions. Some subexpressions are reserved exclusively for types. For example, the `^-` rune is always followed by two subexpressions, the first of which must indicate a type. Subexpressions reserved exclusively for types are interpreted as types. These subexpressions must **always** produce a single structure, at least as an intermediate piece of data at compile-time. When `[@ ?]` is interpreted by Hoon as indicating a type, the result is a structure equivalent to that of `$:(@ ?)`.
 
 The first subexpression after the `|=` rune is also interpreted in the same way, i.e., as giving a type definition (in this case for the gate sample).
 
 But expressions of Hoon that aren't exclusively for types interpret expressions such as `[@ ?]` differently, i.e., as a cell of structures. Interpreted in this way, `[@ ?]` isn't equivalent to `$:(@ ?)`.
 
-`$:` expressions _always_ evaluate to a single structure, regardless of where they're located in the code.  Expressions like `[@ ?]` are only understood as a single structure if it's a subexpression that must indicate a type; otherwise it's taken to be a pair of structures.
+`$:` expressions _always_ evaluate to a single structure, regardless of where they're located in the code. Expressions like `[@ ?]` are only understood as a single structure if it's a subexpression that must indicate a type; otherwise it's taken to be a pair of structures.
 
 Here we can see the difference by noting how many molds each produces:
 
-```
+```hoon
 > $:(@ ?)
 < 1.igg
   { *
@@ -232,9 +232,9 @@ Here we can see the difference by noting how many molds each produces:
 ]
 ```
 
-You can force `[@ ?]` to be interpreted as a single mold by prepending it with `,`: `,[@ ?]`.  However, there usually is no need for this.
+You can force `[@ ?]` to be interpreted as a single mold by prepending it with `,`: `,[@ ?]`. However, there usually is no need for this.
 
-```
+```hoon
 > ,[@ ?]
 < 1.igg
   { *
@@ -246,9 +246,9 @@ You can force `[@ ?]` to be interpreted as a single mold by prepending it with `
 
 ### `$-` Define a Gate Type
 
-You can use `$-` to define a gate type.  The `$-` rune takes two subexpressions, which correspond to the gate input type and output type, respectively.  For example, if you want to cast for a gate that takes `@` and returns `@` when called, use `$-(@ @)`:
+You can use `$-` to define a gate type. The `$-` rune takes two subexpressions, which correspond to the gate input type and output type, respectively. For example, if you want to cast for a gate that takes `@` and returns `@` when called, use `$-(@ @)`:
 
-```
+```hoon
 > (`$-(@ @)`|=(@ `@`15) 12)
 15
 
@@ -267,11 +267,11 @@ nest-fail
 
 ### `$?` Define a Union
 
-In set theory, the [union](https://en.wikipedia.org/wiki/Union_%28set_theory%29) of sets A and B is a set containing all members of both A and B.  For example, the union of the set of even integers and the set of odd integers is the set of all integers.
+In set theory, the [union](https://en.wikipedia.org/wiki/Union_%28set_theory%29) of sets A and B is a set containing all members of both A and B. For example, the union of the set of even integers and the set of odd integers is the set of all integers.
 
-It's useful to be able to define a type that is the union of other types.  The `$?` rune lets us do this.  The `$?` takes a series of subexpressions, each of which must be a structure.  The resulting type is the union of all types indicated in the expression.  For example, `$?(%green %yellow %red)` is the union of the types indicated by `%green`, `%yellow`, and `%red`.
+It's useful to be able to define a type that is the union of other types. The `$?` rune lets us do this. The `$?` takes a series of subexpressions, each of which must be a structure. The resulting type is the union of all types indicated in the expression. For example, `$?(%green %yellow %red)` is the union of the types indicated by `%green`, `%yellow`, and `%red`.
 
-```
+```hoon
 > `$?(%green %yellow %red)`%green
 %green
 
@@ -287,7 +287,7 @@ nest-fail
 
 The irregular form of `$?` is just `?( )`:
 
-```
+```hoon
 > `?(%green %yellow %red)`%green
 %green
 
@@ -295,9 +295,9 @@ The irregular form of `$?` is just `?( )`:
 %yellow
 ```
 
-`$?` should only be used on types that are disjoint, i.e., which have no values in common.  For example, it shouldn't be used on atom types differing only in aura.
+`$?` should only be used on types that are disjoint, i.e., which have no values in common. For example, it shouldn't be used on atom types differing only in aura.
 
-```
+```hoon
 > `?(@ud @ux)`10
 10
 
@@ -305,15 +305,15 @@ The irregular form of `$?` is just `?( )`:
 18
 ```
 
-Notice that in the latter cast, the type of the literal `0x12` is ignored and the value is printed as `@ud`.  To avoid this when using `$?`, make sure you use types with no values in common.
+Notice that in the latter cast, the type of the literal `0x12` is ignored and the value is printed as `@ud`. To avoid this when using `$?`, make sure you use types with no values in common.
 
 ### `$%` Define a Tagged Union
 
-A [tagged union](https://en.wikipedia.org/wiki/Tagged_union) is a structure corresponding to a union of tagged cell types.  A tagged cell is a cell whose head is a tag, e.g., `[%employee name='John Smith' full-time=%.y]`.  The type of this cell is `[%employee name=@t full-time=?]`, and you may want a union of this type and another tagged cell type, `[%customer name=@t]`.  To construct such a type, use `$%`.
+A [tagged union](https://en.wikipedia.org/wiki/Tagged_union) is a structure corresponding to a union of tagged cell types. A tagged cell is a cell whose head is a tag, e.g., `[%employee name='John Smith' full-time=%.y]`. The type of this cell is `[%employee name=@t full-time=?]`, and you may want a union of this type and another tagged cell type, `[%customer name=@t]`. To construct such a type, use `$%`.
 
-The `$%` rune takes a series of subexpressions, each of which must define a tagged cell type.  The result is a tagged union.  For example, we can make a tagged union of the tagged cell types above using `$%`.  We'll store this structure using the dojo `=` operation (not a feature of Hoon):
+The `$%` rune takes a series of subexpressions, each of which must define a tagged cell type. The result is a tagged union. For example, we can make a tagged union of the tagged cell types above using `$%`. We'll store this structure using the dojo `=` operation (not a feature of Hoon):
 
-```
+```hoon
 > =user $%([%employee name=@t full-time=?] [%customer name=@t])
 
 > `user`[%employee 'John Smith' &]
@@ -329,15 +329,15 @@ The `$%` rune takes a series of subexpressions, each of which must define a tagg
 nest-fail
 ```
 
-`$%` is especially useful when you need a composite type of various categories, each of which has a different structure.  There is to be a unique tag for each category, which your Hoon program will use to determine how to handle the data appropriately.
+`$%` is especially useful when you need a composite type of various categories, each of which has a different structure. There is to be a unique tag for each category, which your Hoon program will use to determine how to handle the data appropriately.
 
 ### `$@` Define a Union of Atom and Cell Types
 
-The `$@` rune takes two subexpressions.  The first must be an atomic type, and the second must be a cell type.  The result is a union.
+The `$@` rune takes two subexpressions. The first must be an atomic type, and the second must be a cell type. The result is a union.
 
-Often `$@` is used to define a type with a null or trivial case for the `@` case.  For example, we can expand the `user` structure using `$@` to give it a null case:
+Often `$@` is used to define a type with a null or trivial case for the `@` case. For example, we can expand the `user` structure using `$@` to give it a null case:
 
-```
+```hoon
 > =user $@(~ $%([%employee name=@t full-time=?] [%customer name=@t]))
 
 > `user`[%employee 'Ryan Jones' |]
@@ -353,4 +353,3 @@ Often `$@` is used to define a type with a null or trivial case for the `@` case
 Now the `~` value is included as a possible value for `user`.
 
 We will see types arise again, in the context of polymorphism in [Lesson 2.5](@/docs/hoon/hoon-school/type-polymorphism.md).
-

--- a/hoon/hoon-school/the-subject-and-its-legs.md
+++ b/hoon/hoon-school/the-subject-and-its-legs.md
@@ -5,7 +5,7 @@ template = "doc.html"
 aliases = ["/docs/learn/hoon/hoon-tutorial/the-subject-and-its-legs/"]
 +++
 
-Hoon isn't an object-oriented programming language; it's a "subject-oriented" programming language.  But what's this "subject"?
+Hoon isn't an object-oriented programming language; it's a "subject-oriented" programming language. But what's this "subject"?
 
 ## A Start
 
@@ -13,7 +13,7 @@ For now we can say three things about the subject: (1) every Hoon expression is 
 
 In fact, you already learned about the noun address system in [Lesson 1.2](@/docs/hoon/hoon-school/nouns.md) when you used `+` to return a fragment of a noun:
 
-```
+```hoon
 > +1:[[11 22] 33]
 [[11 22] 33]
 
@@ -24,20 +24,20 @@ In fact, you already learned about the noun address system in [Lesson 1.2](@/doc
 33
 ```
 
-The `:` operator does two things.  First, it evaluates the expression on the right-hand side; and second, it evaluates the expression on the left-hand side, using the product of the right-hand side as its subject.
+The `:` operator does two things. First, it evaluates the expression on the right-hand side; and second, it evaluates the expression on the left-hand side, using the product of the right-hand side as its subject.
 
 In the examples above, the expression on the right-hand, `[[11 22] 33]`, evaluates to itself:
 
-```
+```hoon
 > [[11 22] 33]
 [[11 22] 33]
 ```
 
-...so the subject for the left-hand expression, `+1`, is simply `[[11 22] 33]`.  The `+` operator is used to produce some fragment of the subject at a given address.  E.g., `+2`, returns whatever is at address `2` of the subject.  Hence, we may read `+2:[[11 22] 33]` as "address `2` of the subject produced by `[[11 22] 33]`".
+...so the subject for the left-hand expression, `+1`, is simply `[[11 22] 33]`. The `+` operator is used to produce some fragment of the subject at a given address. E.g., `+2`, returns whatever is at address `2` of the subject. Hence, we may read `+2:[[11 22] 33]` as "address `2` of the subject produced by `[[11 22] 33]`".
 
 Let's create a subject with some computations:
 
-```
+```hoon
 > [[(add 22 33) (mul 2 6)] 23]
 [[55 12] 23]
 
@@ -54,11 +54,11 @@ Let's create a subject with some computations:
 55
 ```
 
-`add` and `mul` are functions of the Hoon standard library.  `add` is used to add two [atoms](/docs/glossary/atom/), and `mul` is used to multiply them.
+`add` and `mul` are functions of the Hoon standard library. `add` is used to add two [atoms](/docs/glossary/atom/), and `mul` is used to multiply them.
 
 ## Limbs of the Subject
 
-The subject is a noun, just like any other piece of Hoon data.  In Lesson 1.2 we discussed how any noun can be understood as a binary tree.  E.g., `[[4 5] [6 [14 15]]]`:
+The subject is a noun, just like any other piece of Hoon data. In Lesson 1.2 we discussed how any noun can be understood as a binary tree. E.g., `[[4 5] [6 [14 15]]]`:
 
 ```
      [[4 5] [6 [14 15]]]
@@ -71,23 +71,23 @@ The subject is a noun, just like any other piece of Hoon data.  In Lesson 1.2 we
                  14 15
 ```
 
-Each fragment of a noun is itself a noun, and hence can be understood as a binary tree as well.  Each fragment or 'subtree' sticks out of the original tree, like a **limb**.  A 'limb' is a subtree of the subject.
+Each fragment of a noun is itself a noun, and hence can be understood as a binary tree as well. Each fragment or 'subtree' sticks out of the original tree, like a **limb**. A 'limb' is a subtree of the subject.
 
-Sometimes a programmer simply wants to produce a value from the subject.  In other cases more is desired -- programmers often want to carry out substantive computations on data in the subject.  There are two kinds of limbs to accommodate these two cases: [arms](/docs/glossary/arm/) and legs.
+Sometimes a programmer simply wants to produce a value from the subject. In other cases more is desired -- programmers often want to carry out substantive computations on data in the subject. There are two kinds of limbs to accommodate these two cases: [arms](/docs/glossary/arm/) and legs.
 
-**Arms** are limbs of the subject that are used for carrying out substantive computations.  We'll talk about arms in the next lesson.  **Legs** are limbs that store data.  Any limb that isn't an arm is a leg.  In this lesson we'll talk about various ways to access legs of the subject.
+**Arms** are limbs of the subject that are used for carrying out substantive computations. We'll talk about arms in the next lesson. **Legs** are limbs that store data. Any limb that isn't an arm is a leg. In this lesson we'll talk about various ways to access legs of the subject.
 
 ### Address-based Limb Expressions
 
-A limb expression is an expression of Hoon that resolves to a limb of the subject.  An address-based limb expression evaluates to a limb of the subject based on its noun address.
+A limb expression is an expression of Hoon that resolves to a limb of the subject. An address-based limb expression evaluates to a limb of the subject based on its noun address.
 
-In the following you'll learn the various limb expressions available in Hoon, as well as how they work when they resolve to legs.  First we'll explain the limb expressions that return a leg according to subject address.
+In the following you'll learn the various limb expressions available in Hoon, as well as how they work when they resolve to legs. First we'll explain the limb expressions that return a leg according to subject address.
 
 #### `+` operator
 
-You've already used this.  For any unsigned integer `n`, `+n` returns the limb of the subject at address `n`.  If there is no such limb, the result is a crash.
+You've already used this. For any unsigned integer `n`, `+n` returns the limb of the subject at address `n`. If there is no such limb, the result is a crash.
 
-```
+```hoon
 > +2:[111 222 333]
 111
 
@@ -100,9 +100,9 @@ You've already used this.  For any unsigned integer `n`, `+n` returns the limb o
 
 #### `.` expression
 
-Using `.` as an expression returns the entire subject.  It's equivalent to `+1`.
+Using `.` as an expression returns the entire subject. It's equivalent to `+1`.
 
-```
+```hoon
 > .:[[4 5] [6 [14 15]]]
 [[4 5] 6 14 15]
 
@@ -117,7 +117,7 @@ Using `.` as an expression returns the entire subject.  It's equivalent to `+1`.
 
 Using `-` by itself returns the head of the subject, and using `+` by itself returns the tail:
 
-```
+```hoon
 > -:[[4 5] [6 [14 15]]]
 [4 5]
 
@@ -125,20 +125,20 @@ Using `-` by itself returns the head of the subject, and using `+` by itself ret
 [6 14 15]
 ```
 
-To think of it another way, `-` is for the left and `+` is for the right.  You can remember this by thinking of a number line -- the negative numbers are to the left, the positive numbers to the right.
+To think of it another way, `-` is for the left and `+` is for the right. You can remember this by thinking of a number line -- the negative numbers are to the left, the positive numbers to the right.
 
-`-` and `+` only work if the subject is a cell, naturally.  An atom doesn't have a head or a tail.
+`-` and `+` only work if the subject is a cell, naturally. An atom doesn't have a head or a tail.
 
-```
+```hoon
 > +:12
 ford: %ride failed to execute:
 ```
 
-What if you want the tail of the tail of the subject?  You might expect that you can double up on `+` for this: `++`.  Not so.  Instead, combine `+` with `>`: `+>`.  `>` means the same thing as `+`, but is used with `+` to make for easier reading.
+What if you want the tail of the tail of the subject? You might expect that you can double up on `+` for this: `++`. Not so. Instead, combine `+` with `>`: `+>`. `>` means the same thing as `+`, but is used with `+` to make for easier reading.
 
-And the analogous point also holds for `-` and `<`.  You can combine `+` or `-` with either of `>` or `<` to get a more specific limb of the subject.  `-<` returns the head of the head; `->` returns the tail of the head; and `+<` returns the head of the tail.
+And the analogous point also holds for `-` and `<`. You can combine `+` or `-` with either of `>` or `<` to get a more specific limb of the subject. `-<` returns the head of the head; `->` returns the tail of the head; and `+<` returns the head of the tail.
 
-```
+```hoon
 > -<:[[4 5] [6 [14 15]]]
 4
 
@@ -154,7 +154,7 @@ And the analogous point also holds for `-` and `<`.  You can combine `+` or `-` 
 
 By alternating the `+`/`-` symbols with `<`/`>` symbols, you can grab an even more specific limb of the subject:
 
-```
+```hoon
 > +>-:[[4 5] [6 [14 15]]]
 14
 
@@ -162,7 +162,7 @@ By alternating the `+`/`-` symbols with `<`/`>` symbols, you can grab an even mo
 15
 ```
 
-You can think of this sort of lark series -- e.g., `+>-<` -- as indicating a binary tree path to a limb of the subject, starting from the root node of the tree.  In the case of `+>-<` this path is: tail, tail, head, head.
+You can think of this sort of lark series -- e.g., `+>-<` -- as indicating a binary tree path to a limb of the subject, starting from the root node of the tree. In the case of `+>-<` this path is: tail, tail, head, head.
 
 ```
         *Root*
@@ -177,7 +177,9 @@ You can think of this sort of lark series -- e.g., `+>-<` -- as indicating a bin
 ```
 
 #### Exercise 1.6a
+
 1. Use a lark expression to obtain the value 6 in the following noun represented by a binary tree:
+
 ```
          .
          /\
@@ -193,31 +195,32 @@ You can think of this sort of lark series -- e.g., `+>-<` -- as indicating a bin
    / \
   6   7
 ```
+
 2. Use a lark expression to obtain the value 9 in the following noun: `[[5 6] 7 [[8 9 10] 3] 2]`.
 
 Solutions to these exercises may be found at the bottom of this lesson.
 
 #### `&` and `|` operators
 
-`&n` returns the `n`th item of a list that has at least `n + 1` items.  `|n` returns everything after `&n`.
+`&n` returns the `n`th item of a list that has at least `n + 1` items. `|n` returns everything after `&n`.
 
-But what's a list?  There are two kinds of lists: empty and non-empty.  The empty list is null, `~`.  A non-empty list is a cell whose head is the first item and whose tail is the rest of the list.  'The rest of the list' is itself a list.  Hoon lists are null-terminated; that is, the null symbol `~` indicates the end of the list.  Consider the following cell of nouns:
+But what's a list? There are two kinds of lists: empty and non-empty. The empty list is null, `~`. A non-empty list is a cell whose head is the first item and whose tail is the rest of the list. 'The rest of the list' is itself a list. Hoon lists are null-terminated; that is, the null symbol `~` indicates the end of the list. Consider the following cell of nouns:
 
-```
+```hoon
 > ['first' 'second' 'third' 'fourth' ~]
 ['first' 'second' 'third' 'fourth' ~]
 ```
 
-The `'first'` noun is at `+2`, `'second'` is at `+6`, `'third'` is at `+14`, and so on.  (Try it!)  That's because the above noun is really the following:
+The `'first'` noun is at `+2`, `'second'` is at `+6`, `'third'` is at `+14`, and so on. (Try it!) That's because the above noun is really the following:
 
-```
+```hoon
 > ['first' ['second' ['third' ['fourth' ~]]]]
 ['first' 'second' 'third' 'fourth' ~]
 ```
 
-...with the superfluous brackets removed.  Rather than using `+2` to produce `'first'` and `+6` to produce `'second'`, you can use `&1` and `&2` to produce the first and second items in the list, respectively:
+...with the superfluous brackets removed. Rather than using `+2` to produce `'first'` and `+6` to produce `'second'`, you can use `&1` and `&2` to produce the first and second items in the list, respectively:
 
-```
+```hoon
 > &1:['first' 'second' 'third' 'fourth' ~]
 'first'
 
@@ -233,7 +236,7 @@ The `'first'` noun is at `+2`, `'second'` is at `+6`, `'third'` is at `+14`, and
 
 The list items can themselves be cells:
 
-```
+```hoon
 > &1:[['first' %pair] ['second' %pair] ['third' %pair] ~]
 ['first' %pair]
 
@@ -244,13 +247,13 @@ The list items can themselves be cells:
 ['third' %pair]
 ```
 
-We can give an alternate, recursive definition of `&n` for all positive integers `n`.  In the base case, `&1` is equivalent to `+2`.  For the generating case, assume that `&(n - 1)` is equivalent to `+k`.  Then `&n` is equivalent to `+((k × 2) + 2)`.
+We can give an alternate, recursive definition of `&n` for all positive integers `n`. In the base case, `&1` is equivalent to `+2`. For the generating case, assume that `&(n - 1)` is equivalent to `+k`. Then `&n` is equivalent to `+((k × 2) + 2)`.
 
-For example, let `n` be 4.  What is `&4`?  `&3` is equivalent to `+14`.  `(14 × 2) + 2` is `30`, so `&4` is equivalent to `+30`.
+For example, let `n` be 4. What is `&4`? `&3` is equivalent to `+14`. `(14 × 2) + 2` is `30`, so `&4` is equivalent to `+30`.
 
 `|n` returns the rest of the list after `&n`:
 
-```
+```hoon
 > |1:['first' 'second' 'third' 'fourth' ~]
 ['second' 'third' 'fourth' ~]
 
@@ -264,23 +267,23 @@ For example, let `n` be 4.  What is `&4`?  `&3` is equivalent to `+14`.  `(14 ×
 ~
 ```
 
-As with `&n`, we can characterize `|n` recursively.  In the base case, `|1` is `+3`.  In the generating case, assume that `|(n - 1)` is equivalent to `+k`.  Then `|n` is equivalent to `+((k × 2) + 1)`.
+As with `&n`, we can characterize `|n` recursively. In the base case, `|1` is `+3`. In the generating case, assume that `|(n - 1)` is equivalent to `+k`. Then `|n` is equivalent to `+((k × 2) + 1)`.
 
 ### Other Limb Expressions: Names
 
-Working with specific addresses of the subject can be cumbersome even when the subject is small.  When the subject is a really large noun -- as is often the case -- it's downright impractical.  Thankfully there's a more convenient method for resolving to a limb of the subject: using names.
+Working with specific addresses of the subject can be cumbersome even when the subject is small. When the subject is a really large noun -- as is often the case -- it's downright impractical. Thankfully there's a more convenient method for resolving to a limb of the subject: using names.
 
-A name can resolve either an arm or a leg of the subject.  Recall that arms are for computations and legs are for data.  When a name resolves to an arm, the relevant computation is run and the product of the computation is produced.  When a limb name resolves to a leg, the value of that leg is produced.  We aren't yet ready to talk about arm resolution; for now let's focus on leg names.
+A name can resolve either an arm or a leg of the subject. Recall that arms are for computations and legs are for data. When a name resolves to an arm, the relevant computation is run and the product of the computation is produced. When a limb name resolves to a leg, the value of that leg is produced. We aren't yet ready to talk about arm resolution; for now let's focus on leg names.
 
 #### Faces
 
-Hoon doesn't have variables like other programming languages do; it has 'faces'.  Faces are like variables in certain respects, but not in others.  Faces play various roles in Hoon, but most frequently faces are used simply as labels for legs.
+Hoon doesn't have variables like other programming languages do; it has 'faces'. Faces are like variables in certain respects, but not in others. Faces play various roles in Hoon, but most frequently faces are used simply as labels for legs.
 
-A face is a limb expression that consists of a series of alphanumeric characters.  A face has a combination of lowercase letters, numbers, and the `-` character.  Some example faces: `b`, `c3`, `var`, `this-is-kebab-case123`.  Faces must begin with a letter.
+A face is a limb expression that consists of a series of alphanumeric characters. A face has a combination of lowercase letters, numbers, and the `-` character. Some example faces: `b`, `c3`, `var`, `this-is-kebab-case123`. Faces must begin with a letter.
 
-There are various ways to affix a face to a limb of the subject, but for now we'll use the simplest method: `face=value`.  An expression of this form is equivalent in value to simply `value`.  Hoon registers the given `face` as metadata about where the value is stored in the subject, so that when that face is invoked later its data is produced.
+There are various ways to affix a face to a limb of the subject, but for now we'll use the simplest method: `face=value`. An expression of this form is equivalent in value to simply `value`. Hoon registers the given `face` as metadata about where the value is stored in the subject, so that when that face is invoked later its data is produced.
 
-```
+```hoon
 > b=5
 b=5
 
@@ -300,11 +303,11 @@ b=5
 [14 15]
 ```
 
-To be clear, `b=5` is equivalent in value to `5`, and `[[4 b2=5] [cat=6 d=[14 15]]]` is equivalent in value to `[[4 5] 6 14 15]`.  The faces are not part of the underlying noun; they're stored as metadata about address values in the subject.
+To be clear, `b=5` is equivalent in value to `5`, and `[[4 b2=5] [cat=6 d=[14 15]]]` is equivalent in value to `[[4 5] 6 14 15]`. The faces are not part of the underlying noun; they're stored as metadata about address values in the subject.
 
 If you use a face that isn't in the subject you'll get a `find.[face]` crash:
 
-```
+```hoon
 > a:[b=12 c=14]
 -find.a
 [crash message]
@@ -312,16 +315,16 @@ If you use a face that isn't in the subject you'll get a `find.[face]` crash:
 
 You can give your faces faces:
 
-```
+```hoon
 > b:[b=c=123 d=456]
 c=123
 ```
 
 #### Duplicate Faces
 
-There is no restriction against using the same face name for multiple limbs of the subject.  This is one way in which faces aren't like ordinary variables:
+There is no restriction against using the same face name for multiple limbs of the subject. This is one way in which faces aren't like ordinary variables:
 
-```
+```hoon
 > [[4 b=5] [b=6 b=[14 15]]]
 [[4 b=5] b=6 b=[14 15]]
 
@@ -329,54 +332,53 @@ There is no restriction against using the same face name for multiple limbs of t
 5
 ```
 
-Why does this return `5` rather than `6` or `[14 15]`?  When a face is evaluated on a subject, a head-first binary tree search occurs starting at address `1` of the subject.  If there is no matching face for address `n` of the subject, first the head of `n` is searched and then `n`'s tail.  The complete search path for `[[4 b=5] [b=6 b=[14 15]]]` is:
+Why does this return `5` rather than `6` or `[14 15]`? When a face is evaluated on a subject, a head-first binary tree search occurs starting at address `1` of the subject. If there is no matching face for address `n` of the subject, first the head of `n` is searched and then `n`'s tail. The complete search path for `[[4 b=5] [b=6 b=[14 15]]]` is:
 
-
-+ `[[4 b=5] [b=6 b=[14 15]]]`
-+ `[4 b=5]`
-+ `4`
-+ `b=5`
-+ `[b=6 b=[14 15]]`
-+ `b=6`
-+ `b=[14 15]`
+- `[[4 b=5] [b=6 b=[14 15]]]`
+- `[4 b=5]`
+- `4`
+- `b=5`
+- `[b=6 b=[14 15]]`
+- `b=6`
+- `b=[14 15]`
 
 There are matches at steps 4, 6, and 7 of the total search path, but the search ends when the first match is found at step 4.
 
-The children of legs bearing names aren't included in the search path.  For example, the search path of `[[4 a=5] b=[c=14 15]]` is:
+The children of legs bearing names aren't included in the search path. For example, the search path of `[[4 a=5] b=[c=14 15]]` is:
 
-+ `[[4 a=5] b=[c=14 15]]`
-+ `[4 a=5]`
-+ `4`
-+ `a=5`
-+ `b=[c=14 15]`
+- `[[4 a=5] b=[c=14 15]]`
+- `[4 a=5]`
+- `4`
+- `a=5`
+- `b=[c=14 15]`
 
-Neither of the legs `c=14` or `15` is checked.  Accordingly, a search for `c` of `[[4 a=5] b=[c=14 15]]` fails:
+Neither of the legs `c=14` or `15` is checked. Accordingly, a search for `c` of `[[4 a=5] b=[c=14 15]]` fails:
 
-```
+```hoon
 > c:[[4 b=5] [b=6 b=[c=14 15]]]
 -find.c [crash message]
 ```
 
-There are cases when you don't want the limb of the first matching face.  You can 'skip' the first match by prepending `^` to the face.  Upon discovery of the first match at address `n`, the search skips `n` (as well as its children) and continues the search elsewhere:
+There are cases when you don't want the limb of the first matching face. You can 'skip' the first match by prepending `^` to the face. Upon discovery of the first match at address `n`, the search skips `n` (as well as its children) and continues the search elsewhere:
 
-```
+```hoon
 > ^b:[[4 b=5] [b=6 b=[14 15]]]
 6
 ```
 
 Recall that the search path for this noun is:
 
-+ `[[4 b=5] [b=6 b=[14 15]]]`
-+ `[4 b=5]`
-+ `4`
-+ `b=5`
-+ `[b=6 b=[14 15]]`
-+ `b=6`
-+ `b=[14 15]`
+- `[[4 b=5] [b=6 b=[14 15]]]`
+- `[4 b=5]`
+- `4`
+- `b=5`
+- `[b=6 b=[14 15]]`
+- `b=6`
+- `b=[14 15]`
 
-The second match in the search path is step 6, `b=6`, so the value at that leg is produced.  You can stack `^` characters to skip more than one matching face:
+The second match in the search path is step 6, `b=6`, so the value at that leg is produced. You can stack `^` characters to skip more than one matching face:
 
-```
+```hoon
 > a:[[[a=1 a=2] a=3] a=4]
 1
 
@@ -392,7 +394,7 @@ The second match in the search path is step 6, `b=6`, so the value at that leg i
 
 When a face is skipped at some address `n`, neither the head nor the tail of `n` is searched:
 
-```
+```hoon
 > b:[b=[a=1 b=2 c=3] a=11]
 [a=1 b=2 c=3]
 
@@ -400,28 +402,28 @@ When a face is skipped at some address `n`, neither the head nor the tail of `n`
 -find.^b
 ```
 
-The first `b`, `b=[a=1 b=2 c=3]`, is skipped; so the entire head of the subject is skipped.  The tail has no `b`; so `^b` doesn't resolve to a limb when the subject is `[b=[a=1 b=2 c=3] a=11]`.
+The first `b`, `b=[a=1 b=2 c=3]`, is skipped; so the entire head of the subject is skipped. The tail has no `b`; so `^b` doesn't resolve to a limb when the subject is `[b=[a=1 b=2 c=3] a=11]`.
 
-How do you get to that `b=2`?  And how do you get to the `c` in `[[4 a=5] b=[c=14 15]]`?  In each case you should use a wing.
+How do you get to that `b=2`? And how do you get to the `c` in `[[4 a=5] b=[c=14 15]]`? In each case you should use a wing.
 
 ## Wings
 
-A **wing** is a limb resolution path into the subject.  A wing expression indicates the path as a series of limb expressions separated by the `.` character.  E.g.,
+A **wing** is a limb resolution path into the subject. A wing expression indicates the path as a series of limb expressions separated by the `.` character. E.g.,
 
 ```
 limb1.limb2.limb3
 ```
 
-You can read this as `limb1` in `limb2` in `limb3`, etc.  You can use a wing to get the value of `c` in `[[4 a=5] b=[c=14 15]]`: `c.b`
+You can read this as `limb1` in `limb2` in `limb3`, etc. You can use a wing to get the value of `c` in `[[4 a=5] b=[c=14 15]]`: `c.b`
 
-```
+```hoon
 > c.b:[[4 a=5] b=[c=14 15]]
 14
 ```
 
 And to get the `b` inside the head of `[b=[a=1 b=2 c=3] a=11]`: `b.b`.
 
-```
+```hoon
 > b.b:[b=[a=1 b=2 c=3] a=11]
 2
 
@@ -440,7 +442,7 @@ And to get the `b` inside the head of `[b=[a=1 b=2 c=3] a=11]`: `b.b`.
 
 Here are some other wing examples:
 
-```
+```hoon
 > g.s:[s=[c=[d=12 e='hello'] g=[h=0xff i=0b11]] r='howdy']
 [h=0xff i=0b11]
 
@@ -459,33 +461,33 @@ r='howdy'
 
 ### Limbs are Trivial Wings
 
-As stated before, a wing is a limb resolution path into the subject.  This definition includes as a trivial case a path of just one limb.  Thus, all limbs are wings, and all limb expressions are wing expressions.
+As stated before, a wing is a limb resolution path into the subject. This definition includes as a trivial case a path of just one limb. Thus, all limbs are wings, and all limb expressions are wing expressions.
 
-We mention this because it is convenient to refer to all limbs and non-trivial wings as simply 'wings'.  This will be our usual practice for the rest of this series.
+We mention this because it is convenient to refer to all limbs and non-trivial wings as simply 'wings'. This will be our usual practice for the rest of this series.
 
 ## Exploring the Subject
 
-Earlier we said that every Hoon expression is evaluated relative to a subject.  We then showed how the `:` operator uses a Hoon expression on the right-hand side to set the subject for the expression on the left.
+Earlier we said that every Hoon expression is evaluated relative to a subject. We then showed how the `:` operator uses a Hoon expression on the right-hand side to set the subject for the expression on the left.
 
-```
+```hoon
 > b:[b='Hello world!' c='This is the tail of the subject for the LHS']
 'Hello world!'
 ```
 
-The left, `b`, uses the product of the right as its subject.  But what about the right-hand expression?  What's _its_ subject?  Until now we've included an explicit subject in all the examples, but it's time to remove the training wheels.  Usually the subject of a Hoon expression isn't shown explicitly.
+The left, `b`, uses the product of the right as its subject. But what about the right-hand expression? What's _its_ subject? Until now we've included an explicit subject in all the examples, but it's time to remove the training wheels. Usually the subject of a Hoon expression isn't shown explicitly.
 
 Consider the expression `(add 2 2)`:
 
-```
+```hoon
 > (add 2 2)
 4
 ```
 
 What's the subject of this expression?
 
-In fact, you may already know how to find the answer.  The subject is a noun and as such its limbs have addresses.  To see that noun, use `+1`.  You'll see something like the following:
+In fact, you may already know how to find the answer. The subject is a noun and as such its limbs have addresses. To see that noun, use `+1`. You'll see something like the following:
 
-```
+```hoon
 > +1
 [ [ our=~zod
     now=~2018.12.10..22.10.44..09d7
@@ -500,9 +502,9 @@ In fact, you may already know how to find the answer.  The subject is a noun and
 
 This noun (or a modified version of it) is the subject used for Hoon expressions entered into the dojo.
 
-We can't explain every part of the subject just yet, but you should be able to recognize some of it.  There is a face, `our`, serving as a label for the urbit's name.  Another face, `now`, is a label for an absolute date.  `eny` is a face for an atom serving as [entropy](https://en.wikipedia.org/wiki/Entropy_%28computing%29).  The value for `eny` is different every time it's checked.
+We can't explain every part of the subject just yet, but you should be able to recognize some of it. There is a face, `our`, serving as a label for the urbit's name. Another face, `now`, is a label for an absolute date. `eny` is a face for an atom serving as [entropy](https://en.wikipedia.org/wiki/Entropy_%28computing%29). The value for `eny` is different every time it's checked.
 
-```
+```hoon
 > our
 ~zod
 
@@ -520,16 +522,16 @@ We can't explain every part of the subject just yet, but you should be able to r
 \/                                                                           \/
 ```
 
-Also embedded in that subject is the Hoon 'standard library', a library of commonly-used functions.  We've already used two of them: `add` and `mul`.  Have you noticed that these function names look like faces?  They aren't actually faces, but Hoon searches for them like it searches for faces.  When we call `add`,
+Also embedded in that subject is the Hoon 'standard library', a library of commonly-used functions. We've already used two of them: `add` and `mul`. Have you noticed that these function names look like faces? They aren't actually faces, but Hoon searches for them like it searches for faces. When we call `add`,
 
-```
+```hoon
 > (add 22 33)
 55
 ```
 
-...it only works because Hoon finds `add` somewhere in the subject.  We can make a subject that doesn't have `add` in it and try to use it:
+...it only works because Hoon finds `add` somewhere in the subject. We can make a subject that doesn't have `add` in it and try to use it:
 
-```
+```hoon
 > (add 22 33):[123 456]
 -find.add
 
@@ -537,9 +539,9 @@ Also embedded in that subject is the Hoon 'standard library', a library of commo
 -find.add
 ```
 
-It doesn't work because, as far as Hoon is concerned, `add` doesn't exist for the expression on the left.  We can put `add` back into the subject manually, however:
+It doesn't work because, as far as Hoon is concerned, `add` doesn't exist for the expression on the left. We can put `add` back into the subject manually, however:
 
-```
+```hoon
 > (add 22 33):[123 456 add]
 55
 ```
@@ -550,19 +552,19 @@ The subject of the right-hand side expression of the `:` is the same implicit su
 
 ## Dojo Faces
 
-We're playing in the Urbit `dojo`.  The dojo is like a cross between a Lisp REPL and the Unix shell.  (If you know the Unix shell, the Urbit command line has the same history model and Emacs editing commands.)
+We're playing in the Urbit `dojo`. The dojo is like a cross between a Lisp REPL and the Unix shell. (If you know the Unix shell, the Urbit command line has the same history model and Emacs editing commands.)
 
 It's worth taking a moment to learn about certain features of the dojo that aren't part of Hoon, but which can be handy to experiment with when learning Hoon.
 
-You can use the dojo to add a noun with a face to the subject.  Type:
+You can use the dojo to add a noun with a face to the subject. Type:
 
-```
+```hoon
 > =a 37
 ```
 
-You've added `37` to the dojo subject with the face `a`.  Hoon expressions entered into the dojo can now use `a` and it will resolve to this value. So you can write:
+You've added `37` to the dojo subject with the face `a`. Hoon expressions entered into the dojo can now use `a` and it will resolve to this value. So you can write:
 
-```
+```hoon
 > a
 37
 
@@ -578,13 +580,13 @@ You've added `37` to the dojo subject with the face `a`.  Hoon expressions enter
 
 To unbind `a` and remove its value from the subject, enter `=a` and omit the value:
 
-```
+```hoon
 > =a
 ```
 
-You removed `a` from the subject.  (We can bind it again later, or bind over it without removing it.)
+You removed `a` from the subject. (We can bind it again later, or bind over it without removing it.)
 
-```
+```hoon
 > [4 a]
 -find.a
 ```
@@ -593,7 +595,7 @@ You removed `a` from the subject.  (We can bind it again later, or bind over it 
 
 We can use dojo faces to get used to how wings work.
 
-```
+```hoon
 > =a [g=37 b=[%hi c=.6.28] h=0xdead.beef]
 
 > a
@@ -617,7 +619,7 @@ g=37
 
 Here are a few more examples:
 
-```
+```hoon
 > c:[c=[d=15 e=20] f=[g=45 h=50]]
 [d=15 e=20]
 
@@ -636,17 +638,17 @@ e=20
 
 ## Creating a Modified Leg
 
-Often a leg of the subject is produced with its value unchanged.  But there is a way to produce a modified version of the leg as well.  To do so, we use an expression of the form:
+Often a leg of the subject is produced with its value unchanged. But there is a way to produce a modified version of the leg as well. To do so, we use an expression of the form:
 
 ```
 wing-of-subject(wing-1 new-value-1, wing-2 new-value 2, ...)
 ```
 
-The `wing-of-subject` resolves to some limb in the subject.  This is followed by a set of parentheses.  `wing-1` and `wing-2` pick out which parts of that limb we want to change.  Their values are replaced with `new-value-1` and `new-value-2`, respectively.  Commas separate each of the `wing` `new-value` pairs.
+The `wing-of-subject` resolves to some limb in the subject. This is followed by a set of parentheses. `wing-1` and `wing-2` pick out which parts of that limb we want to change. Their values are replaced with `new-value-1` and `new-value-2`, respectively. Commas separate each of the `wing` `new-value` pairs.
 
-Let's create a mutant version of the noun we have stored in `a`.  To do this, type in the face `a` followed by the desired modifications in parentheses:
+Let's create a mutant version of the noun we have stored in `a`. To do this, type in the face `a` followed by the desired modifications in parentheses:
 
-```
+```hoon
 > a
 [g=37 b=[%hi c=.6.28] h=0xdead.beef]
 
@@ -668,18 +670,21 @@ Let's create a mutant version of the noun we have stored in `a`.  To do this, ty
 
 You can also use more complex wings and modify their values as well:
 
-```
+```hoon
 > b.a(c .3.14)
 [%hi c=.3.14]
 ```
 
-At this point you should have at least a rough idea of what the subject is, and a fair understanding of how to get legs of the subject using wings.  But legs are only one kind of limb -- we'll talk about arms in the next lesson.
+At this point you should have at least a rough idea of what the subject is, and a fair understanding of how to get legs of the subject using wings. But legs are only one kind of limb -- we'll talk about arms in the next lesson.
 
 #### Exercise 1.6b
+
 Enter the following into dojo:
-```
+
+```hoon
 =a [[[b=%bweh a=%.y c=8] b="no" c="false"] 9]
 ```
+
 Test your knowledge from this lesson by evaluating the following expressions and then checking your answer in the dojo or see the solutions below.
 
 1. `> b:a(a [b=%skrt a="four"])`
@@ -696,20 +701,25 @@ Test your knowledge from this lesson by evaluating the following expressions and
 ## Exercise Solutions
 
 ### Exercise 1.6a
+
 1.
-```
+
+```hoon
 > =b [[[5 6 7] 8 9] 10 11 12 13]
 > -<+<:b
 6
 ```
+
 2.
-```
+
+```hoon
 > =c [[5 6] 7 [[8 9 10] 3] 2]
 > +>-<+<:c
 9
 ```
 
 ### Exercise 1.6b
+
 1. `%bweh`
 2. `"no"`
 3. Error: `ford: %slim failed:`
@@ -720,7 +730,8 @@ Test your knowledge from this lesson by evaluating the following expressions and
 8. `[[[b=%bweh a=[[[b=%bweh a=%.y c=8] b="no" c="false"] 9] c=8] b="no" c="false"]9]`
 9. `%bweh`
 10. `9` appears 3 times:
-```
+
+```hoon
 > a(a a(a a))
 [[[ b=%bweh a [[[b=%bweh a=[[[b=%bweh a=%.y c=8] b="no" c="false"] 9] c=8] b="no" c="false"] 9] c=8] b="no" c="false"] 9]
 ```

--- a/hoon/hoon-school/trees-sets-and-maps.md
+++ b/hoon/hoon-school/trees-sets-and-maps.md
@@ -5,7 +5,7 @@ template = "doc.html"
 aliases = ["/docs/learn/hoon/hoon-tutorial/trees-sets-and-maps/"]
 +++
 
-Along with lists, the Hoon standard library also supports trees, sets, and maps as data structures.  A Hoon `tree` is the data structure for a binary tree.  A Hoon `set` is the data structure for a set of values.  A Hoon `map` is the data structure for a set of `[key value]` pairs.
+Along with lists, the Hoon standard library also supports trees, sets, and maps as data structures. A Hoon `tree` is the data structure for a binary tree. A Hoon `set` is the data structure for a set of values. A Hoon `map` is the data structure for a set of `[key value]` pairs.
 
 In this lesson we'll cover each.
 
@@ -13,7 +13,7 @@ In this lesson we'll cover each.
 
 We use `tree` to make a binary tree data structure in Hoon, e.g., `(tree @)` for a binary tree of [atoms](/docs/glossary/atom/).
 
-There are two kinds of `tree` in Hoon: (1) the null tree, `~`, and (2) a non-null tree which is a cell with three parts.  Part (i) is the node value, part (ii) is the left child of the node, and part (iii) is the right child of the node.  Each child is itself a tree.  The node value has the face `n`, the left child has the face `l`, and the right child has the face `r`.  The following diagram provides an illustration of a `(tree @)` (without the faces):
+There are two kinds of `tree` in Hoon: (1) the null tree, `~`, and (2) a non-null tree which is a cell with three parts. Part (i) is the node value, part (ii) is the left child of the node, and part (iii) is the right child of the node. Each child is itself a tree. The node value has the face `n`, the left child has the face `l`, and the right child has the face `r`. The following diagram provides an illustration of a `(tree @)` (without the faces):
 
 ```
           12
@@ -25,16 +25,16 @@ There are two kinds of `tree` in Hoon: (1) the null tree, `~`, and (2) a non-nul
 ~    ~          ~    ~
 ```
 
-Hoon supports trees of any type that can be constructed in Hoon, e.g.: `(tree @)`, `(tree ^)`, `(tree [@ ?])`, etc.  Let's construct the tree in the diagram above in the dojo, casting it accordingly:
+Hoon supports trees of any type that can be constructed in Hoon, e.g.: `(tree @)`, `(tree ^)`, `(tree [@ ?])`, etc. Let's construct the tree in the diagram above in the dojo, casting it accordingly:
 
-```
+```hoon
 > `(tree @)`[12 [8 [4 ~ ~] ~] [14 ~ [16 ~ ~]]]
 {4 8 12 14 16}
 ```
 
-Notice that we don't have to insert the faces manually; by casting the [noun](/docs/glossary/noun/) above to a `(tree @)` Hoon inserts the faces for us.  Let's put this noun in the dojo subject with the face `b` and pull out the tree at the left child of the `12` node:
+Notice that we don't have to insert the faces manually; by casting the [noun](/docs/glossary/noun/) above to a `(tree @)` Hoon inserts the faces for us. Let's put this noun in the dojo subject with the face `b` and pull out the tree at the left child of the `12` node:
 
-```
+```hoon
 > =b `(tree @)`[12 [8 [4 ~ ~] ~] [14 ~ [16 ~ ~]]]
 
 > b
@@ -45,9 +45,9 @@ Notice that we don't have to insert the faces manually; by casting the [noun](/d
 find-fork-d
 ```
 
-This didn't work because we haven't first proved to Hoon that `b` is a non-null tree.  A null tree has no `l` in it, after all.  Let's try again, using `?~` to prove that `b` isn't null.  We can also look at `r` and `n`:
+This didn't work because we haven't first proved to Hoon that `b` is a non-null tree. A null tree has no `l` in it, after all. Let's try again, using `?~` to prove that `b` isn't null. We can also look at `r` and `n`:
 
-```
+```hoon
 > ?~(b ~ l.b)
 {4 8}
 
@@ -73,9 +73,9 @@ Here's a program that finds and replaces certain atoms in a `(tree @)`.
 $(hay r.hay)
 ```
 
-`nedl` is the atom to be replaced, `hay` is the tree, and `new` is the new atom with which to replace `nedl`.  Save this as `findreplacetree.hoon` and run in the dojo:
+`nedl` is the atom to be replaced, `hay` is the tree, and `new` is the new atom with which to replace `nedl`. Save this as `findreplacetree.hoon` and run in the dojo:
 
-```
+```hoon
 > b
 {4 8 12 14 16}
 
@@ -88,15 +88,15 @@ $(hay r.hay)
 
 ## Sets
 
-Use `set` to create a data structure for a set of values, e.g., `(set @)` for a set of atoms.  The `in` [core](/docs/glossary/core/) in the Hoon standard library contains the various functions for operating on sets.  See the standard library reference documentation for sets [here](@/docs/hoon/reference/stdlib/2h.md).
+Use `set` to create a data structure for a set of values, e.g., `(set @)` for a set of atoms. The `in` [core](/docs/glossary/core/) in the Hoon standard library contains the various functions for operating on sets. See the standard library reference documentation for sets [here](@/docs/hoon/reference/stdlib/2h.md).
 
-As with `list`s and `tree`s, there are two categories of sets: null `~`, and non-null.  Hoon implements sets using trees for the underlying noun.
+As with `list`s and `tree`s, there are two categories of sets: null `~`, and non-null. Hoon implements sets using trees for the underlying noun.
 
 Two common methods for populating a set include (1) creating it from a list of values using the `sy` function, and (2) inserting items into a set using the `put` [arm](/docs/glossary/arm/) of the `in` core.
 
 Using `sy`:
 
-```
+```hoon
 > =c (sy ~[11 22 33 44 55])
 
 > c
@@ -107,11 +107,12 @@ Using `sy`:
 
 > =c `(set @)`c
 ```
+
 Note that the dojo does not necessarily print elements of a set in the same order they were given. Mathematically speaking, sets are not ordered, so this is alright. There is no difference between two sets with the same elements written in a different order. Try forming `c` with a different ordering and check this.
 
 And we can add an item to the set using `put` of `in`:
 
-```
+```hoon
 > (~(put in c) 77)
 [n=11 l={} r={22 77 55 33 44}]
 
@@ -121,16 +122,17 @@ And we can add an item to the set using `put` of `in`:
 
 You can remove items using `del` of `in`:
 
-```
+```hoon
 > (~(del in c) 55)
 [n=11 l={} r={22 33 44}]
 
 > `(set @)`(~(del in c) 55)
 {11 22 33 44}
 ```
+
 Check whether an item is in the set using `has` of `in`:
 
-```
+```hoon
 > (~(has in c) 33)
 %.y
 
@@ -140,16 +142,17 @@ Check whether an item is in the set using `has` of `in`:
 
 You can apply a [gate](/docs/glossary/gate/) to each item of a set using `run` of `in` and produce a new set from the products:
 
-```
+```hoon
 > c
 {11 22 55 33 44}
 
 > (~(run in c) |=(a=@ +(a)))
 {56 45 23 12 34}
 ```
+
 You can also apply a gate to all items of the set and return an accumulated value using `rep` of `in`:
 
-```
+```hoon
 > c
 {11 22 55 33 44}
 
@@ -159,7 +162,7 @@ b=165
 
 The standard library also has the union and intersection functions for sets:
 
-```
+```hoon
 > c
 {11 22 55 33 44}
 
@@ -181,9 +184,9 @@ The standard library also has the union and intersection functions for sets:
 {66 11 22 77 55 33 44}
 ```
 
-It may be convenient to turn a set into a list for some operation and then operate on the list.  You can convert a set to a list using `tap` of `in`:
+It may be convenient to turn a set into a list for some operation and then operate on the list. You can convert a set to a list using `tap` of `in`:
 
-```
+```hoon
 > c
 {11 22 33 44 55}
 
@@ -195,7 +198,7 @@ There are other set functions in the Hoon standard library we won't cover here.
 
 ### Cartesian Product
 
-Here's a program that takes two sets of atoms and returns the [Cartesian product](https://en.wikipedia.org/wiki/Cartesian_product) of those sets.  A Cartesian product of two sets `a` and `b` is a set of all the cells whose head is a member of `a` and whose tail is a member of `b`.
+Here's a program that takes two sets of atoms and returns the [Cartesian product](https://en.wikipedia.org/wiki/Cartesian_product) of those sets. A Cartesian product of two sets `a` and `b` is a set of all the cells whose head is a member of `a` and whose tail is a member of `b`.
 
 ```hoon
 |=  [a=(set @) b=(set @)]
@@ -216,7 +219,7 @@ Here's a program that takes two sets of atoms and returns the [Cartesian product
 
 Save this as `cartesian.hoon` in your urbit's pier and run in the dojo:
 
-```
+```hoon
 > =c `(set @)`(sy ~[1 2 3])
 
 > c
@@ -233,17 +236,17 @@ Save this as `cartesian.hoon` in your urbit's pier and run in the dojo:
 
 ## Maps
 
-Use `map` to create a set of key-value pairs, e.g., `(map @tas *)` for a set of `@tas` and `*` pairs.  The `@tas` value serves as the 'key', which is a mechanism for tagging or naming the value, `*`.  The key of each key-value pair is unique; every value in a map gets its own unique name.
+Use `map` to create a set of key-value pairs, e.g., `(map @tas *)` for a set of `@tas` and `*` pairs. The `@tas` value serves as the 'key', which is a mechanism for tagging or naming the value, `*`. The key of each key-value pair is unique; every value in a map gets its own unique name.
 
 One example use case is for storing customer information as a set of pairs: `(map [employee-name employee-data])`.
 
-The `by` core in the Hoon standard library contains the various functions for operating on maps.  Many of these functions are similar to the set functions of the `in` core.  See the standard library reference documentation for maps [here](@/docs/hoon/reference/stdlib/2i.md).  As was the case with sets, the underlying noun of each map is a tree.
+The `by` core in the Hoon standard library contains the various functions for operating on maps. Many of these functions are similar to the set functions of the `in` core. See the standard library reference documentation for maps [here](@/docs/hoon/reference/stdlib/2i.md). As was the case with sets, the underlying noun of each map is a tree.
 
 Two common methods for populating a map include (1) creating it from a list of key-value cells using the `my` function, and (2) inserting items into a map using the `put` arm of the `by` core.
 
 Using `my`:
 
-```
+```hoon
 > =c (my ~[[%one 1] [%two 2] [%three 3]])
 
 > c
@@ -257,7 +260,7 @@ Using `my`:
 
 We can add a key-value pair with `put` of `by`:
 
-```
+```hoon
 > (~(put by c) [%four 4])
 [n=[p=%one q=1] l={[p=%four q=4] [p=%two q=2]} r={[p=%three q=3]}]
 
@@ -267,32 +270,32 @@ We can add a key-value pair with `put` of `by`:
 
 Delete a key-value pair with `del` of `by`, keeping in mind that you only need to pick the key of the pair to be deleted:
 
-```
+```hoon
 > `(map @tas @)`(~(del by c) %two)
 {[p=%one q=1] [p=%three q=3]}
 ```
 
 You can produce the value of a key-value pair using `get` of `by` on the key:
 
-```
+```hoon
 > (~(get by c) %two)
 [~ 2]
 ```
 
-This result may be unexpected.  Why didn't it just give us `2`?  The answer has to do with the possibility that a requested key may not be in the map.  For example:
+This result may be unexpected. Why didn't it just give us `2`? The answer has to do with the possibility that a requested key may not be in the map. For example:
 
-```
+```hoon
 > (~(get by c) %chicken)
 ~
 ```
 
-Because there is no `%chicken` key in `c`, `get` simply returns `~` to indicate it's not in the map.  Otherwise it returns a pair like the one you see in the next to last example.
+Because there is no `%chicken` key in `c`, `get` simply returns `~` to indicate it's not in the map. Otherwise it returns a pair like the one you see in the next to last example.
 
-`get` of `by` returns the key's value as a `unit`, not as raw data.  There are two kinds of `unit`s: null `~`, and non-null.  A non-null `unit` is a pair of `[~ value]`.  Unit types are constructed the way list, set, and map types are; for example, `(unit @)` is the type for a unit whose value is an atom.
+`get` of `by` returns the key's value as a `unit`, not as raw data. There are two kinds of `unit`s: null `~`, and non-null. A non-null `unit` is a pair of `[~ value]`. Unit types are constructed the way list, set, and map types are; for example, `(unit @)` is the type for a unit whose value is an atom.
 
 If you want to get some key value without producing a unit, use `got` instead:
 
-```
+```hoon
 > (~(got by c) %two)
 2
 
@@ -303,7 +306,7 @@ ford: %ride failed to execute:
 
 Use `has` of `by` to see whether a certain key is in the map:
 
-```
+```hoon
 > (~(has by c) %two)
 %.y
 
@@ -313,7 +316,7 @@ Use `has` of `by` to see whether a certain key is in the map:
 
 You can use `run` of `by` to apply a gate to each value in a map, producing a map with the modified values:
 
-```
+```hoon
 > (~(run by c) |=(a=@ (mul 2 a)))
 {[p=%two q=4] [p=%one q=2] [p=%three q=6]}
 ```

--- a/hoon/hoon-school/type-checking-and-type-inference.md
+++ b/hoon/hoon-school/type-checking-and-type-inference.md
@@ -5,7 +5,7 @@ template = "doc.html"
 aliases = ["/docs/learn/hoon/hoon-tutorial/type-checking-and-type-inference/"]
 +++
 
-As the Hoon compiler compiles your Hoon code, it does a **type check** on certain expressions to make sure they are guaranteed to produce a value of the correct type.  If it cannot be proved that the output value is correctly typed, the compile will fail with a `nest-fail` crash.  In order to figure out what type of value is produced by a given expression, the compiler uses **type inference** on that code.  In this lesson we'll cover various cases in which a type check is performed, and also how the compiler does type inference on an expression.
+As the Hoon compiler compiles your Hoon code, it does a **type check** on certain expressions to make sure they are guaranteed to produce a value of the correct type. If it cannot be proved that the output value is correctly typed, the compile will fail with a `nest-fail` crash. In order to figure out what type of value is produced by a given expression, the compiler uses **type inference** on that code. In this lesson we'll cover various cases in which a type check is performed, and also how the compiler does type inference on an expression.
 
 ## Type Checking
 
@@ -13,13 +13,13 @@ Let's enumerate the most common cases where a type check is called for in Hoon.
 
 ### Cast Runes
 
-The most obvious case is when there is a cast rune in your code.  These runes don't directly have any effect on the compiled result of your code; they simply indicate that a type check should be performed on a piece of code at compile-time.
+The most obvious case is when there is a cast rune in your code. These runes don't directly have any effect on the compiled result of your code; they simply indicate that a type check should be performed on a piece of code at compile-time.
 
 #### `^-` Cast with a Type
 
 You've already seen one rune that calls for a type check: `^-`:
 
-```
+```hoon
 > ^-(@ 12)
 12
 
@@ -47,9 +47,9 @@ nest-fail
 
 #### `^+` Cast with an Example Value
 
-The rune `^+` is like `^-`, except that instead of using a type name for the cast, it uses an example value of the type in question.  E.g.:
+The rune `^+` is like `^-`, except that instead of using a type name for the cast, it uses an example value of the type in question. E.g.:
 
-```
+```hoon
 > ^+(7 12)
 12
 
@@ -60,13 +60,13 @@ The rune `^+` is like `^-`, except that instead of using a type name for the cas
 nest-fail
 ```
 
-The `^+` rune takes two subexpressions.  The first subexpression is evaluated and its type is inferred.  The second subexpression is evaluated and its inferred type is compared against the type of the first.  If the type of the second provably nests under the type of the first, the result of the `^+` expression is just the value of its second subexpression.  Otherwise, the code fails to compile.
+The `^+` rune takes two subexpressions. The first subexpression is evaluated and its type is inferred. The second subexpression is evaluated and its inferred type is compared against the type of the first. If the type of the second provably nests under the type of the first, the result of the `^+` expression is just the value of its second subexpression. Otherwise, the code fails to compile.
 
-This rune is useful for casting when you already have a [noun](/docs/glossary/noun/) -- or expression producing a [noun](/docs/glossary/noun/) -- whose type you may not know or be able to construct easily.  If you want your output value to be of the same type, you can use `^+`.
+This rune is useful for casting when you already have a [noun](/docs/glossary/noun/) -- or expression producing a [noun](/docs/glossary/noun/) -- whose type you may not know or be able to construct easily. If you want your output value to be of the same type, you can use `^+`.
 
 More examples:
 
-```
+```hoon
 > ^+([12 13] [123 456])
 [123 456]
 
@@ -79,9 +79,9 @@ nest-fail
 
 ### The `.=` and `.+` Runes
 
-You saw earlier in Chapter 1 how a type check is performed when `.=` -- or its irregular variant, `=( )` -- is used.  For any expression of the form `=(a b)`, either the type of `a` must be a subset of the type of `b` or the type of `b` must be a subset of the type of `a`.  Otherwise, the type check fails and you'll get a `nest-fail`.
+You saw earlier in Chapter 1 how a type check is performed when `.=` -- or its irregular variant, `=( )` -- is used. For any expression of the form `=(a b)`, either the type of `a` must be a subset of the type of `b` or the type of `b` must be a subset of the type of `a`. Otherwise, the type check fails and you'll get a `nest-fail`.
 
-```
+```hoon
 > =(12 [33 44])
 nest-fail
 
@@ -91,7 +91,7 @@ nest-fail
 
 You can evade the `.=` type-check by casting one of its subexpressions to a `*`, under which all other types nest:
 
-```
+```hoon
 > .=(`*`12 [33 44])
 %.n
 ```
@@ -100,7 +100,7 @@ It isn't recommended that you evade the rules in this way, however.
 
 The `.+` increment rune -- including its `+( )` irregular form -- does a type check to ensure that its subexpression must evaluate to an [atom](/docs/glossary/atom/).
 
-```
+```hoon
 > +(12)
 13
 
@@ -110,11 +110,11 @@ nest-fail
 
 ### Arm Evaluation
 
-Whenever an [arm](/docs/glossary/arm/) is evaluated in Hoon it expects to have some version of its parent [core](/docs/glossary/core/) as the subject.  Specifically, a type check is performed to see whether the [arm](/docs/glossary/arm/) subject is of the appropriate **type**.  We see this in action whenever a [gate](/docs/glossary/gate/) or a multi-arm [door](/docs/glossary/door/) is called.
+Whenever an [arm](/docs/glossary/arm/) is evaluated in Hoon it expects to have some version of its parent [core](/docs/glossary/core/) as the subject. Specifically, a type check is performed to see whether the [arm](/docs/glossary/arm/) subject is of the appropriate **type**. We see this in action whenever a [gate](/docs/glossary/gate/) or a multi-arm [door](/docs/glossary/door/) is called.
 
-A gate is a one-armed core with a sample.  When it is called, its `$` arm is evaluated with (a version of) the gate as the subject.  The only part of the core that might change is the [payload](/docs/glossary/payload/), including the sample.  Of course, we want the sample to be able to change.  The sample is where the argument(s) of the function call are placed.  For example, when we call `add` the `$` arm expects two atoms for the sample, i.e., the two numbers to be added.  When the type check occurs, the [payload](/docs/glossary/payload/) must be of the appropriate type.  If it isn't, the result is a `nest-fail` crash.
+A gate is a one-armed core with a sample. When it is called, its `$` arm is evaluated with (a version of) the gate as the subject. The only part of the core that might change is the [payload](/docs/glossary/payload/), including the sample. Of course, we want the sample to be able to change. The sample is where the argument(s) of the function call are placed. For example, when we call `add` the `$` arm expects two atoms for the sample, i.e., the two numbers to be added. When the type check occurs, the [payload](/docs/glossary/payload/) must be of the appropriate type. If it isn't, the result is a `nest-fail` crash.
 
-```
+```hoon
 > (add 22 33)
 55
 
@@ -133,15 +133,15 @@ nest-fail
 
 We'll talk in more detail about the various kinds of type-checking that can occur at arm evaluation when we discuss type polymorphism later in Chapter 2.
 
-This isn't a comprehensive list of the type checks in Hoon.  It's only some of the most commonly used kinds.  Two other runes that include a type check are `=.` and `%_`.
+This isn't a comprehensive list of the type checks in Hoon. It's only some of the most commonly used kinds. Two other runes that include a type check are `=.` and `%_`.
 
 ## Intro to Hoon Type Inference
 
-It's helpful to know **that** Hoon infers the type of any given expression, but it's important to know **how** such inference works.  Hoon uses various tools for inferring the type of any given expression: literal syntax, cast expressions, gate sample definitions, conditional expressions, and more.
+It's helpful to know **that** Hoon infers the type of any given expression, but it's important to know **how** such inference works. Hoon uses various tools for inferring the type of any given expression: literal syntax, cast expressions, gate sample definitions, conditional expressions, and more.
 
 ### Literals
 
-[Literals](https://en.wikipedia.org/wiki/Literal_%28computer_programming%29) are expressions that represent fixed values.  Some examples (with the inferred type on the right):
+[Literals](https://en.wikipedia.org/wiki/Literal_%28computer_programming%29) are expressions that represent fixed values. Some examples (with the inferred type on the right):
 
 ```
 123                   @ud
@@ -151,13 +151,13 @@ It's helpful to know **that** Hoon infers the type of any given expression, but 
 [0x1f 'hello' %.y]    [@ux @t ?]
 ```
 
-As you can see there are both atom and cell literals in Hoon.  Hoon infers the type of literals -- including atom auras -- directly from such expressions.
+As you can see there are both atom and cell literals in Hoon. Hoon infers the type of literals -- including atom auras -- directly from such expressions.
 
 ### Casts
 
-Cast runes also shape how Hoon understands an expression type.  The inferred type of a cast expression is just the type being cast for.  It can be inferred that, if the cast didn't result in a `nest-fail`, the value produced must be of the cast type.  Here are some examples of cast expressions with the inferred output type on the right:
+Cast runes also shape how Hoon understands an expression type. The inferred type of a cast expression is just the type being cast for. It can be inferred that, if the cast didn't result in a `nest-fail`, the value produced must be of the cast type. Here are some examples of cast expressions with the inferred output type on the right:
 
-```
+```hoon
 ^-(@ud 123)                       @ud
 ^-(@ 123)                         @
 ^-(^ [12 14])                     ^
@@ -171,15 +171,15 @@ Cast runes also shape how Hoon understands an expression type.  The inferred typ
 
 You can also use the irregular `` ` `` syntax for casting in the same way as `^-`; e.g., `` `@`123 `` for `^-(@ 123)`.
 
-One thing to note about casts is that they can 'throw away' type information.  The second subexpression of `^-` and `^+` casts may be inferred to have a very specific type.  If the cast type is more general, then the more specific type information is lost.  Consider the literal `[12 14]`.  The inferred type of this expression is `[@ @]`, i.e., a cell of two atoms.  If we cast over `[12 14]` with `^-(^ [12 14])` then the inferred type is just `^`, the set of all cells.  The information about what kind of cell it is has been thrown away.  If we cast over `[12 14]` with `^-(* [12 14])` then the inferred type is `*`, the set of all nouns.  All interesting type information is thrown away on the latter cast.
+One thing to note about casts is that they can 'throw away' type information. The second subexpression of `^-` and `^+` casts may be inferred to have a very specific type. If the cast type is more general, then the more specific type information is lost. Consider the literal `[12 14]`. The inferred type of this expression is `[@ @]`, i.e., a cell of two atoms. If we cast over `[12 14]` with `^-(^ [12 14])` then the inferred type is just `^`, the set of all cells. The information about what kind of cell it is has been thrown away. If we cast over `[12 14]` with `^-(* [12 14])` then the inferred type is `*`, the set of all nouns. All interesting type information is thrown away on the latter cast.
 
-It's important to remember to include a cast rune with each gate expression.  That way it's clear what the inferred product type will be for calls to that gate.
+It's important to remember to include a cast rune with each gate expression. That way it's clear what the inferred product type will be for calls to that gate.
 
 ### (Dry) Gate Sample Definitions
 
-By now you've used the `|=` rune to define several gates.  This rune is used to produce a 'dry' gate, which has different type-checking and type-inference properties than a 'wet' gate does.  We won't explain the wet/dry distinction until later in Chapter 2 -- for now, just keep in mind that we're only dealing with one kind of gate (albeit the more common kind).
+By now you've used the `|=` rune to define several gates. This rune is used to produce a 'dry' gate, which has different type-checking and type-inference properties than a 'wet' gate does. We won't explain the wet/dry distinction until later in Chapter 2 -- for now, just keep in mind that we're only dealing with one kind of gate (albeit the more common kind).
 
-The first subexpression after the `|=` defines the sample type.  Any faces used in this definition have the type declared for it in this definition.  Consider again the addition function:
+The first subexpression after the `|=` defines the sample type. Any faces used in this definition have the type declared for it in this definition. Consider again the addition function:
 
 ```hoon
 |=  [a=@ b=@]                                           ::  take two @
@@ -191,7 +191,7 @@ $(a +(a), b (dec b))                                    ::  add a+1 and b-1
 
 We run it in the dojo using a cell to pass the two arguments:
 
-```
+```hoon
 > +add 12 14
 26
 
@@ -201,19 +201,19 @@ nest-fail
 -have.@ud
 ```
 
-If you try to call this gate with the wrong kind of argument, you get a `nest-fail`.  If the call succeeds, then the argument takes on the type of the sample definition: `[a=@ b=@]`.  Accordingly, the inferred type of `a` is `@`, and the inferred type of `b` is `@`.  In this case some type information has been thrown away; the inferred type of `[12 14]` is `[@ud @ud]`, but the addition program takes all atoms, regardless of aura.
+If you try to call this gate with the wrong kind of argument, you get a `nest-fail`. If the call succeeds, then the argument takes on the type of the sample definition: `[a=@ b=@]`. Accordingly, the inferred type of `a` is `@`, and the inferred type of `b` is `@`. In this case some type information has been thrown away; the inferred type of `[12 14]` is `[@ud @ud]`, but the addition program takes all atoms, regardless of aura.
 
 ### Using Conditionals for Inference by Branch
 
-You learned about a few conditional runes earlier in the chapter (e.g., `?:`, `?.`), but other runes of the `?` family are used for branch-specialized type inference.  The `?@`, `?^`, and `?~` conditionals each take three subexpressions, which play the same basic role as the corresponding subexpressions of `?:` -- the first is the test condition, which evaluates to a flag `?`.  If the test condition is true, the second subexpression is evaluated; otherwise the third.  These second and third subexpressions are the 'branches' of the conditional.
+You learned about a few conditional runes earlier in the chapter (e.g., `?:`, `?.`), but other runes of the `?` family are used for branch-specialized type inference. The `?@`, `?^`, and `?~` conditionals each take three subexpressions, which play the same basic role as the corresponding subexpressions of `?:` -- the first is the test condition, which evaluates to a flag `?`. If the test condition is true, the second subexpression is evaluated; otherwise the third. These second and third subexpressions are the 'branches' of the conditional.
 
 There is also a `?=` rune for matching expressions with certain types, returning `%.y` for a match and `%.n` otherwise.
 
 #### `?=` Non-recursive Type Match Test
 
-The `?=` rune takes two subexpressions.  The first subexpression should be a type.  The second subexpression is evaluated and the resulting value is compared to the first type.  If the value is an instance of the type, `%.y` is produced.  Otherwise, `%.n`.  Examples:
+The `?=` rune takes two subexpressions. The first subexpression should be a type. The second subexpression is evaluated and the resulting value is compared to the first type. If the value is an instance of the type, `%.y` is produced. Otherwise, `%.n`. Examples:
 
-```
+```hoon
 > ?=(@ 12)
 %.y
 
@@ -235,7 +235,7 @@ The `?=` rune takes two subexpressions.  The first subexpression should be a typ
 
 `?=` expressions ignore aura information:
 
-```
+```hoon
 > ?=(@ud 0x12)
 %.y
 
@@ -243,9 +243,9 @@ The `?=` rune takes two subexpressions.  The first subexpression should be a typ
 %.y
 ```
 
-We haven't talked much about types that are made with a type constructor yet.  We'll discuss these more soon, but it's worth pointing out that every list type qualifies as such, and hence should not be used with `?=`:
+We haven't talked much about types that are made with a type constructor yet. We'll discuss these more soon, but it's worth pointing out that every list type qualifies as such, and hence should not be used with `?=`:
 
-```
+```hoon
 > ?=((list @) ~[1 2 3 4])
 fish-loop
 ```
@@ -254,43 +254,44 @@ Using these non-basic constructed types with the `?=` rune results in a `fish-lo
 
 ##### Using `?=` for Type Inference
 
-The `?=` rune is particularly useful when used with the `?:` rune, because in these cases Hoon uses the result of the `?=` evaluation to infer type information.  To see how this works lets use `=/` to define a face, `b`, as a generic noun:
+The `?=` rune is particularly useful when used with the `?:` rune, because in these cases Hoon uses the result of the `?=` evaluation to infer type information. To see how this works lets use `=/` to define a face, `b`, as a generic noun:
 
-```
+```hoon
 > =/(b=* 12 b)
 12
 ```
 
-The inferred type of the final `b` is just `*`, because that's how `b` was defined earlier.  We can see this by using `?` in the dojo to see the product type:
+The inferred type of the final `b` is just `*`, because that's how `b` was defined earlier. We can see this by using `?` in the dojo to see the product type:
 
-```
+```hoon
 > ? =/(b=* 12 b)
   *
 12
 ```
+
 (Remember that `?` isn't part of Hoon -- it's a dojo-specific instruction.)
 
-Let's replace that last `b` with a `?:` expression whose condition subexpression is a `?=` test.  If `b` is an `@`, it'll produce `[& b]`; otherwise `[| b]`:
+Let's replace that last `b` with a `?:` expression whose condition subexpression is a `?=` test. If `b` is an `@`, it'll produce `[& b]`; otherwise `[| b]`:
 
-```
+```hoon
 > =/(b=* 12 ?:(?=(@ b) [& b] [| b]))
 [%.y 12]
 ```
 
-You can't see it here, but the inferred type of `b` in `[& b]` is `@`.  That subexpression is only evaluated if `?=(@ b)` evaluates as true; hence, Hoon can safely infer that `b` must be an atom in that subexpression.  Let's set `b` to a different initial value but leave everything else the same:
+You can't see it here, but the inferred type of `b` in `[& b]` is `@`. That subexpression is only evaluated if `?=(@ b)` evaluates as true; hence, Hoon can safely infer that `b` must be an atom in that subexpression. Let's set `b` to a different initial value but leave everything else the same:
 
-```
+```hoon
 > =/(b=* [12 14] ?:(?=(@ b) [& b] [| b]))
 [%.n 12 14]
 ```
 
-You can't see it here either, but the inferred type of `b` in `[| b]` is `^`.  That subexpression is only evaluated if `?=(@ b)` evaluates as false, so `b` can't be an atom there.  It follows that it must be a cell.
+You can't see it here either, but the inferred type of `b` in `[| b]` is `^`. That subexpression is only evaluated if `?=(@ b)` evaluates as false, so `b` can't be an atom there. It follows that it must be a cell.
 
 ##### The Type Spear
 
-We think we're trustworthy, but perhaps you don't want to take our word for it.  What if you want to see the inferred type of `b` for yourself for each conditional branch?  One way to do this is with a 'type spear'.  But you need to understand the `!>` rune before using this mighty weapon of war.  `!>` takes one subexpression and constructs a cell from it.  The subexpression is evaluated and becomes the tail of the product cell, with a `q` face attached.  The head of the product cell is the inferred type of the subexpression.  Examples:
+We think we're trustworthy, but perhaps you don't want to take our word for it. What if you want to see the inferred type of `b` for yourself for each conditional branch? One way to do this is with a 'type spear'. But you need to understand the `!>` rune before using this mighty weapon of war. `!>` takes one subexpression and constructs a cell from it. The subexpression is evaluated and becomes the tail of the product cell, with a `q` face attached. The head of the product cell is the inferred type of the subexpression. Examples:
 
-```
+```hoon
 > !>(15)
 [#t/@ud q=15]
 
@@ -303,9 +304,9 @@ We think we're trustworthy, but perhaps you don't want to take our word for it. 
 
 The `#t/` is just the pretty-printer's way of indicating a type.
 
-To get just the inferred type of a expression, we only want the head of the `!>` product, `-`.  Thus we should use the type spear, `-:!>`.
+To get just the inferred type of a expression, we only want the head of the `!>` product, `-`. Thus we should use the type spear, `-:!>`.
 
-```
+```hoon
 > -:!>(15)
 #t/@ud
 
@@ -316,29 +317,29 @@ To get just the inferred type of a expression, we only want the head of the `!>`
 #t/@
 ```
 
-Now let's try using `?=` with `?:` again.  But this time we'll replace `[& b]` with `[& -:!>(b)]` and `[| b]` with `[| -:!>(b)]`.  With `b` as `12`:
+Now let's try using `?=` with `?:` again. But this time we'll replace `[& b]` with `[& -:!>(b)]` and `[| b]` with `[| -:!>(b)]`. With `b` as `12`:
 
-```
+```hoon
 > =/(b=* 12 ?:(?=(@ b) [& -:!>(b)] [| -:!>(b)]))
 [%.y #t/@]
 ```
 
 ...and with `b` as `[12 14]`:
 
-```
+```hoon
 > =/(b=* [12 14] ?:(?=(@ b) [& -:!>(b)] [| -:!>(b)]))
 [%.n #t/{* *}]
 ```
 
-In both cases, `b` is defined initially as a generic noun, `*`.  But when using `?:` with `?=(@ b)` as the test condition, `b` is inferred to be an atom, `@`, when the condition is true; otherwise `b` is inferred to be a cell, `^` (identical to `{* *}`).
+In both cases, `b` is defined initially as a generic noun, `*`. But when using `?:` with `?=(@ b)` as the test condition, `b` is inferred to be an atom, `@`, when the condition is true; otherwise `b` is inferred to be a cell, `^` (identical to `{* *}`).
 
 ##### `mint-vain`
 
-Expressions of the form `?:(?=(a b) c d)` should only be used when the previously inferred type of `b` isn't specific enough to determine whether it nests under `a`.  This kind of expression is only to be used when `?=` can reveal new type information about `b`, not to confirm information Hoon already has.
+Expressions of the form `?:(?=(a b) c d)` should only be used when the previously inferred type of `b` isn't specific enough to determine whether it nests under `a`. This kind of expression is only to be used when `?=` can reveal new type information about `b`, not to confirm information Hoon already has.
 
-For example, if you have a wing expression (e.g., `b`) that is already known to be an atom, `@`, and you use `?=(@ b)` to test whether `b` is an atom, you'll get a `mint-vain` crash.  The same thing happens if `b` is initially defined to be a cell `^`:
+For example, if you have a wing expression (e.g., `b`) that is already known to be an atom, `@`, and you use `?=(@ b)` to test whether `b` is an atom, you'll get a `mint-vain` crash. The same thing happens if `b` is initially defined to be a cell `^`:
 
-```
+```hoon
 > =/(b=@ 12 ?:(?=(@ b) [& b] [| b]))
 mint-vain
 
@@ -346,13 +347,13 @@ mint-vain
 mint-vain
 ```
 
-In the first case it's already known that `b` is an atom.  In the second case it's already known that `b` isn't an atom.  Either way, the check is superfluous and thus one of the `?:` branches will never be taken.  The `mint-vain` crash indicates that it's provably the case one of the branches will never be taken.
+In the first case it's already known that `b` is an atom. In the second case it's already known that `b` isn't an atom. Either way, the check is superfluous and thus one of the `?:` branches will never be taken. The `mint-vain` crash indicates that it's provably the case one of the branches will never be taken.
 
 #### `?@` Atom Match Tests
 
-The `?@` rune takes three subexpressions.  The first is evaluated, and if its value is an instance of `@`, the second subexpression is evaluated.  Otherwise, the third subexpression is evaluated.
+The `?@` rune takes three subexpressions. The first is evaluated, and if its value is an instance of `@`, the second subexpression is evaluated. Otherwise, the third subexpression is evaluated.
 
-```
+```hoon
 > =/(b=* 12 ?@(b %atom %cell))
 %atom
 
@@ -360,9 +361,9 @@ The `?@` rune takes three subexpressions.  The first is evaluated, and if its va
 %cell
 ```
 
-If the second `?@` subexpression is evaluated, Hoon correctly infers that `b` is an atom.  if the third subexpression is evaluated, Hoon correctly infers that `b` is a cell.
+If the second `?@` subexpression is evaluated, Hoon correctly infers that `b` is an atom. if the third subexpression is evaluated, Hoon correctly infers that `b` is a cell.
 
-```
+```hoon
 > =/(b=* 12 ?@(b [%atom -:!>(b)] [%cell -:!>(b)]))
 [%atom #t/@]
 
@@ -370,9 +371,9 @@ If the second `?@` subexpression is evaluated, Hoon correctly infers that `b` is
 [%cell #t/{* *}]
 ```
 
-If the inferred type of the first `?@` subexpression nests under `@` then one of the conditional branches provably never runs.  Attempting to evaluate the expression results in a `mint-vain`:
+If the inferred type of the first `?@` subexpression nests under `@` then one of the conditional branches provably never runs. Attempting to evaluate the expression results in a `mint-vain`:
 
-```
+```hoon
 > ?@(12 %an-atom %not-an-atom)
 mint-vain
 
@@ -390,9 +391,9 @@ mint-vain
 
 #### `?^` Cell Match Tests
 
-The `?^` rune is just like `?@` except it's a test for a cell match instead of an atom match.  The first subexpression is evaluated, and if the resulting value is an instance of `^` the second subexpression is evaluated.  Otherwise, the third is.
+The `?^` rune is just like `?@` except it's a test for a cell match instead of an atom match. The first subexpression is evaluated, and if the resulting value is an instance of `^` the second subexpression is evaluated. Otherwise, the third is.
 
-```
+```hoon
 > =/(b=* 12 ?^(b %cell %atom))
 %atom
 
@@ -400,9 +401,9 @@ The `?^` rune is just like `?@` except it's a test for a cell match instead of a
 %cell
 ```
 
-Again, if the second subexpression is evaluated Hoon infers that `b` is a cell; if the third, Hoon infers that `b` is an atom.  If one of the conditional branches is provably never evaluated, the expression crashes with a `mint-vain`:
+Again, if the second subexpression is evaluated Hoon infers that `b` is a cell; if the third, Hoon infers that `b` is an atom. If one of the conditional branches is provably never evaluated, the expression crashes with a `mint-vain`:
 
-```
+```hoon
 > =/(b=@ 12 ?^(b %cell %atom))
 mint-vain
 
@@ -412,7 +413,7 @@ nest-fail
 
 #### Leaf Counting
 
-Nouns can be understood as binary trees in which each 'leaf' of the tree is an atom.  Let's look at a program that takes a noun and returns the number of leaves in it, i.e., the number of atoms.
+Nouns can be understood as binary trees in which each 'leaf' of the tree is an atom. Let's look at a program that takes a noun and returns the number of leaves in it, i.e., the number of atoms.
 
 ```hoon
 |=  a=*                                                 ::  1
@@ -424,7 +425,7 @@ Nouns can be understood as binary trees in which each 'leaf' of the tree is an a
 
 Save this as `leafcount.hoon` in your urbit's pier and run it from the dojo:
 
-```
+```hoon
 > +leafcount 12
 1
 
@@ -435,7 +436,7 @@ Save this as `leafcount.hoon` in your urbit's pier and run it from the dojo:
 6
 ```
 
-This program is pretty simple.  If the noun `a` is an atom, then it's a tree of one leaf; return `1`.  Otherwise, the number of leaves in `a` is the sum of the leaves in the head, `-.a`, and the tail, `+.a`.
+This program is pretty simple. If the noun `a` is an atom, then it's a tree of one leaf; return `1`. Otherwise, the number of leaves in `a` is the sum of the leaves in the head, `-.a`, and the tail, `+.a`.
 
 We have been careful to use `-.a` and `+.a` only on a branch for which `a` is proved to be a cell -- then it's safe to treat `a` as having a head and a tail.
 
@@ -457,7 +458,7 @@ Here's a program that counts the number of cells in a noun:
 
 Save this as `cellcount.hoon` and run it from the dojo:
 
-```
+```hoon
 > +cellcount 12
 0
 
@@ -477,21 +478,21 @@ Save this as `cellcount.hoon` and run it from the dojo:
 5
 ```
 
-This code is a little more tricky.  The basic idea, however, is simple.  We have a counter value, `c`, whose initial value is `0`.  We trace through the noun `a`, adding `1` to `c` every time we come across a cell.  For any part of the noun that is just an atom, `c` is returned unchanged.
+This code is a little more tricky. The basic idea, however, is simple. We have a counter value, `c`, whose initial value is `0`. We trace through the noun `a`, adding `1` to `c` every time we come across a cell. For any part of the noun that is just an atom, `c` is returned unchanged.
 
-What makes this program is little harder to follow is that it has a recursion call within a recursion call.  The first recursion expression on line 6 makes changes to two face values: `c`, the counter, and `a`, the input noun.  The new value for `c` defined in line 7 is another recursion call (this time in irregular syntax).  The new value for `c` is to be: the result of running the same function on the the head of `a`, `-.a`, and with `1` added to `c`.  We add `1` because we know that `a` must be a cell.  Otherwise, we're asking for the number of cells in the rest of `-.a`.
+What makes this program is little harder to follow is that it has a recursion call within a recursion call. The first recursion expression on line 6 makes changes to two face values: `c`, the counter, and `a`, the input noun. The new value for `c` defined in line 7 is another recursion call (this time in irregular syntax). The new value for `c` is to be: the result of running the same function on the the head of `a`, `-.a`, and with `1` added to `c`. We add `1` because we know that `a` must be a cell. Otherwise, we're asking for the number of cells in the rest of `-.a`.
 
-Once that new value for `c` is computed from the head of `a`, we're ready to check the tail of `a`, `+.a`.  We've already got everything we want from `-.a`, so we throw that away and replace `a` with `+.a`.
+Once that new value for `c` is computed from the head of `a`, we're ready to check the tail of `a`, `+.a`. We've already got everything we want from `-.a`, so we throw that away and replace `a` with `+.a`.
 
 #### Lists
 
 You learned about lists earlier in the chapter, but we left out a little bit of information about the way Hoon understands list types.
 
-A non-null list is a cell.  If `b` is a non-null list then the head of `b` is the first item of `b` _with an `i` face on it_.  The tail of `b` is the rest of the list.  The 'rest of the list' is itself another list _with a `t` face on it_.  We can (and should) use these `i` and `t` faces in list functions.
+A non-null list is a cell. If `b` is a non-null list then the head of `b` is the first item of `b` _with an `i` face on it_. The tail of `b` is the rest of the list. The 'rest of the list' is itself another list _with a `t` face on it_. We can (and should) use these `i` and `t` faces in list functions.
 
-To illustrate: let's say that `b` is the list of the atoms `11`, `22`, and `33`.  Let's construct this in stages:
+To illustrate: let's say that `b` is the list of the atoms `11`, `22`, and `33`. Let's construct this in stages:
 
-```
+```hoon
 [i=11 t=[rest-of-list-b]]
 
 [i=11 t=[i=22 t=[rest-of-list-b]]]
@@ -499,7 +500,7 @@ To illustrate: let's say that `b` is the list of the atoms `11`, `22`, and `33`.
 [i=11 t=[i=22 t=[i=33 t=~]]]
 ```
 
-(There are lists of every type.  Lists of `@ud`, `@ux`, `@` in general, `^`, `[^ [@ @]]`, etc.  We can even have lists of lists of `@`, `^`, or `?`, etc.)
+(There are lists of every type. Lists of `@ud`, `@ux`, `@` in general, `^`, `[^ [@ @]]`, etc. We can even have lists of lists of `@`, `^`, or `?`, etc.)
 
 Here's a program that takes atoms `a` and `b` and returns a list of all atoms from `a` to `b`:
 
@@ -511,11 +512,11 @@ Here's a program that takes atoms `a` and `b` and returns a list of all atoms fr
 [i=a t=$(a +(a))]                                       ::  5
 ```
 
-This program is very simple.  It takes two `@` as input, `a` and `b`, and returns a `(list @)`, i.e., a list of `@`.  If `a` is greater than `b` the list is finished: return the null list `~`.  Otherwise, return a non-null list: a pair in which the head is `a` with an `i` face on it, and in which the tail is another list with the `t` face on it.  This embedded list is the product of a recursion call: add `1` to `a` and run the function again.
+This program is very simple. It takes two `@` as input, `a` and `b`, and returns a `(list @)`, i.e., a list of `@`. If `a` is greater than `b` the list is finished: return the null list `~`. Otherwise, return a non-null list: a pair in which the head is `a` with an `i` face on it, and in which the tail is another list with the `t` face on it. This embedded list is the product of a recursion call: add `1` to `a` and run the function again.
 
 Save this code as `gulf.hoon` in your urbit's pier and run it from the dojo:
 
-```
+```hoon
 > +gulf [1 10]
 ~[1 2 3 4 5 6 7 8 9 10]
 
@@ -526,7 +527,7 @@ Save this code as `gulf.hoon` in your urbit's pier and run it from the dojo:
 ~
 ```
 
-Where are all the `i`s and `t`s???  For the sake of neatness the Hoon pretty-printer doesn't show the `i` and `t` faces of lists, just the items.
+Where are all the `i`s and `t`s??? For the sake of neatness the Hoon pretty-printer doesn't show the `i` and `t` faces of lists, just the items.
 
 In fact, we could have left out the `i` and `t` faces in the program itself:
 
@@ -538,11 +539,11 @@ In fact, we could have left out the `i` and `t` faces in the program itself:
 [a $(a +(a))]                                           ::  5
 ```
 
-Because there is a cast to a `(list @)` on line 2, Hoon will silently include `i` and `t` faces for the appropriate places of the noun.  Remember that faces are recorded in the type information of the noun in question, not as part of the noun itself.
+Because there is a cast to a `(list @)` on line 2, Hoon will silently include `i` and `t` faces for the appropriate places of the noun. Remember that faces are recorded in the type information of the noun in question, not as part of the noun itself.
 
 We called this program `gulf.hoon` because it replicates the `gulf` function in the Hoon standard library:
 
-```
+```hoon
 > (gulf 1 10)
 ~[1 2 3 4 5 6 7 8 9 10]
 
@@ -552,9 +553,9 @@ We called this program `gulf.hoon` because it replicates the `gulf` function in 
 
 #### `?~` Null Match Test
 
-The `?~` rune is a lot like `?@` and `?^`.  It takes three subexpressions, the first of which is evaluated to see whether the result is null, `~`.  If so, the second subexpression is evaluated.  Otherwise, the third one is evaluated.
+The `?~` rune is a lot like `?@` and `?^`. It takes three subexpressions, the first of which is evaluated to see whether the result is null, `~`. If so, the second subexpression is evaluated. Otherwise, the third one is evaluated.
 
-```
+```hoon
 > =/(b=* ~ ?~(b %null %not-null))
 %null
 
@@ -564,7 +565,7 @@ The `?~` rune is a lot like `?@` and `?^`.  It takes three subexpressions, the f
 
 The inferred type of `b` must not already be known to be null or non-null; otherwise, the expression will crash with a `mint-vain`:
 
-```
+```hoon
 > =/(b=~ ~ ?~(b %null %not-null))
 mint-vain
 
@@ -579,7 +580,7 @@ Hoon will infer that `b` either is or isn't null based on which `?~` branch is e
 
 #### Using `?~` With Lists
 
-The `?~` is especially useful for working with lists.  Is a list null, or not?  You probably want to do different things based on the answer to that question.  Here's a program using `?~` to calculate the number of items in a list of atoms:
+The `?~` is especially useful for working with lists. Is a list null, or not? You probably want to do different things based on the answer to that question. Here's a program using `?~` to calculate the number of items in a list of atoms:
 
 ```hoon
 |=  a=(list @)                                          ::  1
@@ -590,13 +591,13 @@ The `?~` is especially useful for working with lists.  Is a list null, or not?  
 $(c +(c), a t.a)                                        ::  6
 ```
 
-This function takes a list of `@` and returns an `@`.  It uses `c` as a counter value, initially set at `0` on line 2.  If `a` is `~` (i.e., a null list) then the computation is finished; return `c`.  Otherwise `a` must be a non-null list, in which case there is a recursion to the `|-` on line 3, but with `c` incremented, and with the head of the list `a` thrown away.
+This function takes a list of `@` and returns an `@`. It uses `c` as a counter value, initially set at `0` on line 2. If `a` is `~` (i.e., a null list) then the computation is finished; return `c`. Otherwise `a` must be a non-null list, in which case there is a recursion to the `|-` on line 3, but with `c` incremented, and with the head of the list `a` thrown away.
 
-It's important to note that if `a` is a list, you can only use `i.a` and `t.a` after Hoon has inferred that `a` is non-null.  A null list has no `i` or `t` in it!  You'll often use `?~` to distinguish the two kinds of list (null and non-null).  If you use `i.a` or `t.a` without showing that `a` is non-null you'll get a `find-fork-d` crash.
+It's important to note that if `a` is a list, you can only use `i.a` and `t.a` after Hoon has inferred that `a` is non-null. A null list has no `i` or `t` in it! You'll often use `?~` to distinguish the two kinds of list (null and non-null). If you use `i.a` or `t.a` without showing that `a` is non-null you'll get a `find-fork-d` crash.
 
 Save the above code as `lent.hoon` in your urbit's pier and run it from the dojo:
 
-```
+```hoon
 > +lent ~[11 22 33]
 3
 
@@ -620,13 +621,13 @@ Here's a program that takes a noun and returns a list of its 'leaves' (atoms) in
 $(lis $(a +.a), a -.a)                                            ::  6
 ```
 
-The input noun is `a`.  The list of atoms to be output is `lis`, which is given an initial value of `~`.  If `a` is just an atom, return a non-null list whose head is `a` and whose tail is `lis`.  Otherwise, the somewhat complicated recursion in line 6 is evaluated, in effect looping back to the `|-` with modifications made to `lis` and `a`.
+The input noun is `a`. The list of atoms to be output is `lis`, which is given an initial value of `~`. If `a` is just an atom, return a non-null list whose head is `a` and whose tail is `lis`. Otherwise, the somewhat complicated recursion in line 6 is evaluated, in effect looping back to the `|-` with modifications made to `lis` and `a`.
 
-The modification to `lis` in line 6 is to `$(a +.a)`.  The latter is a recursion to `|-` but with `a` replaced by its tail.  This evaluates to the list of `@` in the tail of `a`.  So `lis` becomes the list of atoms in the tail of `a`, and `a` becomes the head of `a`, `-.a`.
+The modification to `lis` in line 6 is to `$(a +.a)`. The latter is a recursion to `|-` but with `a` replaced by its tail. This evaluates to the list of `@` in the tail of `a`. So `lis` becomes the list of atoms in the tail of `a`, and `a` becomes the head of `a`, `-.a`.
 
 Save the above code as `listleaf.hoon` and run it from the dojo:
 
-```
+```hoon
 > +listleaf [[[[12 13] [33 22] 12] 11] 33]
 ~[12 13 33 22 12 11 33]
 ```
@@ -635,9 +636,8 @@ Save the above code as `listleaf.hoon` and run it from the dojo:
 
 So far you've learned about four kinds of type inference, using: (1) literals, (2) explicit casts, (3) gate sample definitions, and (4) branch specialization using runes in the `?` family.
 
-In fact, there are several other ways that Hoon infers type.  Any rune expression that evaluates to a flag, `?`, e.g., `.=`, will be inferred from accordingly.  The `.+` rune always evaluates to an `@`, and Hoon knows that too.  The cell constructor runes, `:-`, `:+`, `:^`, and `:*` are all known to produce cells.
+In fact, there are several other ways that Hoon infers type. Any rune expression that evaluates to a flag, `?`, e.g., `.=`, will be inferred from accordingly. The `.+` rune always evaluates to an `@`, and Hoon knows that too. The cell constructor runes, `:-`, `:+`, `:^`, and `:*` are all known to produce cells.
 
 More subtly, the `=+`, `=/`, and `=|` runes modify the subject by pinning values to the head. Hoon infers from this that the subject has a new type: a cell whose head is the type of the pinned value and whose tail is the type of the (old) subject.
 
-In general, anything that modifies the subject modifies the type of the subject.  Type inference can work in subtle ways for various expressions.  However, we have covered enough that it should be relatively clear how to anticipate how type inference works for the vast majority of ordinary use cases.
-
+In general, anything that modifies the subject modifies the type of the subject. Type inference can work in subtle ways for various expressions. However, we have covered enough that it should be relatively clear how to anticipate how type inference works for the vast majority of ordinary use cases.

--- a/hoon/hoon-school/type-polymorphism.md
+++ b/hoon/hoon-school/type-polymorphism.md
@@ -5,11 +5,11 @@ template = "doc.html"
 aliases = ["/docs/learn/hoon/hoon-tutorial/type-polymorphism/"]
 +++
 
-There are many cases in which one may want to write a function that accepts as input various different types of data.  Such a function is said to be [polymorphic](https://en.wikipedia.org/wiki/Polymorphism_%28computer_science%29).  ("Polymorphism" = "many forms"; so polymorphic functions accept many forms of data as input.)
+There are many cases in which one may want to write a function that accepts as input various different types of data. Such a function is said to be [polymorphic](https://en.wikipedia.org/wiki/Polymorphism_%28computer_science%29). ("Polymorphism" = "many forms"; so polymorphic functions accept many forms of data as input.)
 
-One relatively trivial form of polymorphism involves sub-typing.  A [gate](/docs/glossary/gate/) whose sample is a raw `noun` can accept any Hoon data structure as input -- it's just that the sample will only be treated as a raw [noun](/docs/glossary/noun/).  For example, consider the `copy` gate below:
+One relatively trivial form of polymorphism involves sub-typing. A [gate](/docs/glossary/gate/) whose sample is a raw `noun` can accept any Hoon data structure as input -- it's just that the sample will only be treated as a raw [noun](/docs/glossary/noun/). For example, consider the `copy` gate below:
 
-```
+```hoon
 > =copy |=(a=* [a a])
 
 > (copy 15)
@@ -22,39 +22,39 @@ One relatively trivial form of polymorphism involves sub-typing.  A [gate](/docs
 [[72 101 108 108 111 33 0] [72 101 108 108 111 33 0]]
 ```
 
-`copy` takes the input, `a`, and returns a cell of `[a a]`.  Because every piece of Hoon data is a noun, anything can be taken as input.  Every other type in Hoon is a sub-type of `noun`.  But the output of `copy` is always going to be just a cell of nouns; the type information of the original input value is not preserved by the gate.  Consider the `tape` in the last example: `"Hello!"` was pretty-printed in the dojo as a raw noun, not as a string.  So `copy` is a relatively uninteresting polymorphic function.
+`copy` takes the input, `a`, and returns a cell of `[a a]`. Because every piece of Hoon data is a noun, anything can be taken as input. Every other type in Hoon is a sub-type of `noun`. But the output of `copy` is always going to be just a cell of nouns; the type information of the original input value is not preserved by the gate. Consider the `tape` in the last example: `"Hello!"` was pretty-printed in the dojo as a raw noun, not as a string. So `copy` is a relatively uninteresting polymorphic function.
 
 In this lesson we'll go over Hoon's support for more interesting polymorphic functions.
 
 ## Polymorphic Properties of Cores
 
-Hoon supports type polymorphism at the [core](/docs/glossary/core/) level.  That is, each core  has certain polymorphic properties that are tracked and maintained as metadata by Hoon's type system.  (See `+$  type` of `hoon.hoon`.)  These properties determine the extent to which a core can be used as an interface for values of various types.
+Hoon supports type polymorphism at the [core](/docs/glossary/core/) level. That is, each core has certain polymorphic properties that are tracked and maintained as metadata by Hoon's type system. (See `+$ type` of `hoon.hoon`.) These properties determine the extent to which a core can be used as an interface for values of various types.
 
-This is rather vaguely put so far.  We can clarify by talking more specifically about the kinds of polymorphism supported in Hoon.  There are two kinds of type polymorphism for cores: [genericity](https://en.wikipedia.org/wiki/Generic_programming), to include certain kinds of [parametric polymorphism](https://en.wikipedia.org/wiki/Parametric_polymorphism); and [variance polymorphism](https://en.wikipedia.org/wiki/Covariance_and_contravariance_%28computer_science%29), which involves making use of special sub-typing rules for cores.
+This is rather vaguely put so far. We can clarify by talking more specifically about the kinds of polymorphism supported in Hoon. There are two kinds of type polymorphism for cores: [genericity](https://en.wikipedia.org/wiki/Generic_programming), to include certain kinds of [parametric polymorphism](https://en.wikipedia.org/wiki/Parametric_polymorphism); and [variance polymorphism](https://en.wikipedia.org/wiki/Covariance_and_contravariance_%28computer_science%29), which involves making use of special sub-typing rules for cores.
 
-If you don't understand these very well, that's okay.  We'll explain them.  Let's begin with the former.
+If you don't understand these very well, that's okay. We'll explain them. Let's begin with the former.
 
 ## Dry vs. Wet Cores
 
-To review briefly, a **core** is a pair of `[battery payload]`.  The **battery** contains the various [arms](/docs/glossary/arm/) of the core (code), and the **payload** contains all the data needed to evaluate those arms correctly (data).  Every arm is evaluated with its parent core as the subject.  A **gate** (i.e., a Hoon function) is a core with exactly one arm named `$` and with a [payload](/docs/glossary/payload/) of the form: `[sample context]`.  The **sample** is reserved for the function's argument value, and the **context** is any other data needed to evaluate `$` correctly.
+To review briefly, a **core** is a pair of `[battery payload]`. The **battery** contains the various [arms](/docs/glossary/arm/) of the core (code), and the **payload** contains all the data needed to evaluate those arms correctly (data). Every arm is evaluated with its parent core as the subject. A **gate** (i.e., a Hoon function) is a core with exactly one arm named `$` and with a [payload](/docs/glossary/payload/) of the form: `[sample context]`. The **sample** is reserved for the function's argument value, and the **context** is any other data needed to evaluate `$` correctly.
 
-There are two kinds of cores: **dry** and **wet**.  Dry cores, which are more typical, _don't_ make use of **genericity**.  Wet cores do.  In order to understand generic functions in Hoon, you have to understand the difference between dry and wet cores.
+There are two kinds of cores: **dry** and **wet**. Dry cores, which are more typical, _don't_ make use of **genericity**. Wet cores do. In order to understand generic functions in Hoon, you have to understand the difference between dry and wet cores.
 
-The cores produced with the `|=`, `|-`, `|%`, and `|_` runes, among others, are all dry.  The cores produced with the `|*` and `|@` runes are wet.  (`|*` and `|@` are the wet versions of `|=` and `|%`, respectively.)
+The cores produced with the `|=`, `|-`, `|%`, and `|_` runes, among others, are all dry. The cores produced with the `|*` and `|@` runes are wet. (`|*` and `|@` are the wet versions of `|=` and `|%`, respectively.)
 
-Briefly, the difference between dry and wet cores has to do with how they're treated at compile time, for type inference and type checking.  During the type check, the product type of each arm is inferred.  For computing a dry arm type, it's assumed that the arm's subject type is of the original parent core.  For computing a wet arm type, the parent core type is used, except that the payload value may vary from the original type.
+Briefly, the difference between dry and wet cores has to do with how they're treated at compile time, for type inference and type checking. During the type check, the product type of each arm is inferred. For computing a dry arm type, it's assumed that the arm's subject type is of the original parent core. For computing a wet arm type, the parent core type is used, except that the payload value may vary from the original type.
 
-Because of this, wet gates can be used as functions that take different input types at different call sites.  We'll go over the dry/wet distinction in more detail below and explain why it matters.
+Because of this, wet gates can be used as functions that take different input types at different call sites. We'll go over the dry/wet distinction in more detail below and explain why it matters.
 
 ### Dry Cores
 
-A core's payload can change from its original value.  In fact, this happens in the typical function call -- the default sample is replaced with an input value.  How can we ensure that the core's arms are able to run correctly, that the payload type is still appropriate despite whatever changes it has undergone?
+A core's payload can change from its original value. In fact, this happens in the typical function call -- the default sample is replaced with an input value. How can we ensure that the core's arms are able to run correctly, that the payload type is still appropriate despite whatever changes it has undergone?
 
-There is a type check for each arm of a dry core, intended to verify that the arm's parent core has a payload of the correct type.  In this section we'll describe that type check, starting with typical gate usage.
+There is a type check for each arm of a dry core, intended to verify that the arm's parent core has a payload of the correct type. In this section we'll describe that type check, starting with typical gate usage.
 
-When the `$` arm of a dry gate is evaluated it takes its parent core -- the dry gate itself -- as the subject, often with a modified sample _value_.  But any change in sample _type_ should be conservative; the modified sample value must be of the same type as the default sample value (or possibly a subtype).  When the `$` arm is evaluated it should have a subject of a type it knows how to use.
+When the `$` arm of a dry gate is evaluated it takes its parent core -- the dry gate itself -- as the subject, often with a modified sample _value_. But any change in sample _type_ should be conservative; the modified sample value must be of the same type as the default sample value (or possibly a subtype). When the `$` arm is evaluated it should have a subject of a type it knows how to use.
 
-For illustration, consider the gate created by `add`, a function in the Hoon standard library.  The structure of the `add` gate is as follows:
+For illustration, consider the gate created by `add`, a function in the Hoon standard library. The structure of the `add` gate is as follows:
 
 ```
        add
@@ -64,51 +64,51 @@ For illustration, consider the gate created by `add`, a function in the Hoon sta
     sample   context
 ```
 
-The `add` code depends on the fact that there are two [atoms](/docs/glossary/atom/) in the sample: the numbers to be added together.  Hence, it is appropriate that only a cell of atoms is permitted for the sample.  We can look at the default sample of `add` at address `+6`:
+The `add` code depends on the fact that there are two [atoms](/docs/glossary/atom/) in the sample: the numbers to be added together. Hence, it is appropriate that only a cell of atoms is permitted for the sample. We can look at the default sample of `add` at address `+6`:
 
-```
+```hoon
 > +6:add
 [a=0 b=0]
 ```
 
 If we call `add` with no arguments, we get the sum of these two values:
 
-```
+```hoon
 > (add)
 0
 ```
 
 Any other type of value in the sample results in a `nest-fail` crash:
 
-```
+```hoon
 > (add 12 "hello")
 nest-fail
 ```
 
-This function call attempts to create a modified copy of the `add` gate, replacing the original sample `[0 0]` with `[12 "hello"]`, then evaluate the `$` arm of this modified core.  (We ignore the `a` and `b` faces for now.)  But this piece of code failed to compile; the type system knew to reject it.
+This function call attempts to create a modified copy of the `add` gate, replacing the original sample `[0 0]` with `[12 "hello"]`, then evaluate the `$` arm of this modified core. (We ignore the `a` and `b` faces for now.) But this piece of code failed to compile; the type system knew to reject it.
 
-How does it know?  The type system keeps track of two copies of the payload type for each core:
+How does it know? The type system keeps track of two copies of the payload type for each core:
 
-+ The original payload type, i.e., the type of the payload when the core was first created.  In the case of `add`, the original sample type is a cell of atoms, `[@ @]`. This original type information is always preserved, regardless of the argument values used to call `add`.
-+ The current payload type, i.e., the type of the payload after any substitutions or other changes have been made.  In the last `add` call, `(add 12 "hello")`, the sample would be a cell whose head is an `@ud`, and whose tail is a `tape`.
+- The original payload type, i.e., the type of the payload when the core was first created. In the case of `add`, the original sample type is a cell of atoms, `[@ @]`. This original type information is always preserved, regardless of the argument values used to call `add`.
+- The current payload type, i.e., the type of the payload after any substitutions or other changes have been made. In the last `add` call, `(add 12 "hello")`, the sample would be a cell whose head is an `@ud`, and whose tail is a `tape`.
 
-The type check at compile time compares these two types, and if the current payload type doesn't nest under the original payload, the compile fails with a `nest-fail` crash.  (E.g., a cell of type `[@ud tape]` doesn't nest under `[@ @]`.)  Otherwise, the original payload _type_ is used for evaluation, even though the original sample _value_ has been replaced.  So the arm of a dry core is guaranteed to run with exactly the same subject type each time it is evaluated.
+The type check at compile time compares these two types, and if the current payload type doesn't nest under the original payload, the compile fails with a `nest-fail` crash. (E.g., a cell of type `[@ud tape]` doesn't nest under `[@ @]`.) Otherwise, the original payload _type_ is used for evaluation, even though the original sample _value_ has been replaced. So the arm of a dry core is guaranteed to run with exactly the same subject type each time it is evaluated.
 
-The type check for each arm in a dry core can be understood as implementing a version of the ["Liskov substitution principle"](https://en.wikipedia.org/wiki/Liskov_substitution_principle).  The arm works for some (originally defined) payload type `P`.  Payload type `Q` nests under `P`.  Therefore the arm works for `Q` as well, though for type inference purposes the payload is treated as a `P`.  The inferred type of the arm is based on the assumption that it's evaluated with a subject type exactly like that of its original parent core -- i.e., whose payload is of type `P`.
+The type check for each arm in a dry core can be understood as implementing a version of the ["Liskov substitution principle"](https://en.wikipedia.org/wiki/Liskov_substitution_principle). The arm works for some (originally defined) payload type `P`. Payload type `Q` nests under `P`. Therefore the arm works for `Q` as well, though for type inference purposes the payload is treated as a `P`. The inferred type of the arm is based on the assumption that it's evaluated with a subject type exactly like that of its original parent core -- i.e., whose payload is of type `P`.
 
 ### Wet Cores (Genericity)
 
-The type checking and inference rules for arms are a bit different for wet cores.  Whereas the dry arm is understood as having _exactly_ its parent core type for its subject, wet arms can be evaluated with payloads of various types.
+The type checking and inference rules for arms are a bit different for wet cores. Whereas the dry arm is understood as having _exactly_ its parent core type for its subject, wet arms can be evaluated with payloads of various types.
 
 Let's start again with a typical function call.
 
-When a function call occurs on a wet arm, the [call site](https://en.wikipedia.org/wiki/Call_site) argument value type is used as the sample type -- not the original parent core sample type.  Correspondingly, the inferred type of a wet arm depends, among other things, on the type of the argument value -- i.e., the modified sample value type of the core, not the original sample.  Thus, the inferred product type typically varies from one call site to another.
+When a function call occurs on a wet arm, the [call site](https://en.wikipedia.org/wiki/Call_site) argument value type is used as the sample type -- not the original parent core sample type. Correspondingly, the inferred type of a wet arm depends, among other things, on the type of the argument value -- i.e., the modified sample value type of the core, not the original sample. Thus, the inferred product type typically varies from one call site to another.
 
-The arms of wet cores must be able to handle subjects of various types -- they are interestingly polymorphic in a way that dry cores cannot be.  The Hoon code that defines each wet arm must be [generic](https://en.wikipedia.org/wiki/Generic_programming) with respect to the sample type.
+The arms of wet cores must be able to handle subjects of various types -- they are interestingly polymorphic in a way that dry cores cannot be. The Hoon code that defines each wet arm must be [generic](https://en.wikipedia.org/wiki/Generic_programming) with respect to the sample type.
 
-An example will clarify how wet gates work.  Recall the `copy` gate from earlier in the lesson:
+An example will clarify how wet gates work. Recall the `copy` gate from earlier in the lesson:
 
-```
+```hoon
 > =copy |=(a=* [a a])
 
 > (copy 15)
@@ -121,9 +121,9 @@ An example will clarify how wet gates work.  Recall the `copy` gate from earlier
 [[72 101 108 108 111 33 0] [72 101 108 108 111 33 0]]
 ```
 
-This gate is dry (as are all cores produced with `|=`), and so the inferred type of the product is determined based on the original core sample type.  In this case, that's a raw noun, `*`.  The dojo pretty-printer therefore has no way of knowing that the product of the last `copy` call should be printed as a pair of `tape`s -- it just sees a pair of nouns.  If we want the original type information preserved, we must use a wet gate, which can be produced with `|*`:
+This gate is dry (as are all cores produced with `|=`), and so the inferred type of the product is determined based on the original core sample type. In this case, that's a raw noun, `*`. The dojo pretty-printer therefore has no way of knowing that the product of the last `copy` call should be printed as a pair of `tape`s -- it just sees a pair of nouns. If we want the original type information preserved, we must use a wet gate, which can be produced with `|*`:
 
-```
+```hoon
 > =wet-copy |*(a=* [a a])
 
 > (wet-copy 15)
@@ -136,13 +136,13 @@ This gate is dry (as are all cores produced with `|=`), and so the inferred type
 ["Hello!" "Hello!"]
 ```
 
-We see that the type information about the `tape` literal `"Hello!"` is preserved in the last function call, as desired.  The original sample value of `wet-copy` is replaced with `"Hello!"`, and the original sample type is ignored in favor of the new sample type, `tape`.  So the inferred arm type is a cell of `tape`s, which the dojo pretty-printer handles appropriately.
+We see that the type information about the `tape` literal `"Hello!"` is preserved in the last function call, as desired. The original sample value of `wet-copy` is replaced with `"Hello!"`, and the original sample type is ignored in favor of the new sample type, `tape`. So the inferred arm type is a cell of `tape`s, which the dojo pretty-printer handles appropriately.
 
 In fact, `wet-copy` can take a Hoon value of any type you like.
 
 For another example, consider the following gate that switches the order of the head and tail of a cell:
 
-```
+```hoon
 > =switch |*([a=* b=*] [b a])
 
 > (switch 2 3)
@@ -155,9 +155,9 @@ For another example, consider the following gate that switches the order of the 
 [0b1101 0xbeef]
 ```
 
-Not only does `switch` reverse the order of the values, it also reverses their respective types, as desired.  The dry version of switch is not as useful:
+Not only does `switch` reverse the order of the values, it also reverses their respective types, as desired. The dry version of switch is not as useful:
 
-```
+```hoon
 > =dry-switch |=([a=* b=*] [b a])
 
 > (dry-switch "Hello" [11 22 33])
@@ -171,23 +171,23 @@ Even though both `switch` and `dry-switch` are polymorphic in the sense that eac
 
 But `switch` can't take just any input:
 
-```
+```hoon
 > (switch 11)
 -find.b
 ```
 
-It must take a cell, not an atom.  So it's certainly possible to write a wet gate that doesn't take all possible input types.
+It must take a cell, not an atom. So it's certainly possible to write a wet gate that doesn't take all possible input types.
 
-It is good practice to include a cast in all gates, even wet gates.  But in many cases the desired output type depends on the input type.  How can we cast appropriately?  Often we can cast by example, using the input values themselves.  For example, we can rewrite `switch` as:
+It is good practice to include a cast in all gates, even wet gates. But in many cases the desired output type depends on the input type. How can we cast appropriately? Often we can cast by example, using the input values themselves. For example, we can rewrite `switch` as:
 
-```
+```hoon
 > =switch |*([a=* b=*] ^+([b a] [b a]))
 
 > (switch "Hello" 0xbeef)
 [0xbeef "Hello"]
 ```
 
-As is the case with dry arms, there is a type-check associated with each wet arm.  Or, rather, there are potentially many checks for each wet arm, one for each wing in the code that resolves to a wet arm.  The product type of that arm is inferred at each call site, using the argument value type given at that site.  If the type inference doesn't go through -- e.g., if there is a cast that doesn't succeed relative to the call site argument value -- then the compile will crash with a `nest-fail`.  Otherwise the type check goes through with the inferred type of the wet arm at that call site.  So the product type of a wet gate can differ from one call site to another, as we saw with `switch` above.
+As is the case with dry arms, there is a type-check associated with each wet arm. Or, rather, there are potentially many checks for each wet arm, one for each wing in the code that resolves to a wet arm. The product type of that arm is inferred at each call site, using the argument value type given at that site. If the type inference doesn't go through -- e.g., if there is a cast that doesn't succeed relative to the call site argument value -- then the compile will crash with a `nest-fail`. Otherwise the type check goes through with the inferred type of the wet arm at that call site. So the product type of a wet gate can differ from one call site to another, as we saw with `switch` above.
 
 ### Parametric Polymorphism and `|$`
 
@@ -197,10 +197,10 @@ list of molds and produces a new mold. Here we take another look at this rune as
 an implementation of **parametric polymorphism** in Hoon.
 
 For example, we have `list`s, `tree`s, and `set`s in Hoon, which are each
-defined in `hoon.hoon` as wet gate mold builders.  Take a moment to see for
-yourself.  Each `++` arm is followed by `|$` and a list of labels for input
-types inside brackets `[ ]`.  After that subexpression comes another that
-defines a type that is parametrically polymorphic with respect to the input values.  For example, here is the definition of `list` from `hoon.hoon`:
+defined in `hoon.hoon` as wet gate mold builders. Take a moment to see for
+yourself. Each `++` arm is followed by `|$` and a list of labels for input
+types inside brackets `[ ]`. After that subexpression comes another that
+defines a type that is parametrically polymorphic with respect to the input values. For example, here is the definition of `list` from `hoon.hoon`:
 
 ```hoon
 ++  list
@@ -213,11 +213,11 @@ defines a type that is parametrically polymorphic with respect to the input valu
   $@(~ [i=item t=(list item)])
 ```
 
-The `|$` rune is especially useful for defining [containers](https://en.wikipedia.org/wiki/Container_%28abstract_data_type%29) of various kinds.  Indeed, `list`s, `tree`s, and `set`s are all examples of containers.  You can have a `(list @)`, a `(list ^)`, a `(list *)`, and so on.  Or a `(tree @)`, a `(tree ^)`, a `(tree *)`, etc.  And the same for `set`.
+The `|$` rune is especially useful for defining [containers](https://en.wikipedia.org/wiki/Container_%28abstract_data_type%29) of various kinds. Indeed, `list`s, `tree`s, and `set`s are all examples of containers. You can have a `(list @)`, a `(list ^)`, a `(list *)`, and so on. Or a `(tree @)`, a `(tree ^)`, a `(tree *)`, etc. And the same for `set`.
 
-One nice thing about containers defined by `|$` is that they nest in the expected way.  Intuitively a `(list @)` should nest under `(list *)`, because `@` nests under `*`.  And so it does:
+One nice thing about containers defined by `|$` is that they nest in the expected way. Intuitively a `(list @)` should nest under `(list *)`, because `@` nests under `*`. And so it does:
 
-```
+```hoon
 > =a `(list @)`~[11 22 33]
 
 > ^-((list *) a)
@@ -226,7 +226,7 @@ One nice thing about containers defined by `|$` is that they nest in the expecte
 
 Conversely, a `(list *)` should not nest under `(list @)`, because `*` does not nest under `@`:
 
-```
+```hoon
 > =b `(list *)`~[11 22 33]
 
 > ^-((list @) b)
@@ -235,7 +235,7 @@ nest-fail
 
 Let's clear the dojo subject by unbinding the faces we've used up to now in the lesson:
 
-```
+```hoon
 =a
 
 =b
@@ -251,9 +251,9 @@ Let's clear the dojo subject by unbinding the faces we've used up to now in the 
 
 ## Core Variance
 
-Let's say you want to write a function that takes a gate as one (or more) of its arguments.  It's not hard to imagine useful cases of this.  Consider `turn` from the Hoon standard library, which applies an arbitrary function to each item in a list and returns a modified list:
+Let's say you want to write a function that takes a gate as one (or more) of its arguments. It's not hard to imagine useful cases of this. Consider `turn` from the Hoon standard library, which applies an arbitrary function to each item in a list and returns a modified list:
 
-```
+```hoon
 > =b `(list @)`~[2 3 4 5]
 
 > (turn b |=(a=@ +(a)))
@@ -265,11 +265,11 @@ Let's say you want to write a function that takes a gate as one (or more) of its
 =b
 ```
 
-It's quite useful to be able to pass cores as arguments.  But let's think about how to write a function that accepts a core as input.  How do we define a sample so that it accepts a core?
+It's quite useful to be able to pass cores as arguments. But let's think about how to write a function that accepts a core as input. How do we define a sample so that it accepts a core?
 
-We _could_ define the sample by example -- i.e., with `$_`, or `_` for short -- using a core.  Consider the following, in which `mycore` is the example core and `apply` is  function that accepts gates:
+We _could_ define the sample by example -- i.e., with `$_`, or `_` for short -- using a core. Consider the following, in which `mycore` is the example core and `apply` is function that accepts gates:
 
-```
+```hoon
 > =mycore =>([12 13] |=(a=@ +(a)))
 
 > =apply |=([a=@ b=_mycore] (b a))
@@ -284,51 +284,51 @@ We _could_ define the sample by example -- i.e., with `$_`, or `_` for short -- 
 123
 ```
 
-This works, but in fact `apply` is a very brittle function.  It can only take as input a core whose payload is exactly like, or a subtype of, the payload of `mycore`:
+This works, but in fact `apply` is a very brittle function. It can only take as input a core whose payload is exactly like, or a subtype of, the payload of `mycore`:
 
-```
+```hoon
 > (apply 15 |=(a=@ (mul 2 a)))
 nest-fail
 ```
 
-A core created in one place of your code isn't likely to have the same payload as a core produced elsewhere, unless you intentionally define it so that it does.  This generally isn't practical, so we need another way to indicate that we want a core as input.
+A core created in one place of your code isn't likely to have the same payload as a core produced elsewhere, unless you intentionally define it so that it does. This generally isn't practical, so we need another way to indicate that we want a core as input.
 
-Why did the last example crash?  To understand this, you need to understand the the different variance properties a core can have.  These properties determine the nesting and type inference rules associated with each core.
+Why did the last example crash? To understand this, you need to understand the the different variance properties a core can have. These properties determine the nesting and type inference rules associated with each core.
 
 The basic question to be answered is: when does one core type nest under another?
 
-The battery nesting rules for dry cores are relatively straightforward, and they're the same for all cores, regardless of variance properties.  Let `A` and `B` be two cores.  The type of `B` nests under the type of `A` only if two conditions are met: (i) the batteries of `A` and `B` have exactly the same tree shape, and (ii) the product type of each `B` arm nests under the product type of the corresponding `A` arm.
+The battery nesting rules for dry cores are relatively straightforward, and they're the same for all cores, regardless of variance properties. Let `A` and `B` be two cores. The type of `B` nests under the type of `A` only if two conditions are met: (i) the batteries of `A` and `B` have exactly the same tree shape, and (ii) the product type of each `B` arm nests under the product type of the corresponding `A` arm.
 
-The payload types of `A` and `B` must also be checked.  Certain payload nesting rules apply to all cores, if `B` is to nest under `A`: (i) if `A` is wet then `B` must also be wet; (ii) the original payload type of `A` must mutually nest with the current payload type of `A` (i.e., these types nest under each other); and (iii) the current payload type of `B` must nest under the original payload type of `B`.
+The payload types of `A` and `B` must also be checked. Certain payload nesting rules apply to all cores, if `B` is to nest under `A`: (i) if `A` is wet then `B` must also be wet; (ii) the original payload type of `A` must mutually nest with the current payload type of `A` (i.e., these types nest under each other); and (iii) the current payload type of `B` must nest under the original payload type of `B`.
 
 ### The Four Kinds of Cores: Gold, Iron, Zinc, and Lead
 
 But there are different sets of nesting rules for finishing the payload type check, depending on the variance properties of the core.
 
-There are four kinds of cores: **gold** (invariant payload), **iron** (contravariant sample), **zinc** (covariant sample), and **lead** (bivariant sample).  Information about the kind of core is tracked by the Hoon type system.
+There are four kinds of cores: **gold** (invariant payload), **iron** (contravariant sample), **zinc** (covariant sample), and **lead** (bivariant sample). Information about the kind of core is tracked by the Hoon type system.
 
 Their nesting rules in brief:
 
-+ If `A` is a gold core, then core `B` nests under it only if `B` is gold and the payload of `B` doesn't vary in type from the payload of `A`.  The payload `B` is **invariant** (i.e., neither co- nor contravariant) relative to the payload of an `A` it nests under.  Gold cores have a read-write payload.
-+ If `A` is an iron core, then core `B` nests under it only if `B` is gold or iron and the sample of `A` nests under the sample of `B`.  Notice that the nesting direction of the samples is the opposite of the nesting direction of the cores.  I.e., the sample types are **contravariant** with respect to the iron core types.  Iron cores have a write-only sample and an opaque context. ("Opaque" means neither read nor write.)
-+ If `A` is a zinc core, then core `B` nests under it only if `B` is gold or zinc and the sample of `B` nests under the sample of `A`.  Notice that the nesting direction of the samples is the same as the nesting direction of the cores.  I.e., the sample types are **covariant** with respect to the zinc core types.  Zinc cores have a read-only sample and an opaque context.
-+ If `A` is a lead core, then core `B` nests under it without any additional payload check beyond those described in the previous section.  It trivially follows that the payload type both co- and contravaries with respect to the lead core types (hence lead cores are **bivariant**).  Lead cores have an opaque payload.
+- If `A` is a gold core, then core `B` nests under it only if `B` is gold and the payload of `B` doesn't vary in type from the payload of `A`. The payload `B` is **invariant** (i.e., neither co- nor contravariant) relative to the payload of an `A` it nests under. Gold cores have a read-write payload.
+- If `A` is an iron core, then core `B` nests under it only if `B` is gold or iron and the sample of `A` nests under the sample of `B`. Notice that the nesting direction of the samples is the opposite of the nesting direction of the cores. I.e., the sample types are **contravariant** with respect to the iron core types. Iron cores have a write-only sample and an opaque context. ("Opaque" means neither read nor write.)
+- If `A` is a zinc core, then core `B` nests under it only if `B` is gold or zinc and the sample of `B` nests under the sample of `A`. Notice that the nesting direction of the samples is the same as the nesting direction of the cores. I.e., the sample types are **covariant** with respect to the zinc core types. Zinc cores have a read-only sample and an opaque context.
+- If `A` is a lead core, then core `B` nests under it without any additional payload check beyond those described in the previous section. It trivially follows that the payload type both co- and contravaries with respect to the lead core types (hence lead cores are **bivariant**). Lead cores have an opaque payload.
 
 Let's go through each kind more carefully.
 
 #### Gold Cores (Invariant)
 
-By default, most cores are gold.  This includes the cores produced with the `|%`, `|=`, `|_`, and `|-` runes, among others.
+By default, most cores are gold. This includes the cores produced with the `|%`, `|=`, `|_`, and `|-` runes, among others.
 
-Assume that `A` is a gold core and that `B` is some other core.  The type of `B` nests under the type of `A` only if the original payload types of each mutually nest -- i.e., the original payload type of `A` nests under the original payload type of `B`, and _vice versa_.  Furthermore, only gold cores nest under other gold cores; so `B` must be gold to nest under `A`.
+Assume that `A` is a gold core and that `B` is some other core. The type of `B` nests under the type of `A` only if the original payload types of each mutually nest -- i.e., the original payload type of `A` nests under the original payload type of `B`, and _vice versa_. Furthermore, only gold cores nest under other gold cores; so `B` must be gold to nest under `A`.
 
-These payload nesting rules are the strictest ones for cores.  The payload type is neither covariant nor contravariant; when type-checking against a gold core, the target payload cannot vary at all in type.  Consequently, it is type-safe to modify every part of the payload: gold cores have a read-write payload.
+These payload nesting rules are the strictest ones for cores. The payload type is neither covariant nor contravariant; when type-checking against a gold core, the target payload cannot vary at all in type. Consequently, it is type-safe to modify every part of the payload: gold cores have a read-write payload.
 
-Usually it makes sense to cast for a gold core type when you're treating a core as a state machine.  The check ensures that the payload, which includes the relevant state, doesn't vary in type.  To see state machines that involve casts for gold cores, see Chapter 2 of the Hoon tutorial.
+Usually it makes sense to cast for a gold core type when you're treating a core as a state machine. The check ensures that the payload, which includes the relevant state, doesn't vary in type. To see state machines that involve casts for gold cores, see Chapter 2 of the Hoon tutorial.
 
 Let's look at simpler examples here, using the `^+` rune:
 
-```
+```hoon
 > ^+(|=(^ 15) |=(^ 16))
 < 1.xqz
   { {* *}
@@ -344,11 +344,11 @@ nest-fail
 nest-fail
 ```
 
-The first cast goes through because the right-hand gold core has the same sample type as the left-hand gold core.  The sample types mutually nest.  The second cast fails because the right-hand sample type is more specific than the left-hand sample type.  (Not all cells, `^`, are pairs of atoms, `[@ @]`.)  And the third cast fails because the right-hand sample type is broader than the left-hand sample type. (Not all nouns, `*`, are cells, `^`.)
+The first cast goes through because the right-hand gold core has the same sample type as the left-hand gold core. The sample types mutually nest. The second cast fails because the right-hand sample type is more specific than the left-hand sample type. (Not all cells, `^`, are pairs of atoms, `[@ @]`.) And the third cast fails because the right-hand sample type is broader than the left-hand sample type. (Not all nouns, `*`, are cells, `^`.)
 
 Two more examples:
 
-```
+```hoon
 > ^+(=>([1 2] |=(@ 15)) =>([123 456] |=(@ 16)))
 <1.xqz {@ @ud @ud}>
 
@@ -356,15 +356,15 @@ Two more examples:
 nest-fail
 ```
 
-In these examples, the `=>` rune is used to give each core a simple context.  The context of the left-hand core in each case is a pair of atoms, `[@ @]`.  The first cast goes through because the right-hand core also has a pair of atoms as its context.  The second cast fails because the right-hand core has the wrong type of context -- three atoms, `[@ @ @]`.
+In these examples, the `=>` rune is used to give each core a simple context. The context of the left-hand core in each case is a pair of atoms, `[@ @]`. The first cast goes through because the right-hand core also has a pair of atoms as its context. The second cast fails because the right-hand core has the wrong type of context -- three atoms, `[@ @ @]`.
 
 #### Iron Cores (Contravariant)
 
-Assume that `A` is an iron core and `B` is some other core.  The type of `B` nests under the type of `A` only if the original sample type of `A` nests under the original sample type of `B`.  That is, `B`'s sample type must be equivalent or more general than the sample type of `A`.  Furthermore, `B` must be either iron or gold to nest under `A`.
+Assume that `A` is an iron core and `B` is some other core. The type of `B` nests under the type of `A` only if the original sample type of `A` nests under the original sample type of `B`. That is, `B`'s sample type must be equivalent or more general than the sample type of `A`. Furthermore, `B` must be either iron or gold to nest under `A`.
 
-The context type of `B` isn't checked at all; and because of the nesting rules it isn't type-safe to do type-inference on the sample of an iron gate.  Thus, there are certain restrictions on iron cores that preserve type safety: (i) the context of an iron core is opaque, meaning that it cannot be written-to or read-from; and (ii) the iron core payload is write-only.
+The context type of `B` isn't checked at all; and because of the nesting rules it isn't type-safe to do type-inference on the sample of an iron gate. Thus, there are certain restrictions on iron cores that preserve type safety: (i) the context of an iron core is opaque, meaning that it cannot be written-to or read-from; and (ii) the iron core payload is write-only.
 
-Iron gates are particularly useful when you want to pass gates (having various payload types) to other gates.  We can illustrate this use with a very simple example.  Save the following as `gatepass.hoon` in the `gen` directory of your urbit's pier:
+Iron gates are particularly useful when you want to pass gates (having various payload types) to other gates. We can illustrate this use with a very simple example. Save the following as `gatepass.hoon` in the `gen` directory of your urbit's pier:
 
 ```hoon
 |=  a=_^|(|=(@ 15))
@@ -373,11 +373,11 @@ Iron gates are particularly useful when you want to pass gates (having various p
 (add b 20)
 ```
 
-This generator is mostly very simple.  Everything about it should be clear except possibly the first line.
+This generator is mostly very simple. Everything about it should be clear except possibly the first line.
 
-The first line defines the sample as an iron gate and gives it the face `a`.  The function as a whole is for taking some gate as input, calling it by passing it the value `10`, adding `20` to it, and returning the result.  Let's try it out in the dojo:
+The first line defines the sample as an iron gate and gives it the face `a`. The function as a whole is for taking some gate as input, calling it by passing it the value `10`, adding `20` to it, and returning the result. Let's try it out in the dojo:
 
-```
+```hoon
 > +gatepass |=(a=@ +(a))
 31
 
@@ -388,16 +388,16 @@ The first line defines the sample as an iron gate and gives it the face `a`.  Th
 50
 ```
 
-But we still haven't fully explained the first line of the code.  What does `_^|(|=(@ 15))` mean?  The inside portion is clear enough -- `|=(@ 15)` produces a normal (i.e., gold) gate that takes an atom and returns `15`.  The `^|` rune is used to turn gold gates to iron.  (Reverse alchemy!)  And the `_` character turns that iron gate value into a structure, i.e. a type.  So the whole subexpression means, roughly: "the same type as an iron gate whose sample is an atom, `@`, and whose product is another atom, `@`".  The context isn't checked at all.  This is good, because that allows us to accept gates defined and produced in drastically different environments.  Let's try passing a gate with a different context:
+But we still haven't fully explained the first line of the code. What does `_^|(|=(@ 15))` mean? The inside portion is clear enough -- `|=(@ 15)` produces a normal (i.e., gold) gate that takes an atom and returns `15`. The `^|` rune is used to turn gold gates to iron. (Reverse alchemy!) And the `_` character turns that iron gate value into a structure, i.e. a type. So the whole subexpression means, roughly: "the same type as an iron gate whose sample is an atom, `@`, and whose product is another atom, `@`". The context isn't checked at all. This is good, because that allows us to accept gates defined and produced in drastically different environments. Let's try passing a gate with a different context:
 
-```
+```hoon
 > +gatepass =>([22 33] |=(a=@ +(a)))
 31
 ```
 
-Yup, it still works.  You can't do that with a gold core sample!
+Yup, it still works. You can't do that with a gold core sample!
 
-There's a simpler way to define an iron sample.  Revise the first line of `gatepass.hoon` to the following:
+There's a simpler way to define an iron sample. Revise the first line of `gatepass.hoon` to the following:
 
 ```hoon
 |=  a=$-(@ @)
@@ -406,19 +406,19 @@ There's a simpler way to define an iron sample.  Revise the first line of `gatep
 (add b 20)
 ```
 
-If you test it you'll find that the generator behaves the same as it did before the edits.  The `$-` rune is used to create an iron gate structure, i.e., an iron gate type.  The first expression defines the desired sample type, and the second subexpression defines the gate's desired output type.
+If you test it you'll find that the generator behaves the same as it did before the edits. The `$-` rune is used to create an iron gate structure, i.e., an iron gate type. The first expression defines the desired sample type, and the second subexpression defines the gate's desired output type.
 
-The sample type of an iron gate is contravariant.  This means that, when doing a cast with some iron gate, the desired gate must have either the same sample type or a superset.
+The sample type of an iron gate is contravariant. This means that, when doing a cast with some iron gate, the desired gate must have either the same sample type or a superset.
 
 Why is this a useful nesting rule for passing gates?
 
-Let's say you're writing a function `F` that takes as input some gate `G`. Let's also say you want `G` to be able to take as input any **mammal**.  The code of `F` is going to pass arbitrary **mammals** to `G`, so that `G` needs to know how to handle all **mammals** correctly. You can't pass `F` a gate that only takes **dogs** as input, because `F` might call it with a **cat**. But `F` can accept a gate that takes all **animals** as input, because a gate that can handle any **animal** can handle **any mammal**.
+Let's say you're writing a function `F` that takes as input some gate `G`. Let's also say you want `G` to be able to take as input any **mammal**. The code of `F` is going to pass arbitrary **mammals** to `G`, so that `G` needs to know how to handle all **mammals** correctly. You can't pass `F` a gate that only takes **dogs** as input, because `F` might call it with a **cat**. But `F` can accept a gate that takes all **animals** as input, because a gate that can handle any **animal** can handle **any mammal**.
 
-Iron cores are designed precisely with this purpose in mind.  The reason that the sample is write-only is that we want to be able to assume, within function `F`, that the sample of `G` is a **mammal**.  But that might not be true when `G` is first passed into `F` -- the default value of `G` could be another **animal**, say, a **lizard**.  So we restrict looking into the sample of `G` by making the sample write-only.  The illusion is maintained and type safety secured.
+Iron cores are designed precisely with this purpose in mind. The reason that the sample is write-only is that we want to be able to assume, within function `F`, that the sample of `G` is a **mammal**. But that might not be true when `G` is first passed into `F` -- the default value of `G` could be another **animal**, say, a **lizard**. So we restrict looking into the sample of `G` by making the sample write-only. The illusion is maintained and type safety secured.
 
 Let's illustrate iron core nesting properties:
 
-```
+```hoon
 > ^+(^|(|=(^ 15)) |=(^ 16))
 < 1|xqz
   { {* *}
@@ -441,13 +441,13 @@ nest-fail
 
 (As before, we use the `^|` rune to turn gold gates iron.)
 
-The first cast goes through because the two gates have the same sample type.  The second cast fails because the right-hand gate has a more specific sample type than the left-hand gate does.  If you're casting for a gate that accepts any cell, `^`, it's because we want to be able to pass any cell to it.  A gate that is only designed for pairs of atoms, `[@ @]`, can't handle all such cases, naturally.  The third cast goes through because the right-hand gate sample type is broader than the left-hand gate sample type.  A gate that can take any noun as its sample, `*`, works just fine if we choose only to pass it cells, `^`.
+The first cast goes through because the two gates have the same sample type. The second cast fails because the right-hand gate has a more specific sample type than the left-hand gate does. If you're casting for a gate that accepts any cell, `^`, it's because we want to be able to pass any cell to it. A gate that is only designed for pairs of atoms, `[@ @]`, can't handle all such cases, naturally. The third cast goes through because the right-hand gate sample type is broader than the left-hand gate sample type. A gate that can take any noun as its sample, `*`, works just fine if we choose only to pass it cells, `^`.
 
-We mentioned previously that an iron core has a write-only sample and an opaque core.  Let's prove it.
+We mentioned previously that an iron core has a write-only sample and an opaque core. Let's prove it.
 
 Let's define a trivial gate with a context of `[g=22 h=44 .]`, convert it to iron with `^|`, and bind it to `iron-gate` in the dojo:
 
-```
+```hoon
 > =iron-gate ^|  =>([g=22 h=44 .] |=(a=@ (add a g)))
 
 > (iron-gate 10)
@@ -457,37 +457,37 @@ Let's define a trivial gate with a context of `[g=22 h=44 .]`, convert it to iro
 33
 ```
 
-Not a complicated function, but it serves our purposes.  Normally (i.e., with gold cores) we can look at a context value `p` of some gate `q` with a wing expression: `p.q`.  Not so with the iron gate:
+Not a complicated function, but it serves our purposes. Normally (i.e., with gold cores) we can look at a context value `p` of some gate `q` with a wing expression: `p.q`. Not so with the iron gate:
 
-```
+```hoon
 > g.iron-gate
 -find.g.iron-gate
 ```
 
-And usually we can look at the sample value using the face given in the gate definition.  Not in this case:
+And usually we can look at the sample value using the face given in the gate definition. Not in this case:
 
-```
+```hoon
 > a.iron-gate
 -find.a.iron-gate
 ```
 
 If you really want to look at the sample you can check `+6` of `iron-gate`:
 
-```
+```hoon
 > +6.iron-gate
 0
 ```
 
 ...and if you really want to look at the head of the context (i.e., where `g` is located, `+14`) you can:
 
-```
+```hoon
 > +14.iron-gate
 22
 ```
 
 ...but in both cases all the relevant type information has been thrown away:
 
-```
+```hoon
 > -:!>(+6.iron-gate)
 #t/*
 
@@ -497,7 +497,7 @@ If you really want to look at the sample you can check `+6` of `iron-gate`:
 
 Let's clear up the dojo subject by unbinding `iron-gate`:
 
-```
+```hoon
 =iron-gate
 ```
 
@@ -505,13 +505,13 @@ Let's clear up the dojo subject by unbinding `iron-gate`:
 
 Zinc cores are mirror versions of iron cores.
 
-Assume that `A` is a zinc core and `B` is some other core.  The type of `B` nests under the type of `A` only if the original sample type of `B` nests under the original sample type of `A`.  That is, the target core sample type must be equivalent or a subset of the cast core sample type.  Furthermore, `B` must be either zinc or gold to nest under `A`.
+Assume that `A` is a zinc core and `B` is some other core. The type of `B` nests under the type of `A` only if the original sample type of `B` nests under the original sample type of `A`. That is, the target core sample type must be equivalent or a subset of the cast core sample type. Furthermore, `B` must be either zinc or gold to nest under `A`.
 
-As with iron cores, the context of zinc cores is opaque -- they cannot be written-to or read-from.  The sample of a zinc core is read-only.  That means, among other things, that zinc cores cannot be used for function calls.  Function calls in Hoon involve a change to the sample (the default sample is replaced with the argument value), which is disallowed as type-unsafe for zinc cores.
+As with iron cores, the context of zinc cores is opaque -- they cannot be written-to or read-from. The sample of a zinc core is read-only. That means, among other things, that zinc cores cannot be used for function calls. Function calls in Hoon involve a change to the sample (the default sample is replaced with the argument value), which is disallowed as type-unsafe for zinc cores.
 
-We can illustrate the casting properties of zinc cores with a few examples.  The `^&` rune is used to convert gold cores to zinc:
+We can illustrate the casting properties of zinc cores with a few examples. The `^&` rune is used to convert gold cores to zinc:
 
-```
+```hoon
 > ^+(^&(|=(^ 15)) |=(^ 16))
 < 1&xqz
   { {* *}
@@ -532,11 +532,11 @@ We can illustrate the casting properties of zinc cores with a few examples.  The
 nest-fail
 ```
 
-The first two casts succeed because the right-hand core sample type is either the same or a subset of the left-hand core sample type.  The last one fails because the right-hand sample type is a superset.
+The first two casts succeed because the right-hand core sample type is either the same or a subset of the left-hand core sample type. The last one fails because the right-hand sample type is a superset.
 
-Even though you can't function call a zinc core, the arms of a zinc core can be computed and the sample can be read.  Let's test this with a zinc gate of our own:
+Even though you can't function call a zinc core, the arms of a zinc core can be computed and the sample can be read. Let's test this with a zinc gate of our own:
 
-```
+```hoon
 > =zinc-gate ^&  |=(a=_22 (add 10 a))
 
 > (zinc-gate 12)
@@ -551,19 +551,19 @@ payload-block
 
 Let's clear up the dojo subject again:
 
-```
+```hoon
 > =zinc-gate
 ```
 
 #### Lead Cores (Bivariant)
 
-Lead cores have more permissive nesting rules than either iron or zinc cores.  There is no restriction on which payload types nest.  That means, among other things, that the payload type of a lead core is both covariant and contravariant ('bivariant').
+Lead cores have more permissive nesting rules than either iron or zinc cores. There is no restriction on which payload types nest. That means, among other things, that the payload type of a lead core is both covariant and contravariant ('bivariant').
 
-In order to preserve type safety when working with lead cores, a severe restriction is needed.  The whole payload of a lead core is opaque -- the payload can neither be written-to or read-from.  For this reason, as was the case with zinc cores, lead cores cannot be called as functions.
+In order to preserve type safety when working with lead cores, a severe restriction is needed. The whole payload of a lead core is opaque -- the payload can neither be written-to or read-from. For this reason, as was the case with zinc cores, lead cores cannot be called as functions.
 
-The arms of a lead core can still be evaluated, however.  We can use the `^?` rune to convert a gold, iron, or zinc core to lead:
+The arms of a lead core can still be evaluated, however. We can use the `^?` rune to convert a gold, iron, or zinc core to lead:
 
-```
+```hoon
 > =lead-gate ^?  |=(a=_22 (add 10 a))
 
 > $.lead-gate
@@ -572,13 +572,13 @@ The arms of a lead core can still be evaluated, however.  We can use the `^?` ru
 
 But don't try to read the sample:
 
-```
+```hoon
 > a.lead-gate
 -find.a.lead-gate
 ```
 
 Once more let's clear up the dojo subject:
 
-```
+```hoon
 =lead-gate
 ```


### PR DESCRIPTION
I spent the whole weekend reading through the Hoon School docs to learn Hoon. I initially thought that code blocks that showed Dojo I/O was voluntarily not highlighted, but ended finding a few instances where it was and it helped identifying runes, terms, auras, etc.

This PR adds Hoon syntax highlighting to some actual Hoon code where it was missing, as well as to Dojo I/O code blocks making it easier to read it, especially early on as you're getting familiar with the syntax.