### PR TITLE
updated Ames packet format

### DIFF
--- a/arvo/ames/ames.md
+++ b/arvo/ames/ames.md
@@ -157,7 +157,7 @@ order:
  `origin` is the IP and port of the original sender if the packet was proxied
  through a relay.
  
- `SIV` is an "associated data vector" as defined in AES-256 SIV, the encryption
+ `SIV` is a "synthetic initialization vector" as defined in AES-256 SIV, the encryption
  algorithm utilized to encrypt Ames packets (see the page on [Ames
  cryptography](@/docs/arvo/ames/cryptography.md)). It is formed from the
  following noun: `~[sender=@p receiver=@p sender-life=@ receiver-life=@]` (see
@@ -348,16 +348,16 @@ by an intermediary that knows the IP and port of the receiving ship.
 For now, peer discovery is handled entirely by galaxies. Every galaxy is
 responsible for knowing the IP and port of every planet underneath it. In the
 future, galaxies will only need to know the IP and port of the star sponsoring a
-planet, and stars will be responsible knowing the IP and port of their sponsored planets.
+planet, and stars will be responsible for knowing the IP and port of their sponsored planets.
 
 Galaxies are also utilized for packet relaying in the case where two ships
 cannot communicate directly with one another, as is often the case when one or
 both are behind a
 [NAT](https://en.wikipedia.org/wiki/Network_address_translation) or certain
-firewalls. Again, stars will someday assist with this process as well in a
-similar fashion to peer discovery.
+firewalls. We remark that packet relaying is a necessary component of peer
+discovery. Thus stars will also assist with packet relaying in the future.
 
-In the case of moons, their parent is responsible for packet relaying and peer
+In the case of a moon, its parent ship is responsible for packet relaying and peer
 discovery, analagous to the role that galaxies currently play for stars and planets.
 
 The following diagram summarizes the packet creation and forwarding process.
@@ -396,13 +396,13 @@ intended recipient of the packet, and so gets ready to forward it to
 `~worwel-sipnum`. First, it replaces the origin field with the IP and port of
 `~bacbel-tagfeb`, then computes the `+mug` of the body and replaces the checksum
 with the new mug. Since the packet is being relayed, `~zod` flips the "is it
-relayed?" bit to 1. `~zod` then forwards the packet to `~worwel-sipnum`.
+relayed?" bit to `%.y`. `~zod` then forwards the packet to `~worwel-sipnum`.
 
-In order to decrypt the packet, `~worwel-sipnum` will need to include the
+In order to decrypt the packet, `~worwel-sipnum` will need to calculate the
 associated data vector utilized by SIV, which consists of `~[sender=@p
-receiver=@p sender-life=@ receiver-life=@]`, and insert it into the correct spot
-in the body of the packet before decrypting and `+cue`ing (deserializing) to
-obtain the payload which includes the message fragment.
+receiver=@p sender-life=@ receiver-life=@]`. It then passes that along with the
+SIV and ciphertext to the decryption function, and receives the unencrypted
+packet as a return.
 
 Once `~worwel-sipnum` processes the packet, it will know the IP and port of
 `~bacbel-tagfeb` since `~zod` included it when it forwarded the packet. Thus


### PR DESCRIPTION
This PR updates the Ames overview page to reflect the packet structure
introduced with https://github.com/urbit/urbit/pull/4051 and to address #995.

Reading the code, the format of the payload did not seem to be the same as that
written in the PR description, unless I'm misunderstanding something:

https://github.com/urbit/urbit/blob/master/pkg/arvo/sys/vane/ames.hoon#L421-L422

So I've written it as

```
 - 4 bits: sender life (mod 16)
 - 4 bits: receiver life (mod 16)
 - variable: sender address
 - variable: receiver address
 - 48 bits: (optional) 48-bit `origin`
 - 128 bits: `SIV`
 - 16 bits: ciphertext size
 - variable: ciphertext
 ```

rather than

```
48  bits:  (optional) 48-bit origin
4   bits:  sender life (mod 16)
4   bits:  receiver life (mod 16)
<variable> sender address
<variable> receiver address
128 bits:  SIV
16  bits:  ciphertext size
<variable> ciphertext
```

as indicated in the PR. Please advise if I am mistaken.

This also required modifying the example scenario towards the end of the
document, as well as the accompanying diagram. I added in a bit more detail
about how multi-packet messages are handled. Please read carefully to make sure
I did not misunderstand how relaying works, especially how the SIV is
incorporated since I found it a little confusing to say that the SIV is part of
the packet structure but its never actually sent over the wire.

Lastly, this links to new pages in #1091, so it should not be merged until after
#1091 is.