### PR TITLE
Minor tweaks to graph store documentation

### DIFF
--- a/userspace/_index.md
+++ b/userspace/_index.md
@@ -23,3 +23,8 @@ Resources on the flagship web client Landcape, through which most users interact
 ## [Threads](@/docs/userspace/threads/_index.md)
 
 Resources on threads - monadic functions useful for complex IO.
+
+## [Graph Store](@/docs/userspace/graph-store/_index.md)
+
+Resources on Graph Store, a non-relational database specialized for social media applications.
+

--- a/userspace/graph-store/advanced-info.md
+++ b/userspace/graph-store/advanced-info.md
@@ -54,7 +54,7 @@ Right now, the only thing that `transform-add-nodes` is used for is to replace u
 
 Here is a stubbed out example of a `transform-add-nodes` to show its inputs and outputs:
 
-```
+```hoon
 |=  [=index =post =atom was-parent-modified=?]
 ^-  [^index ^post]
 !!

--- a/userspace/graph-store/data-structure-overview.md
+++ b/userspace/graph-store/data-structure-overview.md
@@ -11,7 +11,7 @@ Let's go through the type definitions of some of the most used types when workin
 
 ## Post
 Here's `sur/post.hoon`
-```
+```hoon
 +$  index       (list atom)
 +$  uid         [=resource =index]
 ::
@@ -55,7 +55,7 @@ Here's `sur/post.hoon`
 
 
 ### Index
