### PR TITLE
add upgrade proposals to glossary

### DIFF
--- a/glossary/docvote.md
+++ b/glossary/docvote.md
@@ -1,9 +1,9 @@
 +++
-title = "Document Vote"
+title = "Document Proposal"
 
 template = "doc.html"
 [extra]
 category = "azimuth"
 +++
 
-A **document vote** is a type of [vote](../voting) action taken by the [Galactic Senate](../senate) over [Azimuth](../azimuth). By passing a document vote, [Galaxies](../galaxy) in the Senate agree legitimize a document with arbitrary content. Such a document might make claims about the state of the world; an example document that would be subject to this type of vote might be a file that says, "@urbit_senate is the official Twitter account of the senate, and is to be managed by John Doe until further notice."
+A **document proposal** is a type of [vote](../voting) action taken by the [Galactic Senate](../senate) over [Azimuth](../azimuth). By passing a document proposal, [Galaxies](../galaxy) in the Senate agree legitimize a document with arbitrary content. Such a document might make claims about the state of the world; an example document that would be subject to this type of vote might be a file that says, "@urbit_senate is the official Twitter account of the senate, and is to be managed by John Doe until further notice."

--- a/glossary/ecliptic.md
+++ b/glossary/ecliptic.md
@@ -8,4 +8,5 @@ category = "azimuth"
 
 The **Ecliptic** contract sets the rules for what is and is not possible on Azimuth. It's the point of entry for interacting with the [Azimuth](../azimuth) ledger data; the Azimuth contract itself is just data, and the Ecliptic contract is the logic for controlling that data. Examples of such logic include verifying permissions of the person asking to access their data, and ensuring a requested change is actually valid.
 
-The Senate (the voting body of [galaxies](../galaxy)) has the power to replace Ecliptic.
+The Senate (the voting body of [galaxies](../galaxy)) has the power to replace
+Ecliptic via an [upgrade proposal](../upgrade).

--- a/glossary/senate.md
+++ b/glossary/senate.md
@@ -8,7 +8,7 @@ category = "azimuth"
 
 The **Galactic Senate** is the body of all [galaxies](../galaxy) that governs
 [Azimuth](../azimuth) by [majority vote](../voting). There are two types of
-votes: a [upgrade proposal](../upgrade), which is a motion to update the logic
-of Azimuth (i.e. [Ecliptic](../ecliptic)), and a [documentation
-vote](../docvote), which is a motion to legitimize or approve the content of an
+votes: an [upgrade proposal](../upgrade), which is a motion to update the logic
+of Azimuth (i.e. [Ecliptic](../ecliptic)), and a [document
+proposal](../docvote), which is a motion to legitimize or approve the content of an
 arbitrary document.

--- a/glossary/senate.md
+++ b/glossary/senate.md
@@ -6,4 +6,9 @@ template = "doc.html"
 category = "azimuth"
 +++
 
-The **Galactic Senate** is the body of all [galaxies](../galaxy) that governs [Azimuth](../azimuth) by [majority vote](../voting). There are two types of votes: a constitution vote, which is a motion to update the logic of Azimuth; and a [documentation vote](../docvote), which is a motion to legitimize or approve the content of an arbitrary document.
+The **Galactic Senate** is the body of all [galaxies](../galaxy) that governs
+[Azimuth](../azimuth) by [majority vote](../voting). There are two types of
+votes: a [upgrade proposal](../upgrade), which is a motion to update the logic
+of Azimuth (i.e. [Ecliptic](../ecliptic)), and a [documentation
+vote](../docvote), which is a motion to legitimize or approve the content of an
+arbitrary document.

--- a/glossary/upgrade.md
+++ b/glossary/upgrade.md
@@ -1,0 +1,18 @@
++++
+title = "Upgrade Proposal"
+
+template = "doc.html"
+[extra]
+category = "azimuth"
++++
+
+An **upgrade proposal** is a type of [vote](../voting) action taken by the
+[Galactic Senate](../senate) over [Azimuth](../azimuth). By passing an upgrade
+proposal, [Galaxies](../galaxy) in the Senate agree to change the
+[Ecliptic](../ecliptic) smart contracts.
+
+An upgrade proposal is always a Yes/No vote on whether to adopt a particular set
+of changes to the Ecliptic contracts. The vote concludes at the end of 30 days,
+or whenever an absolute majority is reached, whichever comes first. At the end
+of 30 days the option that has received the most votes is chosen. In either
+case, the upgrade (or lack thereof) is performed automatically.

