### PR TITLE
irregular.md: add ^* and ^:, adds spacing, more verbose

### DIFF
--- a/hoon/reference/irregular.md
+++ b/hoon/reference/irregular.md
@@ -12,48 +12,52 @@ docs and a short description of the rune. Both regular and irregular forms are g
 
 Want to `Ctrl-f` to find out the meaning of something weird you saw? Search for `\symbol`. ie `\?` or `\=`. It'll show you to the irregular forms that uses that symbol.
 
-## . dot (nock)
+## `.` dot (nock)
 
 Anything Nock can do, Hoon can do also.
 
-### .+ dotlus
+### `.+` dotlus
 
 [docs](@/docs/hoon/reference/rune/dot.md#dotlus) \\+
+
 `[%dtls p=atom]`: increment an atom with Nock 4.
 
 Regular: `.+(p)`
 
 Irregular: `+(p)`
 
-### .= dottis
+### `.=` dottis
 
 [docs](@/docs/hoon/reference/rune/dot.md#dottis) \\=
+
 `[%dtts p=hoon q=hoon]`: test for equality with Nock 5.
 
 Regular: `.=(p q)`
 
 Irregular: `=(p q)`
 
-## ; mic (make)
+## `;` mic (make)
 
 Miscellaneous useful macros.
 
-### ;: miccol
+### `;:` miccol
 
 [docs](@/docs/hoon/reference/rune/mic.md#miccol) \\:
+
 `[%mccl p=hoon q=(list hoon)]`: call a binary function as an n-ary function.
 
 Regular: `;:(p q)`
 
 Irregular: `:(p q)`
 
-## : col (cells)
+## `:` col (cells)
 
 The cell runes.
 
-### :- colhep
+### `:-` colhep
 
 [docs](@/docs/hoon/reference/rune/col.md#colhep)  \\[\\]\\^\\+\\\`\\~
+
 `[%clhp p=hoon q=hoon]`: construct a cell (2-tuple).
 
 Regular: `:-(p q)`
@@ -71,22 +75,24 @@ Irregular:
   [a b]~  ==>   [[a b] ~]
 ```
 
-## = tis (flow)
+## `=` tis (flow)
 
 Flow hoons change the subject. All non-flow hoons (except cores) pass the subject down unchanged.
 
-### =< tisgal
+### `=<` tisgal
 
 [docs](@/docs/hoon/reference/rune/tis.md#tisgal) \\:
+
 `[%tsgl p=hoon q=hoon]`: compose two hoons, inverted.
 
 Regular: `=<(p q)`
 
 Irregular: `p:q`
 
-## | bar (core)
+## `|` bar (core)
 
 [docs](@/docs/hoon/reference/rune/bar.md) \\$
+
 Core hoons are flow hoon.
 
 Technically not irregular syntax, but worth mentioning.
@@ -98,31 +104,34 @@ Technically not irregular syntax, but worth mentioning.
 
 The above runes produce a core with a single arm, named `$` ("buc"). We can recompute this arm with changes, useful for recursion among other things. Commonly used with the irregular syntax for `%=`, `:make`, like so: `$()`.
 
-## % cen (call)
+## `%` cen (call)
 
 The invocation family of runes.
 
-### %= centis
+### `%=` centis
 
 [docs](@/docs/hoon/reference/rune/cen.md#centis)  \\(\\)
+
 `[%cnts p=wing q=(list (pair wing hoon))]`: take a wing with changes.
 
 Regular: `%=(p a 1)`
 
 Irregular: `p(a 1)`
 
-### %~ censig
+### `%~` censig
 
 [docs](@/docs/hoon/reference/rune/cen.md#censig) \\~
+
 `[%cnsg p=wing q=hoon r=hoon]`: call with multi-armed door.
 
 Regular: `%~(p q r)`
 
 Irregular: `~(p q r)`
 
-### %- cenhep
+### `%-` cenhep
 
 [docs](@/docs/hoon/reference/rune/cen.md#cenhep) \\(\\)
+
 `[%cnhp p=hoon q=hoon]`: call a gate (function).
 
 Regular: `%-(p q)`
@@ -131,93 +140,102 @@ Irregular: `(p q)`
 
 Note: `(p)` becomes `$:p` (`=<($ p)`), which behaves as you would expect (func call w/o args).
 
-## $ buc (mold)
+## `$` buc (mold)
 
 A mold is a gate (function) that helps us build simple and rigorous data structures.
 
-### $? bucwut
+### `$?` bucwut
 
 [docs](@/docs/hoon/reference/rune/buc.md#bucwut) \\?
+
 `[%bcwt p=(list model)]`: mold which normalizes a general union.
 
 Regular: `$?(p)`
 
 Irregular: `?(p)`
 
-### $_ buccab
+### `$_` buccab
 
 [docs](@/docs/hoon/reference/rune/buc.md#buccab) \\_
+
 `[%bccb p=value]`: mold which normalizes to an example.
 
 Regular: `$_(p)`
 
 Irregular: `_p`
 
-## ? wut (test)
+## `?` wut (test)
 
 Hoon has the usual branches and logical tests.
 
-### ?! wutzap
+### `?!` wutzap
 
 [docs](@/docs/hoon/reference/rune/wut.md#wutzap) \\!
+
 `[%wtzp p=hoon]`: logical not.
 
 Regular: `?!(p)`
 
 Irregular: `!(p)`
 
-### ?& wutpam
+### `?&` wutpam
 
 [docs](@/docs/hoon/reference/rune/wut.md#wutpam) \\&
+
 `[%wtpm p=(list hoon)]`: logical and.
 
 Regular: `?&(p)`
 
 Irregular: `&(p)`
 
-### ?| wutbar
+### `?|` wutbar
 
 [docs](@/docs/hoon/reference/rune/wut.md#wutbar) \\|
+
 `[%wtbr p=(list hoon)]`: logical or.
 
 Regular: `?|(p)`
 
 Irregular: `|(p)`
 
-## ^ ket (cast)
+## `^` ket (cast)
 
 Lets us adjust types without violating type constraints.
 
-### ^: ketcol
+### `^:` ketcol
 
 [docs](@/docs/hoon/reference/ket.md#ketcol) \\,
+
 `[%ktcl p=spec]`: mold gate for type `p`.
 
 Regular: `^:(p)`
 
 Irregular: `,p`
 
-### ^- kethep
+### `^-` kethep
 
 [docs](@/docs/hoon/reference/rune/ket.md#kethep) \\\`
+
 `[%kthp p=model q=value]`: typecast by mold.
 
 Regular: `^-(p q)`
 
 Irregular: `` `p`q ``
 
-### ^* kettar
+### `^*` kettar
 
 [docs](@/docs/hoon/reference/rune/ket.md#kettar) \\*
+
 `[%kttr p=spec]`: produce bunt value of mold.
 
 Regular: `^*(p)`
 
 Irregular: `*p`
 
-### ^= kettis
+### `^=` kettis
 
 [docs](@/docs/hoon/reference/rune/ket.md#kettis) \\=
+
 `[%ktts p=toga q=value]`: name a value.
 
 Regular: `^=(p q)`
@@ -254,6 +272,7 @@ See [%sand](@/docs/hoon/reference/rune/constants.md#warm) for other irregular de
 ### Limbs
 
 [docs](@/docs/hoon/reference/limbs/limb.md) \\+\\.\\^
+
 `[%limb p=(each @ud [p=@ud q=@tas])]`: attribute of subject.
 
 - `+15` is slot 15

--- a/hoon/reference/irregular.md
+++ b/hoon/reference/irregular.md
@@ -7,7 +7,8 @@ aliases = ["docs/reference/hoon-expressions/irregular/"]
 
 ##### Reading guide
 
-Headings contain runes, phonetics and tokens. Description contains a link to the docs and a short description of the rune. Both regular (R) and irregular (I) forms are given.
+Headings contain runes, phonetics and tokens. Description contains a link to the
+docs and a short description of the rune. Both regular and irregular forms are given.
 
 Want to `Ctrl-f` to find out the meaning of something weird you saw? Search for `\symbol`. ie `\?` or `\=`. It'll show you to the irregular forms that uses that symbol.
 
@@ -20,16 +21,18 @@ Anything Nock can do, Hoon can do also.
 [docs](@/docs/hoon/reference/rune/dot.md#dotlus) \\+
 `[%dtls p=atom]`: increment an atom with Nock 4.
 
-R: `.+(p)`
-I: `+(p)`
+Regular: `.+(p)`
+
+Irregular: `+(p)`
 
 ### .= dottis
 
 [docs](@/docs/hoon/reference/rune/dot.md#dottis) \\=
 `[%dtts p=hoon q=hoon]`: test for equality with Nock 5.
 
-R: `.=(p q)`
-I: `=(p q)`
+Regular: `.=(p q)`
+
+Irregular: `=(p q)`
 
 ## ; mic (make)
 
@@ -40,8 +43,9 @@ Miscellaneous useful macros.
 [docs](@/docs/hoon/reference/rune/mic.md#miccol) \\:
 `[%mccl p=hoon q=(list hoon)]`: call a binary function as an n-ary function.
 
-R: `;:(p q)`
-I: `:(p q)`
+Regular: `;:(p q)`
+
+Irregular: `:(p q)`
 
 ## : col (cells)
 
@@ -52,8 +56,9 @@ The cell runes.
 [docs](@/docs/hoon/reference/rune/col.md#colhep)  \\[\\]\\^\\+\\\`\\~
 `[%clhp p=hoon q=hoon]`: construct a cell (2-tuple).
 
-R: `:-(p q)`
-I:
+Regular: `:-(p q)`
+
+Irregular:
 
 ```
   [a b]   ==>   :-(a b)
@@ -75,8 +80,9 @@ Flow hoons change the subject. All non-flow hoons (except cores) pass the subjec
 [docs](@/docs/hoon/reference/rune/tis.md#tisgal) \\:
 `[%tsgl p=hoon q=hoon]`: compose two hoons, inverted.
 
-R: `=<(p q)`
-I: `p:q`
+Regular: `=<(p q)`
+
+Irregular: `p:q`
 
 ## | bar (core)
 
@@ -101,24 +107,27 @@ The invocation family of runes.
 [docs](@/docs/hoon/reference/rune/cen.md#centis)  \\(\\)
 `[%cnts p=wing q=(list (pair wing hoon))]`: take a wing with changes.
 
-R: `%=(p a 1)`
-I: `p(a 1)`
+Regular: `%=(p a 1)`
+
+Irregular: `p(a 1)`
 
 ### %~ censig
 
 [docs](@/docs/hoon/reference/rune/cen.md#censig) \\~
 `[%cnsg p=wing q=hoon r=hoon]`: call with multi-armed door.
 
-R: `%~(p q r)`
-I: `~(p q r)`
+Regular: `%~(p q r)`
+
+Irregular: `~(p q r)`
 
 ### %- cenhep
 
 [docs](@/docs/hoon/reference/rune/cen.md#cenhep) \\(\\)
 `[%cnhp p=hoon q=hoon]`: call a gate (function).
 
-R: `%-(p q)`
-I: `(p q)`
+Regular: `%-(p q)`
+
+Irregular: `(p q)`
 
 Note: `(p)` becomes `$:p` (`=<($ p)`), which behaves as you would expect (func call w/o args).
 
@@ -131,16 +140,18 @@ A mold is a gate (function) that helps us build simple and rigorous data structu
 [docs](@/docs/hoon/reference/rune/buc.md#bucwut) \\?
 `[%bcwt p=(list model)]`: mold which normalizes a general union.
 
-R: `$?(p)`
-I: `?(p)`
+Regular: `$?(p)`
+
+Irregular: `?(p)`
 
 ### $_ buccab
 
 [docs](@/docs/hoon/reference/rune/buc.md#buccab) \\_
 `[%bccb p=value]`: mold which normalizes to an example.
 
-R: `$_(p)`
-I: `_p`
+Regular: `$_(p)`
+
+Irregular: `_p`
 
 ## ? wut (test)
 
@@ -151,44 +162,67 @@ Hoon has the usual branches and logical tests.
 [docs](@/docs/hoon/reference/rune/wut.md#wutzap) \\!
 `[%wtzp p=hoon]`: logical not.
 
-R: `?!(p)`
-I: `!(p)`
+Regular: `?!(p)`
+
+Irregular: `!(p)`
 
 ### ?& wutpam
 
 [docs](@/docs/hoon/reference/rune/wut.md#wutpam) \\&
 `[%wtpm p=(list hoon)]`: logical and.
 
-R: `?&(p)`
-I: `&(p)`
+Regular: `?&(p)`
+
+Irregular: `&(p)`
 
 ### ?| wutbar
 
 [docs](@/docs/hoon/reference/rune/wut.md#wutbar) \\|
 `[%wtbr p=(list hoon)]`: logical or.
 
-R: `?|(p)`
-I: `|(p)`
+Regular: `?|(p)`
+
+Irregular: `|(p)`
 
 ## ^ ket (cast)
 
 Lets us adjust types without violating type constraints.
+
+### ^: ketcol
+
+[docs](@/docs/hoon/reference/ket.md#ketcol) \\,
+`[%ktcl p=spec]`: mold gate for type `p`.
+
+Regular: `^:(p)`
+
+Irregular: `,p`
 
 ### ^- kethep
 
 [docs](@/docs/hoon/reference/rune/ket.md#kethep) \\\`
 `[%kthp p=model q=value]`: typecast by mold.
 
-R: `^-(p q)`
-I: `` `p`q ``
+Regular: `^-(p q)`
+
+Irregular: `` `p`q ``
+
+### ^* kettar
+
+[docs](@/docs/hoon/reference/rune/ket.md#kettar) \\*
+`[%kttr p=spec]`: produce bunt value of mold.
+
+Regular: `^*(p)`
+
+Irregular: `*p`
 
 ### ^= kettis
 
 [docs](@/docs/hoon/reference/rune/ket.md#kettis) \\=
 `[%ktts p=toga q=value]`: name a value.
 
-R: `^=(p q)`
-I: `p=q`
+Regular: `^=(p q)`
+
+Irregular: `p=q`
 
 ## Miscellaneous
 


### PR DESCRIPTION
This addresses #1016 and #1064

I replaced the terse "I:" and "R:" with "Regular:" and "Irregular:", and put the
entries onto separate lines.

I also added a couple missing entries, for `^*` and `^:`. I didn't even realize
that bunting with `*` was an irregular form since `^*` has never been on this
page. These could be separate PR's but they're all so minor I decided to do them together.

Also, I am under the impression that `^:` is no longer relevant since all molds
crash when you feed them a value of the wrong type. Nonetheless, it still
appears in the codebase, so we ought to have it documented while it lingers. I
can't seem to find the conversation I remember having about this though, so
please correct me if I am mistaken. If so, I should go edit the `ket.md` page to
say as much.