-```
+```hoon
 +$  index       (list atom)
 +$  uid         [=resource =index]
 ```
@@ -67,7 +67,7 @@ Here's `sur/post.hoon`
 An index fragment is not an explicitly defined type, but since an index is `(list atom)`, it follows that the type of an index fragment is `atom`. This is what gives the developer the flexibility to use more than just numbers in an index: any type that is representable as an atom can be used in the index.
 
 ### Hashing (Part 1)
-```
+```hoon
 ::  +sham (half sha-256) hash of +validated-portion
 +$  hash  @ux
 ::
@@ -78,7 +78,7 @@ An index fragment is not an explicitly defined type, but since an index is `(lis
 These types are used to cryptographically sign a given post, so that the host of some content cannot act as an imposter, and post content impersonating as someone else. `signature` represents a triple of signed message of hash, author, and author's life at time of posting. These can be used to cryptographically attest to a message. The implementation is a form of asymmetric/public-key encryption, where `q` and `r` are data necessary to look up a ship's public key on azimuth, which can be used to verify the validity of the message.
 
 ### Content Types
-```
+```hoon
 +$  reference
   $%  [%graph group=resource =uid]
       [%group group=resource]
@@ -107,7 +107,7 @@ These types are used to cryptographically sign a given post, so that the host of
 Currently, these are the only content types supported by Graph Store.
 
 ### Post
-```
+```hoon
 +$  post
   $:  author=ship
       =index
@@ -125,7 +125,7 @@ Post is a fundamental type that represents what we normally think of as a post o
 An `indexed-post` is a post with an associated index fragment that can be used to validate a post's index with an index fragment that is expected at the end of the index list.
 
 ### Hashing (Part 2)
-```
+```hoon
 +$  validated-portion
   $:  parent-hash=(unit hash)
       author=ship
@@ -142,7 +142,7 @@ The parts of a `post` that are actually hashed to obtain a value of type the ear
 
 Here's `sur/graph-store.hoon`
 
-```
+```hoon
 +$  graph         ((mop atom node) gth)
 +$  marked-graph  [p=graph q=(unit mark)]
 ::
@@ -215,7 +215,7 @@ Here's `sur/graph-store.hoon`
 ```
 
 ### Graph, Node, and Related Objects
-```
+```hoon
 +$  graph         ((mop atom node) gth)
 +$  marked-graph  [p=graph q=(unit mark)]
 ::
@@ -261,14 +261,14 @@ Here are some helpful Wikipedia pages for more info on what this data type repre
 
 ### Tag Queries
 
-```
+```hoon
 +$  tag-queries   (jug term resource)
 ```
 
 `tag-queries` is a mapping where the keys are `term`s and the values are a `set` of `resource`s (this pattern is called a `jug`). It is a simple tagging system that allows for various ad-hoc collections, similar to filesystem tags being used to sort different files/folders. While the type's name is `tag-queries`, there is no complex querying system as of now. Currently, you can add term/resources pairs into the tag queries, get a list of all terms in tag-queries, and get the whole `jug` out of Graph Store.
 
 ### Update (Part 1)
-```
+```hoon
 +$  update  [p=time q=action]
 ::
 +$  logged-action
@@ -304,7 +304,7 @@ The `update` type is what is used to interact with Graph Store. It is used both 
 If you want to check out a relevant code listing to see how graph store handles these pokes, check out the `graph-update` arm in the poke handler at [`app/graph-store.hoon`](https://github.com/urbit/urbit/blob/e2ad6e3e9219c8bfad62f27f05c7cac94c9effa8/pkg/arvo/app/graph-store.hoon#L221-L227)
 
 ### Update (Part 2)
-```
+```hoon
 +$  update-log    ((mop time logged-update) gth)
 +$  update-logs   (map resource update-log)
 ::
@@ -320,7 +320,7 @@ It is important to note that the source of truth is actually the `update-logs`, 
 The reason for having the main CRUD actions being `logged-update`s is so that Graph Store knows which order to process the log entries in when it is rebuilding its current state. The time associated with the `logged-update` is a way of specifying the canonical order to process operations. All other actions that aren't part of logged-update stand on their own and don't need a timestamp in order to properly apply them.
 
 ### Permissions
-```
+```hoon
 +$  permissions
   [admin=permission-level writer=permission-level reader=permission-level]
 ::

--- a/userspace/graph-store/validator-walkthrough.md
+++ b/userspace/graph-store/validator-walkthrough.md
@@ -33,7 +33,7 @@ The graph represents a chat channel and contains all chat messages in order. A c
 
 Here's the definition of the schema in the chat validator mark:
 File: [`mar/graph/validator/chat.hoon`](https://github.com/urbit/urbit/blob/fbd85abf4e41d580654606a6defb764f6a97256d/pkg/arvo/mar/graph/validator/chat.hoon#L33-L40)
-```
+```hoon
 ++  grab
   |%
   ++  noun
@@ -77,7 +77,7 @@ For example, it wouldn't make sense to give readers `%self`, because they do not
 Let's see how this permissioning system is implemented in the validator code.
 
 Here is the `grow` arm of [`mar/validator/chat.hoon`](https://github.com/urbit/urbit/blob/fbd85abf4e41d580654606a6defb764f6a97256d/pkg/arvo/mar/graph/validator/chat.hoon#L7-L20)
-```
+```hoon
 |_  i=indexed-post              :: A
 ++  grow
   |%
@@ -132,7 +132,7 @@ The comments section holds all individual comment nodes, but comments are not si
 
 
 Here's the validator, located at [`mar/graph/validator/link.hoon`](https://github.com/urbit/urbit/blob/fbd85abf4e41d580654606a6defb764f6a97256d/pkg/arvo/mar/graph/validator/link.hoon#L49-L73):
-```
+```hoon
 ++  grab
   |%
   ++  noun
@@ -200,7 +200,7 @@ Let's analyze the permissions structure.
 
 Here's how it is implemented [(source)](https://github.com/urbit/urbit/blob/master/pkg/arvo/mar/graph/validator/link.hoon#L2-L27):
 
-```
+```hoon
 |_  i=indexed-post
 ++  grow
   |%
@@ -287,7 +287,7 @@ Here's how it is implemented [(source)](https://github.com/urbit/urbit/blob/mast
 Here, a notebook, which is a collection of blog posts (called notes), is represented by the root graph. All data associated with the blog post is represented by the top level node, which is the note itself along with the associated comments. One level deeper, we see two container structures. The first one is the post revision container; it holds the edit history of your blog post. Every child node of this corresponds to the actual title and text of your blog post. The second one is the comments container. This represents the comment section of your blog post. Every child node of this is not a comment, but a comment revision container, which, as before, contains the edit history of your comment.
 
 Here's its validator, located at [`mar/graph/validator.hoon`](https://github.com/urbit/urbit/blob/master/pkg/arvo/mar/graph/validator/publish.hoon#L56-L97)
-```
+```hoon
   ++  noun
     |=  p=*                            :: 1
     =/  ip  ;;(indexed-post p)         :: 2
@@ -380,7 +380,7 @@ Let's take a look at the permissioning structure for Publish.
 
 [(source)](https://github.com/urbit/urbit/blob/fbd85abf4e41d580654606a6defb764f6a97256d/pkg/arvo/mar/graph/validator/publish.hoon#L6-L24)
 
-```
+```hoon
 |_  i=indexed-post
 ++  grow
   |%


### PR DESCRIPTION
- Added `hoon` to code blocks for syntax highlighting
- Added reference to Graph Store docs in userspace `_index.md` (fixes https://github.com/urbit/urbit/issues/4761)