### PR TITLE
the ecliptic -> ecliptic

### DIFF
--- a/azimuth/azimuth.md
+++ b/azimuth/azimuth.md
@@ -42,7 +42,7 @@ Think of your master ticket like a very high-value password. The master ticket i
 
 ### Ownership Address
 
-An ownership address has all rights over the assets deeded to it. These rights are on-chain actions described and implemented in the Ecliptic, Azimuth's suite of governing smart-contracts.
+An ownership address has all rights over the assets deeded to it. These rights are on-chain actions described and implemented in [Ecliptic](@/docs/glossary/ecliptic.md), Azimuth's suite of governing smart-contracts.
 
 ### Proxies
 
@@ -55,8 +55,8 @@ Proxy addresses allow you to execute non-ownership related actions like spawning
 
 - **Voting Proxy**
 
-  Galaxies only. Galaxies are the part of the galactic senate, and this means
-  they can cast votes on new proposals including changes to the Ecliptic.
+  Galaxies only. Galaxies are the part of the [Galactic Senate](@/docs/glossary/senate.md), and this means
+  they can cast votes on new proposals including changes to Ecliptic.
 
 - **Spawn Proxy**
 
@@ -95,8 +95,7 @@ The ERC-721 standard, having been made specifically to provide a smart-contract
 interface for non-fungible assets, serves our needs well. This is the standard
 that we use for deeding Urbit identities.
 
-Identities, and all of their blockchain operations, are governed by the Ecliptic.
-The Ecliptic is an Ethereum smart-contract that governs identity state and the
+Identities, and all of their blockchain operations, are governed by Ecliptic. Ecliptic is an Ethereum smart-contract that governs identity state and the
 ownership, spawn, management, and voting rights affiliated with your identities.
 
 For the technical implementation details, take a look at Azimuth's


### PR DESCRIPTION
The language we use to refer to Ecliptic is inconsistent. On this page, we
repeateadly call it "the Ecliptic", while everywhere else we seem to just call
it "Ecliptic". While this "the Eclikptic" is closer to its usage as an
astronomical term, we use it as a proper noun to refer to a particular Ethereum
contract, so if we're saying "the" then I think it ought to be The Ecliptic. My
personal opinion is that calling it "The Ecliptic" just sounds weird and we
should just call it Ecliptic, as we do in other places in the documentation and
on the blog.

This is 100% a matter of personal opinion. I'm just noting an inconsistency in
our usage and choosing my preference of how to resolve that inconsistency, but
if anyone feels strongly otherwise then please say so.