--- a/glossary/upgrade.md
+++ b/glossary/upgrade.md
@@ -11,8 +11,3 @@ An **upgrade proposal** is a type of [vote](../voting) action taken by the
 proposal, [Galaxies](../galaxy) in the Senate agree to change the
 [Ecliptic](../ecliptic) smart contracts.
 
-An upgrade proposal is always a Yes/No vote on whether to adopt a particular set
-of changes to the Ecliptic contracts. The vote concludes at the end of 30 days,
-or whenever an absolute majority is reached, whichever comes first. At the end
-of 30 days the option that has received the most votes is chosen. In either
-case, the upgrade (or lack thereof) is performed automatically.

--- a/glossary/voting.md
+++ b/glossary/voting.md
@@ -11,3 +11,13 @@ members of the [Galactic Senate](../senate), through an [Azimuth](../azimuth)
 smart contract. Galaxies collectively make decisions about the governance of
 Azimuth and the [Arvo](../arvo) network by voting. There are two types of proposals that can be voted on:
 an [upgrade proposal](../upgrade) and a [document proposal](../docvote).
+
+A proposal is always a Yes/No vote. The vote concludes at the end of 30 days,
+or whenever an absolute majority is reached, whichever comes first. At the end
+of 30 days the option that has received the most votes is chosen.
+
+In the case of absolute majority, the vote transaction that achieves that
+majority triggers the upgrade or document ratification. In case time runs out,
+an explicit "update vote status/check result" transaction will need to be made.
+This can be performed by anyone at any time. Any effects from doing so will only
+happen if there was a majority vote in favor.

--- a/glossary/voting.md
+++ b/glossary/voting.md
@@ -6,4 +6,8 @@ template = "doc.html"
 category = "azimuth"
 +++
 
-**Voting** is a power available to [galaxies](../galaxy), in their capacities as members of the [Galactic Senate](../senate), through an [Azimuth](../azimuth) smart contract. Galaxies collectively make decisions about the governance of Azimuth and the [Arvo](../arvo) network by voting. There are two types of votes: a [constitution vote](../constitutionvote) and a [document vote](../docvote).
+**Voting** is a power available to [galaxies](../galaxy), in their capacities as
+members of the [Galactic Senate](../senate), through an [Azimuth](../azimuth)
+smart contract. Galaxies collectively make decisions about the governance of
+Azimuth and the [Arvo](../arvo) network by voting. There are two types of votes:
+an [upgrade proposal](../upgrade) and a [document vote](../docvote).

--- a/glossary/voting.md
+++ b/glossary/voting.md
@@ -13,11 +13,15 @@ Azimuth and the [Arvo](../arvo) network by voting. There are two types of propos
 an [upgrade proposal](../upgrade) and a [document proposal](../docvote).
 
 A proposal is always a Yes/No vote. The vote concludes at the end of 30 days,
-or whenever an absolute majority is reached, whichever comes first. At the end
-of 30 days the option that has received the most votes is chosen.
+or whenever an absolute majority is reached, whichever comes first. Assuming a
+quorum of at least 64 galaxies (1/4 of the Senate) has been achieved, at the end
+of 30 days the option that has received the most votes is chosen. If a quorum
+is not achieved then no action is taken.
 
-In the case of absolute majority, the vote transaction that achieves that
-majority triggers the upgrade or document ratification. In case time runs out,
-an explicit "update vote status/check result" transaction will need to be made.
-This can be performed by anyone at any time. Any effects from doing so will only
-happen if there was a majority vote in favor.
+In the case of an absolute majority (129 galaxies), the vote transaction that
+achieves that majority triggers the upgrade or document ratification. If 30 days
+passes without an absolute majority being reached, an explicit "update vote
+status/check result" transaction will need to be made. This can be performed by
+anyone at any time. Any effects from doing so will only take place if there was a
+majority vote in favor.
+

--- a/glossary/voting.md
+++ b/glossary/voting.md
@@ -9,5 +9,5 @@ category = "azimuth"
 **Voting** is a power available to [galaxies](../galaxy), in their capacities as
 members of the [Galactic Senate](../senate), through an [Azimuth](../azimuth)
 smart contract. Galaxies collectively make decisions about the governance of
-Azimuth and the [Arvo](../arvo) network by voting. There are two types of votes:
-an [upgrade proposal](../upgrade) and a [document vote](../docvote).
+Azimuth and the [Arvo](../arvo) network by voting. There are two types of proposals that can be voted on:
+an [upgrade proposal](../upgrade) and a [document proposal](../docvote).


### PR DESCRIPTION
We're about to release a blog post about the current Ecliptic upgrade proposal in the Senate, but we don't actually have a glossary page about it.

This adds one. I realized writing it that I am not 100% certain on the mechanics, so please take a gander @Fang- 

See #808 