### PR TITLE
add page on life and rift

### DIFF
--- a/azimuth/_index.md
+++ b/azimuth/_index.md
@@ -11,6 +11,11 @@ insert_anchor_links = "right"
 
 An overview of the Ethereum-based public key infrastructure utilized by Urbit.
 
+## [Life and Rift](@/docs/azimuth/azimuth.md)
+
+An explanation of how Azimuth keeps track of the most recent set of networking
+keys necessary to communicate with a ship.
+
 ## [Advanced Azimuth Tools](@/docs/azimuth/advanced-azimuth-tools.md)
 
 Expert-level tooling for generating, signing, and sending Azimuth-related

--- a/azimuth/advanced-azimuth-tools.md
+++ b/azimuth/advanced-azimuth-tools.md
@@ -1,6 +1,6 @@
 +++
 title = "Advanced Azimuth Tools"
-weight = 3
+weight = 4
 template = "doc.html"
 +++
 

--- a/azimuth/life-and-rift.md
+++ b/azimuth/life-and-rift.md
@@ -10,16 +10,17 @@ and _rift_. This numbering system partition messages according to the quantity
 of networking key changes and quantity of
 [breaches](@/using/id/guide-to-breaches.md), respectively. This is explained in
 more detail below. These values are utilized by [Ames](@/docs/arvo/ames/ames.md)
-and [Jael](@/docs/arvo/jael/jael-api.md) to ensure that you are communicating
-with a ship using its most recent set of keys.
+and [Jael](@/docs/arvo/jael/jael-api.md) to ensure that communication between
+ships is always done with the most recent set of networking keys, and that
+networking state is appropriately reset when a breach has occurred.
 
 Before it has been spawned, every ship begin with a `life` and `rift` of 0. For
 galaxies, stars, and planets, these values are stored in the Azimuth PKI, while
 for moons, these values are stored by their parent. Comets cannot change their
 networking keys, nor can they breach, and so their `life` and `rift` are always 0.
 
-You can check your current life and rift number by running the `+keys our`
-generator in dojo. You can inspect another ship's life and rift by running
+You can check your current `life` and `rift` number by running the `+keys our`
+generator in dojo. You can inspect another ship's `life` and `rift` by running
 `+keys ~sampel-palnet`.
 
 ## Life

--- a/azimuth/life-and-rift.md
+++ b/azimuth/life-and-rift.md
@@ -14,7 +14,7 @@ and [Jael](@/docs/arvo/jael/jael-api.md) to ensure that communication between
 ships is always done with the most recent set of networking keys, and that
 networking state is appropriately reset when a breach has occurred.
 
-Before it has been spawned, every ship begin with a `life` and `rift` of 0. For
+Every ship begins with a `life` and `rift` of 0. For
 galaxies, stars, and planets, these values are stored in the Azimuth PKI, while
 for moons, these values are stored by their parent. Comets cannot change their
 networking keys, nor can they breach, and so their `life` and `rift` are always 0.

--- a/azimuth/life-and-rift.md
+++ b/azimuth/life-and-rift.md
@@ -26,8 +26,8 @@ generator in dojo. You can inspect another ship's `life` and `rift` by running
 ## Life
 
 A ship's `life`, or _key revision number_, is a count of the number of times which
-a ship's networking keys have been altered. The initial value of the keys is
-always 0, and the initial `life` is always 0.
+a ship's networking keys have been altered. The initial value of each key is
+always zero, and the initial `life` is always 0.
 
 Thus, setting the keys of a ship to a nonzero value for the first time will
 increment the `life` from 0 to 1. Rotating to a new set of keys will then
@@ -36,29 +36,24 @@ increment the `life` to 2. Setting the keys back to zero would increment the
 
 ## Rift
 
-A ship's `rift`, or _continuity number_, is a count of the number of times which
-a ship has breached after its networking keys have been set.
+A ship's `rift`, or _continuity number_, is a count of the number of times that
+a ship has breached, also known as broken continuity.
 
-In other words, a ship's `rift` will remain at 0 until its the first time it is
-breached after its `life` has been incremented for the first time. Spawning a
-ship has no effect on `rift`, and neither does breaching it, until its
-networking keys have been set to a non-zero value for the first time.
+In other words, a ship's `rift` will remain at 0 until the first time it is
+breached.
 
-Networking breaches do not affect the `rift` of any ship. They are only used to
+Network-wide breaches do not affect the `rift` of any ship. They are only used to
 count the number of personal breaches.
 
 ## Edge cases
 
 Configuring the keys to the same value they already were (i.e. a no-op) is
 possible, but has no effect on the `life`. Thus `life` is actually a measure of
-networking key _alterations_, and not the number of times they've been set.
+networking key _revisions_, and not the number of times they've been set.
 
 Thus under ordinary circumstances, a breach will increment both `life` and
 `rift` since a breach typically also involves changing the networking keys.
-However, it is possible to breach without changing the networking keys. As a
-breach resets networking keys to 0 unless new keys were specified, if the
-networking keys were already 0 then they have not changed, and so `rift` will
-increment but `life` will not. This is just a special case of breaching while
-maintaining the same networking keys. That is to say, if the new keys specified
-as part of a breach as the same as the old, again `rift` will increment while
+However, it is possible to breach without changing the networking keys.
+If the new keys specified
+as part of a breach are the same as the old, `rift` will increment while
 `life` will not.

--- a/azimuth/life-and-rift.md
+++ b/azimuth/life-and-rift.md
@@ -1,0 +1,63 @@
++++
+title = "Life and Rift"
+weight = 3
+template = "doc.html"
+aliases = ["/docs/learn/azimuth"]
++++
+
+Associated to every Azimuth point are two non-negative integers known as _life_
+and _rift_. This numbering system partition messages according to the quantity
+of networking key changes and quantity of
+[breaches](@/using/id/guide-to-breaches.md), respectively. This is explained in
+more detail below. These values are utilized by [Ames](@/docs/arvo/ames/ames.md)
+and [Jael](@/docs/arvo/jael/jael-api.md) to ensure that you are communicating
+with a ship using its most recent set of keys.
+
+Before it has been spawned, every ship begin with a `life` and `rift` of 0. For
+galaxies, stars, and planets, these values are stored in the Azimuth PKI, while
+for moons, these values are stored by their parent. Comets cannot change their
+networking keys, nor can they breach, and so their `life` and `rift` are always 0.
+
+You can check your current life and rift number by running the `+keys our`
+generator in dojo. You can inspect another ship's life and rift by running
+`+keys ~sampel-palnet`.
+
+## Life
+
+A ship's `life`, or _key revision number_, is a count of the number of times which
+a ship's networking keys have been altered. The initial value of the keys is
+always 0, and the initial `life` is always 0.
+
+Thus, setting the keys of a ship to a nonzero value for the first time will
+increment the `life` from 0 to 1. Rotating to a new set of keys will then
+increment the `life` to 2. Setting the keys back to zero would increment the
+`life` once more, to 3.
+
+## Rift
+
+A ship's `rift`, or _continuity number_, is a count of the number of times which
+a ship has breached after its networking keys have been set.
+
+In other words, a ship's `rift` will remain at 0 until its the first time it is
+breached after its `life` has been incremented for the first time. Spawning a
+ship has no effect on `rift`, and neither does breaching it, until its
+networking keys have been set to a non-zero value for the first time.
+
+Networking breaches do not affect the `rift` of any ship. They are only used to
+count the number of personal breaches.
+
+## Edge cases
+
+Configuring the keys to the same value they already were (i.e. a no-op) is
+possible, but has no effect on the `life`. Thus `life` is actually a measure of
+networking key _alterations_, and not the number of times they've been set.
+
+Thus under ordinary circumstances, a breach will increment both `life` and
+`rift` since a breach typically also involves changing the networking keys.
+However, it is possible to breach without changing the networking keys. As a
+breach resets networking keys to 0 unless new keys were specified, if the
+networking keys were already 0 then they have not changed, and so `rift` will
+increment but `life` will not. This is just a special case of breaching while
+maintaining the same networking keys. That is to say, if the new keys specified
+as part of a breach as the same as the old, again `rift` will increment while
+`life` will not.

--- a/glossary/breach.md
+++ b/glossary/breach.md
@@ -6,27 +6,22 @@ category = "arvo"
 +++
 
 Continuity on the [Ames](../ames) network occasionally needs to be broken at
-this early stage in order to correct a networking error or make major changes to
-Arvo. These infrequent events are known as
-**breaches** which either cause an individual ship to forget its network message
-history, called a **personal breach**, or cause the entire network to forget its
-history, called a **network breach**.
+this early stage in order to correct a networking error or to make major changes
+to Arvo. These infrequent events are known as **breaches** which either cause an
+individual ship to forget its network message history, called a **personal
+breach**, or cause the entire network to forget its history, called a **network
+breach**. 
 
 Personal breaches are always initiated by the user, frequently in response to a
 connectivity error. The easiest way to do this is with [Bridge](../bridge).
-There are two types of personal breaches: changing private keys, and changing
-the Urbit ID ownership address. Each one increments the _life_ number of the ship by one, which is
-an integer that represents how many personal breaches have been performed on
-that ship. Transferring the ID to a new address will also increase the _rift_
-number of the ship in addition to the life number.
-
-You can check your life and rift number by typing `+keys our`
-into dojo and pressing Enter.
+There are two types of personal breaches: changing networking keys, and changing
+the Urbit ID ownership address.
 
 Network breaches happen when a major Arvo revision that cannot be implemented
-via an [OTA update](../ota-updates) occurs. When this happens, a new binary
-will need to be downloaded, and your ship's [pier](../pier) needs to be moved to the
-directory containing the new binary.
+via an [OTA update](../ota-updates) occurs. When this happens, a new binary will
+need to be downloaded, and your ship's [pier](../pier) needs to be moved to the
+directory containing the new binary. The most recent network breach occurred in
+December 2020, and we expect it to be the final one.
 
 ### Further Reading
 

--- a/glossary/breach.md
+++ b/glossary/breach.md
@@ -7,21 +7,19 @@ category = "arvo"
 
 Continuity on the [Ames](../ames) network occasionally needs to be broken at
 this early stage in order to correct a networking error or to make major changes
-to Arvo. These infrequent events are known as **breaches** which either cause an
-individual ship to forget its network message history, called a **personal
-breach**, or cause the entire network to forget its history, called a **network
-breach**. 
+to [Arvo](../arvo). These infrequent events are known as **breaches**, which cause an
+individual ship to forget its network message history.
 
-Personal breaches are always initiated by the user, frequently in response to a
+Breaches are always initiated by the user, frequently in response to a
 connectivity error. The easiest way to do this is with [Bridge](../bridge).
 There are two types of personal breaches: changing networking keys, and changing
 the Urbit ID ownership address.
 
-Network breaches happen when a major Arvo revision that cannot be implemented
-via an [OTA update](../ota-updates) occurs. When this happens, a new binary will
-need to be downloaded, and your ship's [pier](../pier) needs to be moved to the
-directory containing the new binary. The most recent network breach occurred in
-December 2020, and we expect it to be the final one.
+Historically, there were also "network breaches", which happened when a major
+Arvo revision that could not be implemented via an [OTA update](../ota-updates)
+occured. Network breaches were effectively breaching every ship on the network
+at once. The most recent network breach occurred in December 2020, and we expect
+it to be the final one.
 
 ### Further Reading
 

--- a/glossary/breach.md
+++ b/glossary/breach.md
@@ -5,10 +5,10 @@ template = "doc.html"
 category = "arvo"
 +++
 
-Continuity on the [Ames](../ames) network occasionally needs to be broken at
-this early stage in order to correct a networking error or to make major changes
-to [Arvo](../arvo). These infrequent events are known as **breaches**, which cause an
-individual ship to forget its network message history.
+Continuity on the [Ames](../ames) network occasionally needs to be broken
+(though with increasing rarity) in order to correct a networking error. These
+infrequent events are known as **breaches**, which cause an individual ship to
+forget its network message history.
 
 Breaches are always initiated by the user, frequently in response to a
 connectivity error. The easiest way to do this is with [Bridge](../bridge).


### PR DESCRIPTION
Addresses #980

Our description of life and rift has been incomplete and perhaps mildly misleading for some time. I've made a new page addressing this which I've put in the Azimuth section, though since these concepts also apply to moons and comets, I had also considered putting this page in the Ames section. It might make sense to rename the Azimuth section to Urbit ID to be more encompassing, but that can be a separate PR.

This is accompanied by changes to the using docs, which I'll put up a PR for in the urbit.org repo shortly.